### PR TITLE
Adding Outcome coverage checking, changing Patient coverage checking to match

### DIFF
--- a/src/lib/outcomeCoverage.js
+++ b/src/lib/outcomeCoverage.js
@@ -1,0 +1,42 @@
+const fhirpath = require('fhirpath');
+const { getDiseaseStatus, getTumor, getTumorSize } = require('./resourceUtils');
+const testbundle = require('../../test/fullBundle.json');
+
+/**
+ * Takes a bundle and returns the coverage of outcome resources in that bundle
+ * @param {Object} bundle, an mCODE bundle
+ * @return {Array}, an array of objects where each object has keys corresponding to fields in the mCODE diagram
+ * and boolean values indicating if the field is covered
+ */
+function getOutcomeCoverage(bundle) {
+  const diseaseStatus = getDiseaseStatus(bundle);
+  const coverage = [];
+  diseaseStatus.forEach((status) => {
+    coverage.push({
+      'Evidence Type': fhirpath.evaluate(
+        status,
+        "Observation.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status-evidence-type').exists()",
+      )[0],
+    });
+  });
+  const tumors = getTumor(bundle);
+  tumors.forEach((tumor) => {
+    coverage.push({
+      Location: fhirpath.evaluate(tumor, 'BodyStructure.location.exists()')[0],
+    });
+  });
+  const tumorSize = getTumorSize(bundle);
+  tumorSize.forEach((size) => {
+    coverage.push({
+      Method: fhirpath.evaluate(size, 'Observation.method.exists()')[0],
+      Component: fhirpath.evaluate(size, 'Observation.component.exists()')[0],
+    });
+  });
+  return coverage;
+}
+
+console.log(getOutcomeCoverage(testbundle));
+
+module.exports = {
+  getOutcomeCoverage,
+};

--- a/src/lib/outcomeCoverage.js
+++ b/src/lib/outcomeCoverage.js
@@ -10,32 +10,48 @@ const testbundle = require('../../test/fullBundle.json');
  */
 function getOutcomeCoverage(bundle) {
   const diseaseStatus = getDiseaseStatus(bundle);
-  const coverage = [];
+  const diseaseStatusCoverage = { profile: 'Disease Status', coverage: [] };
   diseaseStatus.forEach((status) => {
-    coverage.push({
-      'Evidence Type': fhirpath.evaluate(
-        status,
-        "Observation.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status-evidence-type').exists()",
-      )[0],
+    diseaseStatusCoverage.coverage.push({
+      resourceID: fhirpath.evaluate(status, 'Observation.id')[0],
+      data: {
+        'Evidence Type': {
+          covered: fhirpath.evaluate(
+            status,
+            "Observation.extension.where(url = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status-evidence-type').exists()",
+          )[0],
+        },
+      },
     });
   });
   const tumors = getTumor(bundle);
+  const tumorCoverage = { profile: 'Tumor', coverage: [] };
   tumors.forEach((tumor) => {
-    coverage.push({
-      Location: fhirpath.evaluate(tumor, 'BodyStructure.location.exists()')[0],
+    tumorCoverage.coverage.push({
+      resourceID: fhirpath.evaluate(tumor, 'BodyStructure.id')[0],
+      data: {
+        Location: { covered: fhirpath.evaluate(tumor, 'BodyStructure.location.exists()')[0] },
+      },
     });
   });
   const tumorSize = getTumorSize(bundle);
+  const tumorSizeCoverage = { profile: 'Tumor Size', coverage: [] };
   tumorSize.forEach((size) => {
-    coverage.push({
-      Method: fhirpath.evaluate(size, 'Observation.method.exists()')[0],
-      Component: fhirpath.evaluate(size, 'Observation.component.exists()')[0],
+    tumorSizeCoverage.coverage.push({
+      resourceID: fhirpath.evaluate(size, 'Observation.id')[0],
+      data: {
+        Method: { covered: fhirpath.evaluate(size, 'Observation.method.exists()')[0] },
+        Component: { covered: fhirpath.evaluate(size, 'Observation.component.exists()')[0] },
+      },
     });
   });
-  return coverage;
+  return {
+    section: 'Outcome',
+    data: [diseaseStatusCoverage, tumorCoverage, tumorSizeCoverage],
+  };
 }
 
-console.log(getOutcomeCoverage(testbundle));
+console.log(JSON.stringify(getOutcomeCoverage(testbundle), null, 2));
 
 module.exports = {
   getOutcomeCoverage,

--- a/src/lib/outcomeCoverage.js
+++ b/src/lib/outcomeCoverage.js
@@ -2,11 +2,11 @@ const fhirpath = require('fhirpath');
 const { getDiseaseStatus, getTumor, getTumorSize, getTumorSpecimen } = require('./resourceUtils');
 
 /**
- * Takes a bundle and returns the coverage of outcome resources in that bundle
+ * Takes a bundle and returns the coverage of disease status resources in that bundle
  * @param {Object} bundle, an mCODE bundle
- * @return {Object}, an object representing the coverage of the Outcome dection of the mCODE diagram
+ * @return {Object}, an object representing the coverage of all disease status resources
  */
-function getOutcomeCoverage(bundle) {
+function getDiseaseStatusCoverage(bundle) {
   const diseaseStatus = getDiseaseStatus(bundle);
   const diseaseStatusCoverage = { profile: 'Disease Status', coverage: [] };
   diseaseStatus.forEach((status) => {
@@ -22,6 +22,15 @@ function getOutcomeCoverage(bundle) {
       },
     });
   });
+  return diseaseStatusCoverage;
+}
+
+/**
+ * Takes a bundle and returns the coverage of tumor resources in that bundle
+ * @param {Object} bundle, an mCODE bundle
+ * @return {Object}, an object representing the coverage of all tumor resources
+ */
+function getTumorCoverage(bundle) {
   const tumors = getTumor(bundle);
   const tumorCoverage = { profile: 'Tumor', coverage: [] };
   tumors.forEach((tumor) => {
@@ -38,6 +47,15 @@ function getOutcomeCoverage(bundle) {
       },
     });
   });
+  return tumorCoverage;
+}
+
+/**
+ * Takes a bundle and returns the coverage of tumor size resources in that bundle
+ * @param {Object} bundle, an mCODE bundle
+ * @return {Object}, an object representing the coverage of all tumor size resources
+ */
+function getTumorSizeCoverage(bundle) {
   const tumorSize = getTumorSize(bundle);
   const tumorSizeCoverage = { profile: 'Tumor Size', coverage: [] };
   tumorSize.forEach((size) => {
@@ -61,6 +79,15 @@ function getOutcomeCoverage(bundle) {
       },
     });
   });
+  return tumorSizeCoverage;
+}
+
+/**
+ * Takes a bundle and returns the coverage of tumor specimen resources in that bundle
+ * @param {Object} bundle, an mCODE bundle
+ * @return {Object}, an object representing the coverage of all tumor specimen resources
+ */
+function getTumorSpecimenCoverage(bundle) {
   const tumorSpecimen = getTumorSpecimen(bundle);
   const tumorSpecimenCoverage = { profile: 'Tumor Specimen', coverage: [] };
   tumorSpecimen.forEach((specimen) => {
@@ -76,9 +103,23 @@ function getOutcomeCoverage(bundle) {
       },
     });
   });
+  return tumorSpecimenCoverage;
+}
+
+/**
+ * Takes a bundle and returns the coverage of outcome resources in that bundle
+ * @param {Object} bundle, an mCODE bundle
+ * @return {Object}, an object representing the coverage of the Outcome dection of the mCODE diagram
+ */
+function getOutcomeCoverage(bundle) {
   return {
     section: 'Outcome',
-    data: [diseaseStatusCoverage, tumorCoverage, tumorSizeCoverage, tumorSpecimenCoverage],
+    data: [
+      getDiseaseStatusCoverage(bundle),
+      getTumorCoverage(bundle),
+      getTumorSizeCoverage(bundle),
+      getTumorSpecimenCoverage(bundle),
+    ],
   };
 }
 

--- a/src/lib/patientCoverage.js
+++ b/src/lib/patientCoverage.js
@@ -1,6 +1,6 @@
 const fhirpath = require('fhirpath');
 const { getPatient } = require('./resourceUtils');
-const testbundle = require('../../test/fullBundle.json');
+
 /**
  * Takes a bundle and returns the coverage of patient resources in that bundle
  * @param {Object} bundle, an mCODE bundle
@@ -32,6 +32,9 @@ function getPatientCoverage(bundle) {
             "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').exists()",
           )[0],
         },
+        'Death Date': {
+          covered: fhirpath.evaluate(patient, 'Patient.deceasedDateTime.exists()')[0],
+        },
       },
     });
   });
@@ -40,8 +43,6 @@ function getPatientCoverage(bundle) {
     data: [patientCoverage],
   };
 }
-
-console.log(JSON.stringify(getPatientCoverage(testbundle), null, 2));
 
 module.exports = {
   getPatientCoverage,

--- a/src/lib/patientCoverage.js
+++ b/src/lib/patientCoverage.js
@@ -1,34 +1,44 @@
 const fhirpath = require('fhirpath');
 const { getPatient } = require('./resourceUtils');
-
+const testbundle = require('../../test/fullBundle.json');
 /**
  * Takes a bundle and returns the coverage of patient resources in that bundle
  * @param {Object} bundle, an mCODE bundle
- * @return {Array}, an array of objects where each object has keys corresponding to fields in the mCODE diagram
- * and boolean values indicating if the field is covered
+ * @return {Object}, an object representing the coverage of the Patient dection of the mCODE diagram
  */
 function getPatientCoverage(bundle) {
   const patients = getPatient(bundle);
-  const coverage = [];
+  const patientCoverage = { profile: 'Cancer Patient', coverage: [] };
   patients.forEach((patient) => {
-    coverage.push({
-      Name: fhirpath.evaluate(patient, 'Patient.name.exists()')[0],
-      'Contact Info': fhirpath.evaluate(patient, 'Patient.contact.telecom.exists()')[0],
-      'Birth Date': fhirpath.evaluate(patient, 'Patient.birthDate.exists()')[0],
-      Gender: fhirpath.evaluate(patient, 'Patient.gender.exists()')[0],
-      'Zip Code': fhirpath.evaluate(patient, 'Patient.address.exists() and Patient.address.postalCode.exists()')[0],
-      'US Core Race': fhirpath.evaluate(
-        patient,
-        "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').exists()",
-      )[0],
-      'US Core Ethnicity': fhirpath.evaluate(
-        patient,
-        "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').exists()",
-      )[0],
+    patientCoverage.coverage.push({
+      Name: { covered: fhirpath.evaluate(patient, 'Patient.name.exists()')[0] },
+      'Contact Info': { covered: fhirpath.evaluate(patient, 'Patient.contact.telecom.exists()')[0] },
+      'Birth Date': { covered: fhirpath.evaluate(patient, 'Patient.birthDate.exists()')[0] },
+      Gender: { covered: fhirpath.evaluate(patient, 'Patient.gender.exists()')[0] },
+      'Zip Code': {
+        covered: fhirpath.evaluate(patient, 'Patient.address.exists() and Patient.address.postalCode.exists()')[0],
+      },
+      'US Core Race': {
+        covered: fhirpath.evaluate(
+          patient,
+          "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').exists()",
+        )[0],
+      },
+      'US Core Ethnicity': {
+        covered: fhirpath.evaluate(
+          patient,
+          "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').exists()",
+        )[0],
+      },
     });
   });
-  return coverage;
+  return {
+    section: 'Patient',
+    data: [patientCoverage],
+  };
 }
+
+console.log(JSON.stringify(getPatientCoverage(testbundle), null, 2));
 
 module.exports = {
   getPatientCoverage,

--- a/src/lib/patientCoverage.js
+++ b/src/lib/patientCoverage.js
@@ -11,24 +11,27 @@ function getPatientCoverage(bundle) {
   const patientCoverage = { profile: 'Cancer Patient', coverage: [] };
   patients.forEach((patient) => {
     patientCoverage.coverage.push({
-      Name: { covered: fhirpath.evaluate(patient, 'Patient.name.exists()')[0] },
-      'Contact Info': { covered: fhirpath.evaluate(patient, 'Patient.contact.telecom.exists()')[0] },
-      'Birth Date': { covered: fhirpath.evaluate(patient, 'Patient.birthDate.exists()')[0] },
-      Gender: { covered: fhirpath.evaluate(patient, 'Patient.gender.exists()')[0] },
-      'Zip Code': {
-        covered: fhirpath.evaluate(patient, 'Patient.address.exists() and Patient.address.postalCode.exists()')[0],
-      },
-      'US Core Race': {
-        covered: fhirpath.evaluate(
-          patient,
-          "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').exists()",
-        )[0],
-      },
-      'US Core Ethnicity': {
-        covered: fhirpath.evaluate(
-          patient,
-          "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').exists()",
-        )[0],
+      resourceID: fhirpath.evaluate(patient, 'Patient.id')[0],
+      data: {
+        Name: { covered: fhirpath.evaluate(patient, 'Patient.name.exists()')[0] },
+        'Contact Info': { covered: fhirpath.evaluate(patient, 'Patient.contact.telecom.exists()')[0] },
+        'Birth Date': { covered: fhirpath.evaluate(patient, 'Patient.birthDate.exists()')[0] },
+        Gender: { covered: fhirpath.evaluate(patient, 'Patient.gender.exists()')[0] },
+        'Zip Code': {
+          covered: fhirpath.evaluate(patient, 'Patient.address.exists() and Patient.address.postalCode.exists()')[0],
+        },
+        'US Core Race': {
+          covered: fhirpath.evaluate(
+            patient,
+            "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').exists()",
+          )[0],
+        },
+        'US Core Ethnicity': {
+          covered: fhirpath.evaluate(
+            patient,
+            "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').exists()",
+          )[0],
+        },
       },
     });
   });

--- a/src/lib/patientCoverage.js
+++ b/src/lib/patientCoverage.js
@@ -32,8 +32,11 @@ function getPatientCoverage(bundle) {
             "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').exists()",
           )[0],
         },
-        'Death Date': {
-          covered: fhirpath.evaluate(patient, 'Patient.deceasedDateTime.exists()')[0],
+        Deceased: {
+          covered: fhirpath.evaluate(
+            patient,
+            'Patient.deceasedDateTime.exists() or Patient.deceasedBoolean.exists()',
+          )[0],
         },
       },
     });

--- a/src/lib/resourceUtils.js
+++ b/src/lib/resourceUtils.js
@@ -39,13 +39,6 @@ function getTumorSpecimen(bundle) {
   );
 }
 
-function getBodyStructureIdentifier(bundle) {
-  return fhirpath.evaluate(
-    bundle,
-    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-body-structure-identifier')",
-  );
-}
-
 // Disease
 
 function getTumorMarkerTest(bundle) {
@@ -193,7 +186,6 @@ module.exports = {
   getTumor,
   getTumorSize,
   getTumorSpecimen,
-  getBodyStructureIdentifier,
   getTumorMarkerTest,
   getPrimaryCancerCondition,
   getSecondaryCancerCondition,

--- a/test/bundles/fullBundle.json
+++ b/test/bundles/fullBundle.json
@@ -1037,6 +1037,112 @@
       }
     },
     {
+      "fullUrl": "whatever",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "tumor-specimen-left-breast-jenny-m",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-specimen"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"tumor-specimen-left-breast-jenny-m\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-mcode-tumor-specimen.html\">Tumor Specimen Profile</a></p></div><p><b>identifier</b>: BodyStructure: Tumor 1234 (USUAL)</p><p><b>status</b>: available</p><p><b>type</b>: Tumor <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.0.0/CodeSystem-v2-0487.html\">specimenType</a>#TUMOR)</span></p><p><b>subject</b>: <a href=\"Patient-cancer-patient-jenny-m.html\">Patient/cancer-patient-jenny-m</a> \" M\"</p><p><b>receivedTime</b>: 2018-04-01</p><h3>Collections</h3><table class=\"grid\"><tr><td>-</td><td><b>BodySite</b></td></tr><tr><td>*</td><td>Left breast structure (body structure) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#80248007)</span></td></tr></table></div>"
+        },
+        "identifier": [
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/resource-types",
+                  "code": "BodyStructure"
+                }
+              ]
+            },
+            "system": "http://radiology.hospital.example.org",
+            "value": "Tumor 1234"
+          }
+        ],
+        "status": "available",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+              "code": "TUMOR"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/cancer-patient-jenny-m"
+        },
+        "receivedTime": "2018-04-01",
+        "collection": {
+          "bodySite": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "80248007",
+                "display": "Left breast structure (body structure)"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl": "whatever",
+      "resource": {
+        "resourceType": "BodyStructure",
+        "id": "tumor-lobular-carcinoma-left-breast",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor"
+          ]
+        },
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"tumor-lobular-carcinoma-left-breast\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-mcode-tumor.html\">Tumor Profile</a></p></div><p><b>Related Condition Extension</b>: <a href=\"Condition-primary-cancer-condition-breast.html\">Condition/primary-cancer-condition-breast</a></p><p><b>identifier</b>: BodyStructure: Tumor 1234 (USUAL)</p><p><b>location</b>: Left breast structure (body structure) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#80248007)</span></p><p><b>patient</b>: <a href=\"Patient-cancer-patient-eve-anyperson.html\">Patient/cancer-patient-eve-anyperson</a> \" ANYPERSON\"</p></div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-related-condition",
+            "valueReference": {
+              "reference": "Condition/primary-cancer-condition-breast"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/resource-types",
+                  "code": "BodyStructure"
+                }
+              ]
+            },
+            "system": "http://radiology.hospital.example.org",
+            "value": "Tumor 1234"
+          }
+        ],
+        "location": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "80248007",
+              "display": "Left breast structure (body structure)"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/cancer-patient-eve-anyperson"
+        }
+      }
+    },
+    {
       "fullUrl": "http://example.org/fhir/Specimen/genomic-specimen-left-breast-jenny-m",
       "resource": {
         "resourceType": "Specimen",

--- a/test/bundles/outcomeBundle.json
+++ b/test/bundles/outcomeBundle.json
@@ -1,0 +1,309 @@
+{
+  "resourceType": "Bundle",
+  "id": "mcode-patient-bundle-jenny-m",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-patient-bundle"
+    ]
+  },
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "empty-disease-status",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/Observation/cancer-disease-status-jenny-m",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cancer-disease-status-jenny-m",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
+          ]
+        },
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"cancer-disease-status-jenny-m\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-mcode-cancer-disease-status.html\">Cancer Disease Status Profile</a></p></div><p><b>Cancer Disease Status Evidence Type Extension</b>: Imaging (procedure) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#363679005)</span></p><p><b>status</b>: final</p><p><b>code</b>: Cancer Disease Progression <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#97509-4)</span></p><p><b>subject</b>: <a href=\"#Patient_cancer-patient-jenny-m\">See above (Patient/cancer-patient-jenny-m)</a></p><p><b>focus</b>: <a href=\"#Condition_primary-cancer-condition-jenny-m\">See above (Condition/primary-cancer-condition-jenny-m)</a></p><p><b>effective</b>: 2018-11-01</p><p><b>performer</b>: <a href=\"#Practitioner_us-core-practitioner-owen-oncologist\">See above (Practitioner/us-core-practitioner-owen-oncologist)</a></p><p><b>value</b>: Patient's condition improved (finding) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#268910001)</span></p></div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status-evidence-type",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "363679005",
+                  "display": "Imaging (procedure)"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "97509-4",
+              "display": "Cancer Disease Progression"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/cancer-patient-jenny-m"
+        },
+        "focus": [
+          {
+            "reference": "Condition/primary-cancer-condition-jenny-m"
+          }
+        ],
+        "effectiveDateTime": "2018-11-01",
+        "performer": [
+          {
+            "reference": "Practitioner/us-core-practitioner-owen-oncologist"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "268910001",
+              "display": "Patient's condition improved (finding)"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "whatever",
+      "resource": {
+        "resourceType": "BodyStructure",
+        "id": "empty-tumor",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor"
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "whatever",
+      "resource": {
+        "resourceType": "BodyStructure",
+        "id": "tumor-lobular-carcinoma-left-breast",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor"
+          ]
+        },
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"tumor-lobular-carcinoma-left-breast\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-mcode-tumor.html\">Tumor Profile</a></p></div><p><b>Related Condition Extension</b>: <a href=\"Condition-primary-cancer-condition-breast.html\">Condition/primary-cancer-condition-breast</a></p><p><b>identifier</b>: BodyStructure: Tumor 1234 (USUAL)</p><p><b>location</b>: Left breast structure (body structure) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#80248007)</span></p><p><b>patient</b>: <a href=\"Patient-cancer-patient-eve-anyperson.html\">Patient/cancer-patient-eve-anyperson</a> \" ANYPERSON\"</p></div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-related-condition",
+            "valueReference": {
+              "reference": "Condition/primary-cancer-condition-breast"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/resource-types",
+                  "code": "BodyStructure"
+                }
+              ]
+            },
+            "system": "http://radiology.hospital.example.org",
+            "value": "Tumor 1234"
+          }
+        ],
+        "location": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "80248007",
+              "display": "Left breast structure (body structure)"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/cancer-patient-eve-anyperson"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/Observation/tumor-size-jenny-m",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "empty-tumor-size",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-size"
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/Observation/tumor-size-jenny-m",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "tumor-size-jenny-m",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-size"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"tumor-size-jenny-m\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-mcode-tumor-size.html\">Tumor Size Profile</a></p></div><p><b>status</b>: final</p><p><b>category</b>: Laboratory <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.0.0/CodeSystem-observation-category.html\">Observation Category Codes</a>#laboratory)</span></p><p><b>code</b>: Size Tumor <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#21889-1)</span></p><p><b>subject</b>: <a href=\"#Patient_cancer-patient-jenny-m\">See above (Patient/cancer-patient-jenny-m)</a></p><p><b>effective</b>: 2018-04-01T00:00:00Z</p><p><b>method</b>: Pathology report gross observation <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#24419-4)</span></p><p><b>specimen</b>: <a href=\"Specimen-tumor-specimen-left-breast-jenny-m.html\">Specimen/tumor-specimen-left-breast-jenny-m</a></p><h3>Components</h3><table class=\"grid\"><tr><td>-</td><td><b>Code</b></td><td><b>Value[x]</b></td></tr><tr><td>*</td><td>Size.maximum dimension in Tumor <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#33728-7)</span></td><td>2.5 centimeters<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code cm = 'cm')</span></td></tr></table></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21889-1",
+              "display": "Size Tumor"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/cancer-patient-jenny-m"
+        },
+        "effectiveDateTime": "2018-04-01T00:00:00Z",
+        "method": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "24419-4",
+              "display": "Pathology report gross observation"
+            }
+          ]
+        },
+        "specimen": {
+          "reference": "Specimen/tumor-specimen-left-breast-jenny-m"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "33728-7",
+                  "display": "Size.maximum dimension in Tumor"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 2.5,
+              "unit": "centimeters",
+              "system": "http://unitsofmeasure.org",
+              "code": "cm"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "33729-5"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "whatever",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "empty-tumor-specimen",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-specimen"
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "whatever",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "tumor-specimen-left-breast-jenny-m",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-specimen"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"tumor-specimen-left-breast-jenny-m\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-mcode-tumor-specimen.html\">Tumor Specimen Profile</a></p></div><p><b>identifier</b>: BodyStructure: Tumor 1234 (USUAL)</p><p><b>status</b>: available</p><p><b>type</b>: Tumor <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.0.0/CodeSystem-v2-0487.html\">specimenType</a>#TUMOR)</span></p><p><b>subject</b>: <a href=\"Patient-cancer-patient-jenny-m.html\">Patient/cancer-patient-jenny-m</a> \" M\"</p><p><b>receivedTime</b>: 2018-04-01</p><h3>Collections</h3><table class=\"grid\"><tr><td>-</td><td><b>BodySite</b></td></tr><tr><td>*</td><td>Left breast structure (body structure) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#80248007)</span></td></tr></table></div>"
+        },
+        "identifier": [
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/resource-types",
+                  "code": "BodyStructure"
+                }
+              ]
+            },
+            "system": "http://radiology.hospital.example.org",
+            "value": "Tumor 1234"
+          }
+        ],
+        "status": "available",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+              "code": "TUMOR"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/cancer-patient-jenny-m"
+        },
+        "receivedTime": "2018-04-01",
+        "collection": {
+          "bodySite": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "80248007",
+                "display": "Left breast structure (body structure)"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/bundles/patientBundle.json
+++ b/test/bundles/patientBundle.json
@@ -15,7 +15,8 @@
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
           ]
-        }
+        },
+        "id": "empty-patient"
       }
     },
     {
@@ -92,6 +93,7 @@
             ]
           }
         ],
+        "deceasedDateTime": "1900-01-01",
         "gender": "female",
         "birthDate": "1965-01-01",
         "address": [

--- a/test/outcomeCoverage.test.js
+++ b/test/outcomeCoverage.test.js
@@ -1,0 +1,65 @@
+const testBundle = require('./bundles/outcomeBundle.json');
+const { getOutcomeCoverage } = require('../src/lib/outcomeCoverage');
+
+describe('getOutcomeCoverage()', () => {
+  const res = getOutcomeCoverage(testBundle);
+
+  test('Section object should have length equal to number of profiles in section', () => {
+    expect(res.data.length).toBe(4);
+  });
+
+  test('Coverage arrays should have length equal to number of resources of each type in bundle', () => {
+    expect(res.data[0].coverage.length).toBe(2);
+    expect(res.data[1].coverage.length).toBe(2);
+    expect(res.data[2].coverage.length).toBe(2);
+    expect(res.data[3].coverage.length).toBe(2);
+  });
+
+  test('All values should be true when disease status has all fields covered', () => {
+    const coveredDiseaseStatus = res.data[0].coverage[1].data;
+    expect(coveredDiseaseStatus['Evidence Type'].covered).toBe(true);
+  });
+
+  test('All values should be false when disease status is missing every field', () => {
+    const emptyDiseaseStatus = res.data[0].coverage[0].data;
+    expect(emptyDiseaseStatus['Evidence Type'].covered).toBe(false);
+  });
+
+  test('All values should be true when tumor has all fields covered', () => {
+    const coveredTumor = res.data[1].coverage[1].data;
+    expect(coveredTumor['Body Structure Identifier'].covered).toBe(true);
+    expect(coveredTumor.Location.covered).toBe(true);
+  });
+
+  test('All values should be false when tumor is missing every field', () => {
+    const emptyTumor = res.data[1].coverage[0].data;
+    expect(emptyTumor['Body Structure Identifier'].covered).toBe(false);
+    expect(emptyTumor.Location.covered).toBe(false);
+  });
+
+  test('All values should be true when tumor size has all fields covered', () => {
+    const coveredSize = res.data[2].coverage[1].data;
+    expect(coveredSize.Method.covered).toBe(true);
+    expect(coveredSize.Component.covered).toBe(true);
+    expect(coveredSize['Longest Dimension'].covered).toBe(true);
+    expect(coveredSize['Other Dimension'].covered).toBe(true);
+  });
+
+  test('All values should be false when tumor size is missing every field', () => {
+    const emptySize = res.data[2].coverage[0].data;
+    expect(emptySize.Method.covered).toBe(false);
+    expect(emptySize.Component.covered).toBe(false);
+    expect(emptySize['Longest Dimension'].covered).toBe(false);
+    expect(emptySize['Other Dimension'].covered).toBe(false);
+  });
+
+  test('All values should be true when tumor specimen has all fields covered', () => {
+    const coveredSpecimen = res.data[3].coverage[1].data;
+    expect(coveredSpecimen.Type.covered).toBe(true);
+  });
+
+  test('All values should be false when tumor specimen is missing every field', () => {
+    const emptySpecimen = res.data[3].coverage[0].data;
+    expect(emptySpecimen.Type.covered).toBe(false);
+  });
+});

--- a/test/patientCoverage.test.js
+++ b/test/patientCoverage.test.js
@@ -20,7 +20,7 @@ describe('getPatientCoverage()', () => {
     expect(res.data[0].coverage[1].data['Zip Code'].covered).toBe(true);
     expect(res.data[0].coverage[1].data['US Core Race'].covered).toBe(true);
     expect(res.data[0].coverage[1].data['US Core Ethnicity'].covered).toBe(true);
-    expect(res.data[0].coverage[1].data['Death Date'].covered).toBe(true);
+    expect(res.data[0].coverage[1].data.Deceased.covered).toBe(true);
   });
 
   test('All values should be false when patient is missing every field', () => {
@@ -31,6 +31,6 @@ describe('getPatientCoverage()', () => {
     expect(res.data[0].coverage[0].data['Zip Code'].covered).toBe(false);
     expect(res.data[0].coverage[0].data['US Core Race'].covered).toBe(false);
     expect(res.data[0].coverage[0].data['US Core Ethnicity'].covered).toBe(false);
-    expect(res.data[0].coverage[0].data['Death Date'].covered).toBe(false);
+    expect(res.data[0].coverage[0].data.Deceased.covered).toBe(false);
   });
 });

--- a/test/patientCoverage.test.js
+++ b/test/patientCoverage.test.js
@@ -1,30 +1,36 @@
-const testBundle = require('./patientBundle.json');
+const testBundle = require('./bundles/patientBundle.json');
 const { getPatientCoverage } = require('../src/lib/patientCoverage');
 
 describe('getPatientCoverage()', () => {
   const res = getPatientCoverage(testBundle);
 
-  test('Result should have length equal to number of patients in bundle', () => {
-    expect(res.length).toBe(2);
+  test('Section object should have length equal to number of profiles in section', () => {
+    expect(res.data.length).toBe(1);
+  });
+
+  test('Coverage array should have length equal to number of patients in bundle', () => {
+    expect(res.data[0].coverage.length).toBe(2);
   });
 
   test('All values should be true when patient has all fields covered', () => {
-    expect(res[1].Name).toBe(true);
-    expect(res[1]['Contact Info']).toBe(true);
-    expect(res[1]['Birth Date']).toBe(true);
-    expect(res[1].Gender).toBe(true);
-    expect(res[1]['Zip Code']).toBe(true);
-    expect(res[1]['US Core Race']).toBe(true);
-    expect(res[1]['US Core Ethnicity']).toBe(true);
+    expect(res.data[0].coverage[1].data.Name.covered).toBe(true);
+    expect(res.data[0].coverage[1].data['Contact Info'].covered).toBe(true);
+    expect(res.data[0].coverage[1].data['Birth Date'].covered).toBe(true);
+    expect(res.data[0].coverage[1].data.Gender.covered).toBe(true);
+    expect(res.data[0].coverage[1].data['Zip Code'].covered).toBe(true);
+    expect(res.data[0].coverage[1].data['US Core Race'].covered).toBe(true);
+    expect(res.data[0].coverage[1].data['US Core Ethnicity'].covered).toBe(true);
+    expect(res.data[0].coverage[1].data['Death Date'].covered).toBe(true);
   });
 
   test('All values should be false when patient is missing every field', () => {
-    expect(res[0].Name).toBe(false);
-    expect(res[0]['Contact Info']).toBe(false);
-    expect(res[0]['Birth Date']).toBe(false);
-    expect(res[0].Gender).toBe(false);
-    expect(res[0]['Zip Code']).toBe(false);
-    expect(res[0]['US Core Race']).toBe(false);
-    expect(res[0]['US Core Ethnicity']).toBe(false);
-  })
+    expect(res.data[0].coverage[0].data.Name.covered).toBe(false);
+    expect(res.data[0].coverage[0].data['Contact Info'].covered).toBe(false);
+    expect(res.data[0].coverage[0].data['Birth Date'].covered).toBe(false);
+    expect(res.data[0].coverage[0].data.Gender.covered).toBe(false);
+    expect(res.data[0].coverage[0].data['Zip Code'].covered).toBe(false);
+    expect(res.data[0].coverage[0].data['US Core Race'].covered).toBe(false);
+    expect(res.data[0].coverage[0].data['US Core Ethnicity'].covered).toBe(false);
+    expect(res.data[0].coverage[0].data['Death Date'].covered).toBe(false);
+  });
 });


### PR DESCRIPTION
# Description
Issue: STEAM-845

This PR adds coverage checking for Outcome resources and changes Patient coverage checking to output in the new format 

## Important Changes
Both patient and outcome coverage checking conform to a new output format, which looks like this:
```
{
  "section": "section name",
  "data": [
    {
      "profile": "profile name",
      "coverage": [
        {
          "resourceID": "a-resource-id",
          "data": {
            "property name": {
              "covered": true
            },
            "another property name": {
              "covered": false
            }
          }
        },
        {
          "resourceID": "another-resource-id",
          "data": {
            "property name": {
              "covered": true
            },
            "another property name": {
              "covered": true
            }
          }
        },
        ...
      ]
    },
    ...
  ]
}
```

Coverage checking has been added for the outcome section of the mCODE diagram in `outcomeCoverage.js`. As we discussed, Body Structure Identifier, despite being a profile on the diagram, is treated as a property of Tumor resources. Another thing we discussed, Tumor Specimen had no properties listed on the diagram so I checked for Type (which I think we decided was a reasonable thing to check for?), definitely let me know if there are different and/or other properties we want to check for.

Patient coverage checking, in `patientCoverage.js`, also has one additional  field added, Death Date, which was in the outcome section on the diagram, but added to the Patient section for simplicity

Removed the `getBodyStructureIdentifier()` function from `resourceUtils.js` for reasons mentioned above about Body Structure Identifier

Tests added and updated for Outcome and Patient in `patientCoverage.test.js` and `outcomeCoverage.test.js`. I've also frankenstein-ed together a few different example resources in `fullBundle.js` and the respective section test bundles, so all the references may not match up, but I think it should work for the purposes of coverage testing.

## Testing Recommendations
- Ensure that new tests cover sufficient cases and pass
- Check that the new output format makes sense
- Make sure that each field has a proper true/false value when it is covered or not

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct GH issue reference.
- [x] Comment added to the relevant GH issue(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] You have tried to break the code
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
