### PR TITLE
Steam 909/semantic filters

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: '14.x'
       - run: npm ci
       - run: npm run lint
         env:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: '14.x'
       - run: npm ci
       - run: npm test
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mCODE Coverage Checker
 
-A web application for calculating a FHIR bundles mCODE Coverage
+A web application for calculating a FHIR bundle's mCODE Coverage
 
 ## Available Scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mcode-coverage-checker",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.0.0",
         "fhirpath": "^2.12.0",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
@@ -4548,6 +4548,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.0.0.tgz",
+      "integrity": "sha512-SsHsGFN1qNPFT5QhSoSD37SHDfGyLSW5AESmyLk2JeCMHv5g0I9g0Hz/zQHx2KNe0jGXh2q2hAm7OdkXm360CA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -7800,9 +7823,9 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -13681,6 +13704,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -20216,6 +20244,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
+    "axios": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.0.0.tgz",
+      "integrity": "sha512-SsHsGFN1qNPFT5QhSoSD37SHDfGyLSW5AESmyLk2JeCMHv5g0I9g0Hz/zQHx2KNe0jGXh2q2hAm7OdkXm360CA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -22633,9 +22683,9 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -26723,6 +26773,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5147,13 +5147,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001416",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -20715,9 +20721,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001416",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.0.0",
     "fhirpath": "^2.12.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",

--- a/src/lib/ValueSetCodeChecker.js
+++ b/src/lib/ValueSetCodeChecker.js
@@ -1,0 +1,58 @@
+import TumorMarkerTestVS from './valueSets/ValueSet-mcode-tumor-marker-test-vs.json';
+import SecondaryCancerDisorderVS from './valueSets/ValueSet-mcode-secondary-cancer-disorder-vs.json';
+import PrimaryCancerDisorderVS from './valueSets/ValueSet-mcode-primary-cancer-disorder-vs.json';
+import RadiotherapyVolumeTypeVS from './valueSets/ValueSet-mcode-radiotherapy-volume-type-vs.json';
+import GenomicSpecimenTypeVS from './valueSets/ValueSet-mcode-genomic-specimen-type-vs.json';
+
+const DEFAULTVSLOOKUP = {
+  TumorMarkerTestVS,
+  SecondaryCancerDisorderVS,
+  PrimaryCancerDisorderVS,
+  RadiotherapyVolumeTypeVS,
+  GenomicSpecimenTypeVS,
+};
+
+function getConceptFromVSExpansion(valueSet, code, codeSystem) {
+  if (!code || !codeSystem || !valueSet) return undefined;
+  return valueSet.expansion.contains.find(
+    (containsItem) =>
+      containsItem && containsItem.system && code === containsItem.code && codeSystem === containsItem.system,
+  );
+}
+
+function getConceptFromVSCompose(valueSet, code, codeSystem) {
+  if (!code || !codeSystem || !valueSet) return undefined;
+  const includeItem = valueSet.compose.include.find(
+    (item) => item && item.system && item.system === codeSystem && item.concept,
+  );
+  if (!includeItem) return undefined;
+  return includeItem.concept.find((concept) => concept.code === code);
+}
+class ValueSetCodeChecker {
+  constructor(valueSetLookup = DEFAULTVSLOOKUP) {
+    this.valueSetLookup = valueSetLookup;
+  }
+
+  /**
+   * Check if code is in value set
+   * @param {string} code value to look for in a valueSet
+   * @param {string} codeSystem the system to which the code value belongs
+   * @param {string} valueSetName the name of the value set to be searched
+   * @return {boolean} true if condition is in valueSet's compose block or expansion block
+   */
+  checkCodeInVs(code, codeSystem, valueSetName) {
+    const valueSet = this.valueSetLookup[valueSetName];
+    let inVSExpansion = false;
+    let inVSCompose = false;
+    if (valueSet.expansion) {
+      // If valueSet has expansion, we only need to check these codes
+      inVSExpansion = getConceptFromVSExpansion(valueSet, code, codeSystem) !== undefined;
+    } else {
+      // Checks if code is in any of the valueSet.compose.include arrays
+      inVSCompose = getConceptFromVSCompose(valueSet, code, codeSystem) !== undefined;
+    }
+    return inVSCompose || inVSExpansion;
+  }
+}
+
+export default ValueSetCodeChecker;

--- a/src/lib/ValueSetCodeChecker.js
+++ b/src/lib/ValueSetCodeChecker.js
@@ -1,8 +1,8 @@
-import TumorMarkerTestVS from './valueSets/ValueSet-mcode-tumor-marker-test-vs.json';
-import SecondaryCancerDisorderVS from './valueSets/ValueSet-mcode-secondary-cancer-disorder-vs.json';
-import PrimaryCancerDisorderVS from './valueSets/ValueSet-mcode-primary-cancer-disorder-vs.json';
-import RadiotherapyVolumeTypeVS from './valueSets/ValueSet-mcode-radiotherapy-volume-type-vs.json';
-import GenomicSpecimenTypeVS from './valueSets/ValueSet-mcode-genomic-specimen-type-vs.json';
+const TumorMarkerTestVS = require('./valueSets/ValueSet-mcode-tumor-marker-test-vs.json');
+const SecondaryCancerDisorderVS = require('./valueSets/ValueSet-mcode-secondary-cancer-disorder-vs.json');
+const PrimaryCancerDisorderVS = require('./valueSets/ValueSet-mcode-primary-cancer-disorder-vs.json');
+const RadiotherapyVolumeTypeVS = require('./valueSets/ValueSet-mcode-radiotherapy-volume-type-vs.json');
+const GenomicSpecimenTypeVS = require('./valueSets/ValueSet-mcode-genomic-specimen-type-vs.json');
 
 // Map names used in VS to the corresponding JSON
 const DEFAULTVSLOOKUP = {
@@ -56,4 +56,6 @@ class ValueSetCodeChecker {
   }
 }
 
-export default ValueSetCodeChecker;
+module.exports = {
+  ValueSetCodeChecker,
+};

--- a/src/lib/ValueSetCodeChecker.js
+++ b/src/lib/ValueSetCodeChecker.js
@@ -4,6 +4,7 @@ import PrimaryCancerDisorderVS from './valueSets/ValueSet-mcode-primary-cancer-d
 import RadiotherapyVolumeTypeVS from './valueSets/ValueSet-mcode-radiotherapy-volume-type-vs.json';
 import GenomicSpecimenTypeVS from './valueSets/ValueSet-mcode-genomic-specimen-type-vs.json';
 
+// Map names used in VS to the corresponding JSON
 const DEFAULTVSLOOKUP = {
   TumorMarkerTestVS,
   SecondaryCancerDisorderVS,

--- a/src/lib/coverageChecker/assessmentCoverage.js
+++ b/src/lib/coverageChecker/assessmentCoverage.js
@@ -1,5 +1,5 @@
 const fhirpath = require('fhirpath');
-const { getKarnofskyPerformanceStatus, getComorbidities, getECOGPerfomanceStatus } = require('./resourceUtils');
+const { getKarnofskyPerformanceStatus, getComorbidities, getECOGPerfomanceStatus } = require('../resourceFilters');
 const { assessmentSectionId } = require('../coverageSectionIds');
 const { assessmentProfileIds } = require('../coverageProfileIds');
 

--- a/src/lib/coverageChecker/diseaseCoverage.js
+++ b/src/lib/coverageChecker/diseaseCoverage.js
@@ -7,7 +7,7 @@ const {
   getTNMPrimaryTumorCategory,
   getTNMDistantMetastasesCategory,
   getTNMRegionalNodesCategory,
-} = require('./resourceUtils');
+} = require('../resourceFilters');
 const { diseaseSectionId } = require('../coverageSectionIds');
 const { diseaseProfileIds } = require('../coverageProfileIds');
 

--- a/src/lib/coverageChecker/genomicsCoverage.js
+++ b/src/lib/coverageChecker/genomicsCoverage.js
@@ -4,7 +4,7 @@ const {
   getGenomicSpecimen,
   getGenomicVariant,
   getGenomicsReport,
-} = require('./resourceUtils');
+} = require('../resourceFilters');
 const { genomicsSectionId } = require('../coverageSectionIds');
 const { genomicsProfileIds } = require('../coverageProfileIds');
 

--- a/src/lib/coverageChecker/outcomeCoverage.js
+++ b/src/lib/coverageChecker/outcomeCoverage.js
@@ -1,5 +1,5 @@
 const fhirpath = require('fhirpath');
-const { getDiseaseStatus, getTumor, getTumorSize, getTumorSpecimen } = require('./resourceUtils');
+const { getDiseaseStatus, getTumor, getTumorSize, getTumorSpecimen } = require('../resourceFilters');
 const { outcomeSectionId } = require('../coverageSectionIds');
 const { outcomeProfileIds } = require('../coverageProfileIds');
 

--- a/src/lib/coverageChecker/patientCoverage.js
+++ b/src/lib/coverageChecker/patientCoverage.js
@@ -1,5 +1,5 @@
 const fhirpath = require('fhirpath');
-const { getPatient } = require('./resourceUtils');
+const { getPatient } = require('../resourceFilters');
 const { patientSectionId } = require('../coverageSectionIds');
 const { patientProfileIds } = require('../coverageProfileIds');
 /**

--- a/src/lib/coverageChecker/resourceUtils.js
+++ b/src/lib/coverageChecker/resourceUtils.js
@@ -3,10 +3,7 @@ const fhirpath = require('fhirpath');
 // Patient
 
 function getPatient(bundle) {
-  return fhirpath.evaluate(
-    bundle,
-    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient')",
-  );
+  return fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(Patient)');
 }
 
 // Outcome

--- a/src/lib/coverageChecker/resourceUtils.js
+++ b/src/lib/coverageChecker/resourceUtils.js
@@ -1,40 +1,64 @@
 const fhirpath = require('fhirpath');
 
 // Patient
-// No reliable requirements for mCODE Patients or US Core Patients: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html#conformance
+// No reliable conformance requirements for mCODE Patients or US Core Patients: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html#conformance
 function getPatient(bundle) {
-  return fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(Patient)');
+  const metaProfiledResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient')",
+  );
+  const constrainedResources = fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(Patient)');
+  return metaProfiledResources || constrainedResources;
 }
 
 // Outcome
 // Disease Statuses must have code of LOINC `97509-4`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-disease-status.html#conformance
 function getDiseaseStatus(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status')",
+  );
+  const constrainedResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.ofType(Observation).where(code.coding.code = '97509-4' and code.coding.system = 'http://loinc.org')",
   );
+  return metaProfiledResources || constrainedResources;
 }
-// No reliable requirements for Tumor BodyStructures: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor.html#conformance
+// No reliable conformance requirements for Tumor BodyStructures: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor.html#conformance
 function getTumor(bundle) {
-  return fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(BodyStructure)');
+  const metaProfiledResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor')",
+  );
+  const constrainedResources = fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(BodyStructure)');
+  return metaProfiledResources || constrainedResources;
 }
 // Tumor Size measurements must have an Observation.code of LOINC `21889-1` : https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-size.html#conformance
 function getTumorSize(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-size')",
+  );
+  const constrainedResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.ofType(Observation).where(code.coding.code = '21889-1' and code.coding.system = 'http://loinc.org')",
   );
+  return metaProfiledResources || constrainedResources;
 }
 // TumorSpecimen's must have a Specimen.type of `TUMOR` from system http://terminology.hl7.org/CodeSystem/v2-0487: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-specimen.html#conformance
 function getTumorSpecimen(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-specimen')",
+  );
+  const constrainedResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.ofType(Specimen).where(type.coding.code = 'TUMOR' and type.coding.system = 'http://terminology.hl7.org/CodeSystem/v2-0487')",
   );
+  return metaProfiledResources || constrainedResources;
 }
 
 // Disease
-
 function getTumorMarkerTest(bundle) {
   return fhirpath.evaluate(
     bundle,

--- a/src/lib/coverageChecker/resourceUtils.js
+++ b/src/lib/coverageChecker/resourceUtils.js
@@ -59,7 +59,7 @@ function getTumorSpecimen(bundle) {
 }
 
 // Disease
-// Tumor Marker Tests must have a code from an extensible valueset: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-marker-test.html#conformance
+// Tumor Marker Tests must have a code from an extensible valueset, TumorMarkerTestVS: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-marker-test.html#conformance
 function getTumorMarkerTest(bundle) {
   const metaProfiledResources = fhirpath.evaluate(
     bundle,
@@ -72,7 +72,7 @@ function getTumorMarkerTest(bundle) {
   );
   return metaProfiledResources || constrainedResources;
 }
-// Secondary Cancer Conditions must have a code from an extensible valueset: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-secondary-cancer-condition.html#conformance
+// Secondary Cancer Conditions must have a code from an extensible valueset, SecondaryCancerDisorderVS: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-secondary-cancer-condition.html#conformance
 function getSecondaryCancerCondition(bundle) {
   const metaProfiledResources = fhirpath.evaluate(
     bundle,
@@ -85,7 +85,7 @@ function getSecondaryCancerCondition(bundle) {
   );
   return metaProfiledResources || constrainedResources;
 }
-// Primary Cancer Conditions must have a code from extensible valueset: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-primary-cancer-condition.html#conformance
+// Primary Cancer Conditions must have a code from extensible valueset, PrimaryCancerDisorderVS: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-primary-cancer-condition.html#conformance
 function getPrimaryCancerCondition(bundle) {
   const metaProfiledResources = fhirpath.evaluate(
     bundle,
@@ -148,51 +148,69 @@ function getTNMRegionalNodesCategory(bundle) {
 }
 
 // Genomics
-
+// GenomicsReport must have a LOINC code 81247-9: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-genomics-report.html#conformance
 function getGenomicsReport(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-genomics-report')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(DiagnosticReport).where(code.coding.system = 'http://loinc.org' and code.coding.code = '81247-9')",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// GenomicsSpecimen must have a code form the GenomicSpecimenTypeVS: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-genomic-specimen.html#conformance
 function getGenomicSpecimen(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-genomic-specimen')",
   );
+  // TODO: Figure out how to check valuesets or filter after
+  const constrainedResources = fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(Specimen)');
+  return metaProfiledResources || constrainedResources;
 }
-
+// GenomicsVariant must have a LOINC code `69548-6`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-genomic-variant.html#conformance
 function getGenomicVariant(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-genomic-variant')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and code.coding.code = '69548-6')",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// GenomicsRegion must have a LOINC code `53041-0`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-genomic-region-studied.html#conformance
 function getGenomicRegionStudied(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-genomic-region-studied')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and code.coding.code = '53041-0')",
+  );
+  return metaProfiledResources || constrainedResources;
 }
 
 // Assessment
-
+// KarnofskyStatus must have
 function getKarnofskyPerformanceStatus(bundle) {
   return fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-karnofsky-performance-status')",
   );
 }
-
+// Comorbidities must have
 function getComorbidities(bundle) {
   return fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbidities-elixhauser')",
   );
 }
-
+// ECOG must have
 function getECOGPerfomanceStatus(bundle) {
   return fhirpath.evaluate(
     bundle,
@@ -201,35 +219,35 @@ function getECOGPerfomanceStatus(bundle) {
 }
 
 // Treatment
-
+// CancerRelatedMedicationRequests must
 function getCancerRelatedMedicationRequest(bundle) {
   return fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request')",
   );
 }
-
+// CancerRelatedMedicationAdministration must
 function getCancerRelatedMedicationAdministration(bundle) {
   return fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-administration')",
   );
 }
-
+// CancerRelatedMedicationSurgicalProcedure
 function getCancerRelatedSurgicalProcedure(bundle) {
   return fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure')",
   );
 }
-
+// Radiotheraphy Course Summary
 function getRadiotherapyCourseSummary(bundle) {
   return fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary')",
   );
 }
-
+// Radiotherapy Volume must
 function getRadiotherapyVolume(bundle) {
   return fhirpath.evaluate(
     bundle,

--- a/src/lib/coverageChecker/resourceUtils.js
+++ b/src/lib/coverageChecker/resourceUtils.js
@@ -59,53 +59,92 @@ function getTumorSpecimen(bundle) {
 }
 
 // Disease
+// Tumor Marker Tests must have a code from an extensible valueset: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-marker-test.html#conformance
 function getTumorMarkerTest(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-marker-test')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    // TODO: Figure out how to check valuesets or filter after the fact
+    'Bundle.entry.resource.ofType(Observation)',
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// Secondary Cancer Conditions must have a code from an extensible valueset: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-secondary-cancer-condition.html#conformance
 function getSecondaryCancerCondition(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-secondary-cancer-condition')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    // TODO: Figure out how to check valuesets or filter after
+    'Bundle.entry.resource.ofType(Condition)',
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// Primary Cancer Conditions must have a code from extensible valueset: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-primary-cancer-condition.html#conformance
 function getPrimaryCancerCondition(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-primary-cancer-condition')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    // TODO: Figure out how to check valuesets or filter after
+    'Bundle.entry.resource.ofType(Condition)',
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// Stage Groups must have a code from the following – LOINC 21908-9, 21902-2, or 21914-7: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-stage-group.html#conformance
 function getStageGroup(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and (code.coding.code = '21908-9' or code.coding.code = '21902-2' or code.coding.code = '21914-7'))",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// Primary Tumor Categories must have a code from the following – LOINC 21905-5, 21899-0, or 21911-3: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tnm-primary-tumor-category.html#conformance
 function getTNMPrimaryTumorCategory(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and (code.coding.code = '21905-5' or code.coding.code = '21899-0' or code.coding.code = '21911-3'))",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// Metastases Categories must have a code from the following – LOINC 21907-1, 21901-4, or 21913-9: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tnm-distant-metastases-category.html#conformance
 function getTNMDistantMetastasesCategory(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-distant-metastases-category')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and (code.coding.code = '21907-1' or code.coding.code = '21901-4' or code.coding.code = '21913-9'))",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-
+// Regional Node categories must have a code from the following - LOINC 21906-3, 21900-6, or 21912-1: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tnm-regional-nodes-category.html#conformance
 function getTNMRegionalNodesCategory(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-regional-nodes-category')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and (code.coding.code = '21906-3' or code.coding.code = '21900-6' or code.coding.code = '21912-1'))",
+  );
+  return metaProfiledResources || constrainedResources;
 }
 
 // Genomics

--- a/src/lib/coverageChecker/resourceUtils.js
+++ b/src/lib/coverageChecker/resourceUtils.js
@@ -1,38 +1,35 @@
 const fhirpath = require('fhirpath');
 
 // Patient
-
+// No reliable requirements for mCODE Patients or US Core Patients: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html#conformance
 function getPatient(bundle) {
   return fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(Patient)');
 }
 
 // Outcome
-
+// Disease Statuses must have code of LOINC `97509-4`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-disease-status.html#conformance
 function getDiseaseStatus(bundle) {
   return fhirpath.evaluate(
     bundle,
-    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status')",
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.code = '97509-4' and code.coding.system = 'http://loinc.org')",
   );
 }
-
+// No reliable requirements for Tumor BodyStructures: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor.html#conformance
 function getTumor(bundle) {
-  return fhirpath.evaluate(
-    bundle,
-    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor')",
-  );
+  return fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(BodyStructure)');
 }
-
+// Tumor Size measurements must have an Observation.code of LOINC `21889-1` : https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-size.html#conformance
 function getTumorSize(bundle) {
   return fhirpath.evaluate(
     bundle,
-    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-size')",
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.code = '21889-1' and code.coding.system = 'http://loinc.org')",
   );
 }
-
+// TumorSpecimen's must have a Specimen.type of `TUMOR` from system http://terminology.hl7.org/CodeSystem/v2-0487: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor-specimen.html#conformance
 function getTumorSpecimen(bundle) {
   return fhirpath.evaluate(
     bundle,
-    "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor-specimen')",
+    "Bundle.entry.resource.ofType(Specimen).where(type.coding.code = 'TUMOR' and type.coding.system = 'http://terminology.hl7.org/CodeSystem/v2-0487')",
   );
 }
 

--- a/src/lib/coverageChecker/resourceUtils.js
+++ b/src/lib/coverageChecker/resourceUtils.js
@@ -196,26 +196,41 @@ function getGenomicRegionStudied(bundle) {
 }
 
 // Assessment
-// KarnofskyStatus must have
+// KarnofskyStatus must have a LOINC code `89243-0`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-karnofsky-performance-status.html#conformance
 function getKarnofskyPerformanceStatus(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-karnofsky-performance-status')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and code.coding.code = '89243-0')",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-// Comorbidities must have
+// Comorbidities must have a code `comorbidities-elixhauser` from codesystem `http://hl7.org/fhir/us/mcode/CodeSystem/loinc-requested-cs`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-comorbidities-elixhauser.html#conformance
 function getComorbidities(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbidities-elixhauser')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://hl7.org/fhir/us/mcode/CodeSystem/loinc-requested-cs' and code.coding.code = 'comorbidities-elixhauser')",
+  );
+  return metaProfiledResources || constrainedResources;
 }
-// ECOG must have
+// ECOG must have a LOINC code `89247-1`: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-ecog-performance-status.html#conformance
 function getECOGPerfomanceStatus(bundle) {
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-ecog-performance-status')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    "Bundle.entry.resource.ofType(Observation).where(code.coding.system = 'http://loinc.org' and code.coding.code = '89247-1')",
+  );
+  return metaProfiledResources || constrainedResources;
 }
 
 // Treatment

--- a/src/lib/coverageChecker/treatmentCoverage.js
+++ b/src/lib/coverageChecker/treatmentCoverage.js
@@ -5,7 +5,7 @@ const {
   getCancerRelatedSurgicalProcedure,
   getRadiotherapyCourseSummary,
   getRadiotherapyVolume,
-} = require('./resourceUtils');
+} = require('../resourceFilters');
 const { treatmentSectionId } = require('../coverageSectionIds');
 const { treatmentProfileIds } = require('../coverageProfileIds');
 

--- a/src/lib/resourceFilters.js
+++ b/src/lib/resourceFilters.js
@@ -7,7 +7,6 @@ const vsChecker = new ValueSetCodeChecker();
 // Patient
 // No reliable conformance requirements for mCODE Patients or US Core Patients: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html#conformance
 function getPatient(bundle) {
-  // TODO
   const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient')",
@@ -257,21 +256,31 @@ function getECOGPerfomanceStatus(bundle) {
 }
 
 // Treatment
-// MedicationRequests that reference a CancerCondition must be CancerRelatedMedicationRequests: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-medication-request.html#conformance
+// MedicationRequests that reference a CancerCondition must be CancerRelatedMedicationRequests, either by reasonCode or reasonReference: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-medication-request.html#conformance & constraints section
 function getCancerRelatedMedicationRequest(bundle) {
-  // TODO
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    'Bundle.entry.resource.ofType(MedicationRequest).where(reasonCode.exists() or reasonReference.exists())',
+  );
+  // NOTE: these constraints aren't implemented perfectly, we should be checking these reasons for cancer-relevance; being overly permissive is okay at this stage of the filter.
+  return metaProfiledResources || constrainedResources;
 }
-// MedicationAdministrations that reference a CancerCondition must be CancerRelatedMedicationAdministration: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-medication-administration.html#conformance
+// MedicationAdministrations that reference a CancerCondition must be CancerRelatedMedicationAdministration, either by reasonCode or reasonReference: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-medication-administration.html#conformance & constraints section
 function getCancerRelatedMedicationAdministration(bundle) {
-  // TODO
-  return fhirpath.evaluate(
+  const metaProfiledResources = fhirpath.evaluate(
     bundle,
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-administration')",
   );
+  const constrainedResources = fhirpath.evaluate(
+    bundle,
+    'Bundle.entry.resource.ofType(MedicationAdministration).where(reasonCode.exists() or reasonReference.exists())',
+  );
+  // NOTE: these constraints aren't implemented perfectly, we should be checking these reasons for cancer-relevance; being overly permissive is okay at this stage of the filter.
+  return metaProfiledResources || constrainedResources;
 }
 // Procedures with a SNOMED code `387713003` must be a CancerRelatedMedicationSurgicalProcedure: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-surgical-procedure.html#conformance
 function getCancerRelatedSurgicalProcedure(bundle) {

--- a/src/lib/resourceFilters.js
+++ b/src/lib/resourceFilters.js
@@ -46,7 +46,7 @@ function getTumor(bundle) {
   );
   const constrainedResources = fhirpath.evaluate(
     bundle,
-    "Bundle.entry.resource.ofType(BodyStructure).where(code.coding.system = 'http://snomed.info/sct' and code.coding.code = '367651003')",
+    "Bundle.entry.resource.ofType(BodyStructure).where(morphology.coding.system = 'http://snomed.info/sct' and morphology.coding.code = '367651003')",
   );
   return mergeWithoutDuplicates(metaProfiledResources, constrainedResources);
 }
@@ -293,7 +293,7 @@ function getCancerRelatedMedicationAdministration(bundle) {
   // NOTE: these constraints aren't implemented perfectly, we should be checking these reasons for cancer-relevance; being overly permissive is okay at this stage of the filter.
   return mergeWithoutDuplicates(metaProfiledResources, constrainedResources);
 }
-// Procedures with a SNOMED code `387713003` must be a CancerRelatedMedicationSurgicalProcedure: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-surgical-procedure.html#conformance
+// Procedures with a SNOMED category code `387713003` must be a CancerRelatedMedicationSurgicalProcedure: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-related-surgical-procedure.html#conformance
 function getCancerRelatedSurgicalProcedure(bundle) {
   const metaProfiledResources = fhirpath.evaluate(
     bundle,
@@ -301,7 +301,7 @@ function getCancerRelatedSurgicalProcedure(bundle) {
   );
   const constrainedResources = fhirpath.evaluate(
     bundle,
-    "Bundle.entry.resource.ofType(Procedure).where(code.coding.system = 'http://snomed.info/sct' and code.coding.code = '387713003')",
+    "Bundle.entry.resource.ofType(Procedure).where(category.coding.system = 'http://snomed.info/sct' and category.coding.code = '387713003')",
   );
   return mergeWithoutDuplicates(metaProfiledResources, constrainedResources);
 }
@@ -328,7 +328,7 @@ function getRadiotherapyVolume(bundle) {
     .filter(
       (bodyStructure) =>
         bodyStructure.morphology?.coding?.some((coding) =>
-          vsChecker.checkCodeInVs(coding.code, coding.system, 'TumorMarkerTestVS'),
+          vsChecker.checkCodeInVs(coding.code, coding.system, 'RadiotherapyVolumeTypeVS'),
         ) ?? false,
     );
   return mergeWithoutDuplicates(metaProfiledResources, constrainedResources);

--- a/src/lib/resourceFilters.js
+++ b/src/lib/resourceFilters.js
@@ -106,7 +106,7 @@ function getSecondaryCancerCondition(bundle) {
           vsChecker.checkCodeInVs(coding.code, coding.system, 'SecondaryCancerDisorderVS'),
         ) ?? false,
     );
-  return metaProfiledResources.length > 0 ? metaProfiledResources : constrainedResources;
+  return mergeWithoutDuplicates(metaProfiledResources, constrainedResources);
 }
 // Conditions with a code from extensible valueset, PrimaryCancerDisorderVS, must be Primary Cancer Conditions: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-primary-cancer-condition.html#conformance
 function getPrimaryCancerCondition(bundle) {

--- a/src/lib/resourceFilters.js
+++ b/src/lib/resourceFilters.js
@@ -1,6 +1,6 @@
 const fhirpath = require('fhirpath');
 // NOTE: See here: https://stackoverflow.com/questions/33704714/cant-require-default-export-value-in-babel-6-x
-const ValueSetCodeChecker = require('./ValueSetCodeChecker').default;
+const { ValueSetCodeChecker } = require('./ValueSetCodeChecker');
 
 const vsChecker = new ValueSetCodeChecker();
 
@@ -12,6 +12,7 @@ function getPatient(bundle) {
     "Bundle.entry.resource.where(meta.profile = 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient')",
   );
   const constrainedResources = fhirpath.evaluate(bundle, 'Bundle.entry.resource.ofType(Patient)');
+  // NOTE: Being overly permissive is okay at this stage of the filter.
   return metaProfiledResources || constrainedResources;
 }
 
@@ -28,7 +29,7 @@ function getDiseaseStatus(bundle) {
   );
   return metaProfiledResources || constrainedResources;
 }
-// BodyStructures with a morphology code SNOMED-`367651003` must be Tumors: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor.html#conformance
+// BodyStructures with a morphology code SNOMED `367651003` must be Tumors: https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-tumor.html#conformance
 function getTumor(bundle) {
   const metaProfiledResources = fhirpath.evaluate(
     bundle,

--- a/src/lib/valueSets/ValueSet-mcode-genomic-specimen-type-vs.json
+++ b/src/lib/valueSets/ValueSet-mcode-genomic-specimen-type-vs.json
@@ -1,0 +1,197 @@
+{
+  "resourceType": "ValueSet",
+  "id": "mcode-genomic-specimen-type-vs",
+  "language": "en",
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-genomic-specimen-type-vs",
+  "version": "2.1.0",
+  "name": "GenomicSpecimenTypeVS",
+  "title": "Genomic Specimen Type Value Set",
+  "status": "active",
+  "experimental": false,
+  "expansion": {
+    "identifier": "urn:uuid:3d2cbcf4-570f-4152-9ae0-5f84d73d8121",
+    "timestamp": "2022-10-05T22:14:54.098Z",
+    "parameter": [
+      {
+        "name": "expansion-source",
+        "valueUri": "ValueSet/mcode-genomic-specimen-type-vs"
+      },
+      {
+        "name": "version",
+        "valueUri": "http://terminology.hl7.org/CodeSystem/v2-0487|2.9"
+      }
+    ],
+    "contains": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "AMN",
+        "display": "Amniotic fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "BIFL",
+        "display": "Bile Fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "BLD",
+        "display": "Whole blood"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "BLDA",
+        "display": "Blood arterial"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "BLDCO",
+        "display": "Cord blood"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "BLDV",
+        "display": "Blood venous"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "BON",
+        "display": "Bone"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "CSERU",
+        "display": "Serum, Convalescent"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "CSF",
+        "display": "Cerebral spinal fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "CVM",
+        "display": "Cervical Mucus"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "DUFL",
+        "display": "Duodenal fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "FBLOOD",
+        "display": "Blood, Fetal"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "FGA",
+        "display": "Fluid, Abdomen"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "GENV",
+        "display": "Genital vaginal"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "HYDC",
+        "display": "Fluid, Hydrocele"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "JNTFLD",
+        "display": "Fluid, Joint"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "KIDFLD",
+        "display": "Fluid, Kidney"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "LSAC",
+        "display": "Fluid, Lumbar Sac"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "MAR",
+        "display": "Marrow"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "PAFL",
+        "display": "Pancreatic fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "PCFL",
+        "display": "Fluid, Pericardial"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "PLC",
+        "display": "Placenta"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "PLR",
+        "display": "Pleural fluid (thoracentesis fluid)"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "SAL",
+        "display": "Saliva"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "SKN",
+        "display": "Skin"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "SMN",
+        "display": "Seminal fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "SNV",
+        "display": "Fluid, synovial (Joint fluid)"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "SPT",
+        "display": "Sputum"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "TISS",
+        "display": "Tissue"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "TUMOR",
+        "display": "Tumor"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "VITF",
+        "display": "Vitreous Fluid"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "WND",
+        "display": "Wound"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "UR",
+        "display": "Urine"
+      },
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+        "code": "STL",
+        "display": "Stool = Fecal"
+      }
+    ]
+  }
+}

--- a/src/lib/valueSets/ValueSet-mcode-primary-cancer-disorder-vs.json
+++ b/src/lib/valueSets/ValueSet-mcode-primary-cancer-disorder-vs.json
@@ -1,0 +1,29660 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "PrimaryCancerDisorderVS",
+  "id": "mcode-primary-cancer-disorder-vs",
+  "title": "Primary Cancer Disorder Value Set",
+  "description": "Types of primary malignant neoplastic disease, coded in SNOMED CT or ICD-10-CM.",
+  "version": "2.1.0",
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-primary-cancer-disorder-vs",
+  "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+  "experimental": false,
+  "extension": [
+    {
+      "_sliceName": "FMM",
+      "valueInteger": {
+        "assignedValue": 4,
+        "_primitive": true
+      }
+    }
+  ],
+  "expansion": {
+    "contains": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363346000",
+        "display": "Malignant tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "13048006",
+        "display": "Orbital lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "20224008",
+        "display": "Delta heavy chain disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "25050002",
+        "display": "Alpha heavy chain disease, respiratory form"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "35868009",
+        "display": "Carcinoid syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "36222008",
+        "display": "Carcinoid heart disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "39795003",
+        "display": "Hand-Schuller-Christian disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "58961005",
+        "display": "Lethal midline granuloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "60620005",
+        "display": "Epsilon heavy chain disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "61493004",
+        "display": "Mu heavy chain disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "62497000",
+        "display": "Stewart-Treves syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "68979007",
+        "display": "Heavy chain disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "69408002",
+        "display": "Gorlin syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "82546001",
+        "display": "Reactive immunoproliferative disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91854005",
+        "display": "Acute leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91855006",
+        "display": "Acute leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91856007",
+        "display": "Acute lymphoid leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91857003",
+        "display": "Acute lymphoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91858008",
+        "display": "Acute monocytic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91860005",
+        "display": "Acute myeloid leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91861009",
+        "display": "Acute myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92511007",
+        "display": "Burkitt's tumor of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92512000",
+        "display": "Burkitt's tumor of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92513005",
+        "display": "Burkitt's tumor of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92516002",
+        "display": "Burkitt's tumor of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92811003",
+        "display": "Chronic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92812005",
+        "display": "Chronic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92813000",
+        "display": "Chronic lymphoid leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92814006",
+        "display": "Chronic lymphoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92817004",
+        "display": "Chronic myeloid leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92818009",
+        "display": "Chronic myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93133006",
+        "display": "Letterer-Siwe disease of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93134000",
+        "display": "Letterer-Siwe disease of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93135004",
+        "display": "Letterer-Siwe disease of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93136003",
+        "display": "Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93137007",
+        "display": "Letterer-Siwe disease of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93138002",
+        "display": "Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93139005",
+        "display": "Letterer-Siwe disease of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93140007",
+        "display": "Letterer-Siwe disease of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93141006",
+        "display": "Letterer-Siwe disease of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93142004",
+        "display": "Leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93143009",
+        "display": "Leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93151007",
+        "display": "Leukemic reticuloendotheliosis of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93169003",
+        "display": "Lymphoid leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93182006",
+        "display": "Malignant histiocytosis of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93183001",
+        "display": "Malignant histiocytosis of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93184007",
+        "display": "Malignant histiocytosis of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93185008",
+        "display": "Malignant histiocytosis of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93186009",
+        "display": "Malignant histiocytosis of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93187000",
+        "display": "Malignant histiocytosis of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93188005",
+        "display": "Malignant histiocytosis of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93189002",
+        "display": "Malignant histiocytosis of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93190006",
+        "display": "Malignant histiocytosis of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93191005",
+        "display": "Malignant lymphoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93192003",
+        "display": "Malignant lymphoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93193008",
+        "display": "Malignant lymphoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93194002",
+        "display": "Malignant lymphoma of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93195001",
+        "display": "Malignant lymphoma of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93196000",
+        "display": "Malignant lymphoma of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93197009",
+        "display": "Malignant lymphoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93198004",
+        "display": "Malignant lymphoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93199007",
+        "display": "Malignant lymphoma of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93200005",
+        "display": "Malignant mast cell tumor of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93201009",
+        "display": "Malignant mast cell tumor of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93202002",
+        "display": "Malignant mast cell tumor of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93203007",
+        "display": "Malignant mast cell tumor of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93204001",
+        "display": "Malignant mast cell tumor of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93205000",
+        "display": "Malignant mast cell tumor of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93209006",
+        "display": "Malignant melanoma of perianal skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93210001",
+        "display": "Malignant melanoma of skin of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93211002",
+        "display": "Malignant melanoma of skin of ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93213004",
+        "display": "Malignant melanoma of skin of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93214005",
+        "display": "Malignant melanoma of skin of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93215006",
+        "display": "Malignant melanoma of skin of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93216007",
+        "display": "Malignant melanoma of skin of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93217003",
+        "display": "Malignant melanoma of skin of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93218008",
+        "display": "Malignant melanoma of skin of chest"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93219000",
+        "display": "Malignant melanoma of skin of chin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93220006",
+        "display": "Malignant melanoma of skin of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93221005",
+        "display": "Malignant melanoma of skin of elbow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93222003",
+        "display": "Malignant melanoma of skin of external auditory canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93223008",
+        "display": "Malignant melanoma of skin of eyebrow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93224002",
+        "display": "Malignant melanoma of skin of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93225001",
+        "display": "Malignant melanoma of skin of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93226000",
+        "display": "Malignant melanoma of skin of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93227009",
+        "display": "Malignant melanoma of skin of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93228004",
+        "display": "Malignant melanoma of skin of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93229007",
+        "display": "Malignant melanoma of skin of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93230002",
+        "display": "Malignant melanoma of skin of groin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93451002",
+        "display": "Di Guglielmo's disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93487009",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93488004",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93489007",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93492006",
+        "display": "Hodgkin's disease, lymphocytic depletion of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93493001",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93494007",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93495008",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93496009",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93497000",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93498005",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93500006",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93501005",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93505001",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93506000",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93507009",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93509007",
+        "display": "Hodgkin's disease, mixed cellularity of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93510002",
+        "display": "Hodgkin's disease, mixed cellularity of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93514006",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93515007",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93516008",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93518009",
+        "display": "Hodgkin's disease, nodular sclerosis of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93519001",
+        "display": "Hodgkin's disease, nodular sclerosis of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93520007",
+        "display": "Hodgkin's disease of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93521006",
+        "display": "Hodgkin's disease of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93522004",
+        "display": "Hodgkin's disease of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93523009",
+        "display": "Hodgkin's disease of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93524003",
+        "display": "Hodgkin's disease of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93525002",
+        "display": "Hodgkin's disease of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93526001",
+        "display": "Hodgkin's disease of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93527005",
+        "display": "Hodgkin's disease of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93528000",
+        "display": "Hodgkin's disease of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93530003",
+        "display": "Hodgkin's granuloma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93531004",
+        "display": "Hodgkin's granuloma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93532006",
+        "display": "Hodgkin's granuloma of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93533001",
+        "display": "Hodgkin's granuloma of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93534007",
+        "display": "Hodgkin's granuloma of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93536009",
+        "display": "Hodgkin's granuloma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93537000",
+        "display": "Hodgkin's granuloma of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93541001",
+        "display": "Hodgkin's paragranuloma of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93542008",
+        "display": "Hodgkin's paragranuloma of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93543003",
+        "display": "Hodgkin's paragranuloma of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93546006",
+        "display": "Hodgkin's paragranuloma of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93547002",
+        "display": "Hodgkin's sarcoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93548007",
+        "display": "Hodgkin's sarcoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93549004",
+        "display": "Hodgkin's sarcoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93550004",
+        "display": "Hodgkin's sarcoma of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93551000",
+        "display": "Hodgkin's sarcoma of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93552007",
+        "display": "Hodgkin's sarcoma of lymph nodes of inguinal region AND/OR lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93554008",
+        "display": "Hodgkin's sarcoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93555009",
+        "display": "Hodgkin's sarcoma of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93636004",
+        "display": "Malignant melanoma of skin of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93637008",
+        "display": "Malignant melanoma of skin of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93638003",
+        "display": "Malignant melanoma of skin of knee"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93640008",
+        "display": "Malignant melanoma of skin of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93641007",
+        "display": "Malignant melanoma of skin of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93642000",
+        "display": "Malignant melanoma of skin of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93643005",
+        "display": "Malignant melanoma of skin of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93644004",
+        "display": "Malignant melanoma of skin of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93645003",
+        "display": "Malignant melanoma of skin of popliteal area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93646002",
+        "display": "Malignant melanoma of skin of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93647006",
+        "display": "Malignant melanoma of skin of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93648001",
+        "display": "Malignant melanoma of skin of temporal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93649009",
+        "display": "Malignant melanoma of skin of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93650009",
+        "display": "Malignant melanoma of skin of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93651008",
+        "display": "Malignant melanoma of skin of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93652001",
+        "display": "Malignant melanoma of skin of umbilicus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93653006",
+        "display": "Malignant melanoma of skin of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93654000",
+        "display": "Malignant melanoma of skin of wrist"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93655004",
+        "display": "Malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93657007",
+        "display": "Primary malignant neoplasm of abducens nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93658002",
+        "display": "Primary malignant neoplasm of accessory nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93659005",
+        "display": "Primary malignant neoplasm of accessory sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93660000",
+        "display": "Primary malignant neoplasm of acoustic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93661001",
+        "display": "Primary malignant neoplasm of acromion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93662008",
+        "display": "Primary malignant neoplasm of adenoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93663003",
+        "display": "Primary malignant neoplasm of adnexa of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93665005",
+        "display": "Primary malignant neoplasm of adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93667002",
+        "display": "Primary malignant neoplasm of alveolar ridge mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93669004",
+        "display": "Primary malignant neoplasm of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93670003",
+        "display": "Primary malignant neoplasm of anterior aspect of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93671004",
+        "display": "Primary malignant neoplasm of anterior mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93672006",
+        "display": "Primary malignant neoplasm of anterior portion of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93674007",
+        "display": "Primary malignant neoplasm of anterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93675008",
+        "display": "Primary malignant neoplasm of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93676009",
+        "display": "Primary malignant neoplasm of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93677000",
+        "display": "Primary malignant neoplasm of aortic body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93679002",
+        "display": "Primary malignant neoplasm of appendix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93680004",
+        "display": "Primary malignant neoplasm of areola of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93681000",
+        "display": "Primary malignant neoplasm of areola of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93682007",
+        "display": "Primary malignant neoplasm of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93683002",
+        "display": "Primary malignant neoplasm of ascending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93684008",
+        "display": "Primary malignant neoplasm of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93686005",
+        "display": "Primary malignant neoplasm of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93687001",
+        "display": "Primary malignant neoplasm of base of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93689003",
+        "display": "Primary malignant neoplasm of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93690007",
+        "display": "Primary malignant neoplasm of blood vessel of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93692004",
+        "display": "Primary malignant neoplasm of blood vessel of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93693009",
+        "display": "Primary malignant neoplasm of blood vessel of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93694003",
+        "display": "Primary malignant neoplasm of blood vessel of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93695002",
+        "display": "Primary malignant neoplasm of blood vessel of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93696001",
+        "display": "Primary malignant neoplasm of blood vessel of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93697005",
+        "display": "Primary malignant neoplasm of blood vessel of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93698000",
+        "display": "Primary malignant neoplasm of blood vessel of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93699008",
+        "display": "Primary malignant neoplasm of blood vessel of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93700009",
+        "display": "Primary malignant neoplasm of blood vessel of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93701008",
+        "display": "Primary malignant neoplasm of blood vessel of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93703006",
+        "display": "Primary malignant neoplasm of blood vessel of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93704000",
+        "display": "Primary malignant neoplasm of blood vessel of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93705004",
+        "display": "Primary malignant neoplasm of blood vessel of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93706003",
+        "display": "Primary malignant neoplasm of blood vessel of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93707007",
+        "display": "Primary malignant neoplasm of blood vessel of popliteal space"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93708002",
+        "display": "Primary malignant neoplasm of blood vessel of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93709005",
+        "display": "Primary malignant neoplasm of blood vessel of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93710000",
+        "display": "Primary malignant neoplasm of blood vessel of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93711001",
+        "display": "Primary malignant neoplasm of blood vessel of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93712008",
+        "display": "Primary malignant neoplasm of blood vessel of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93713003",
+        "display": "Primary malignant neoplasm of blood vessel of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93714009",
+        "display": "Primary malignant neoplasm of blood vessel"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93715005",
+        "display": "Primary malignant neoplasm of body of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93716006",
+        "display": "Primary malignant neoplasm of body of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93717002",
+        "display": "Primary malignant neoplasm of body of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93720005",
+        "display": "Primary malignant neoplasm of bone marrow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93721009",
+        "display": "Primary malignant neoplasm of bone of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93722002",
+        "display": "Primary malignant neoplasm of bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93723007",
+        "display": "Primary malignant neoplasm of bone of skull"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93724001",
+        "display": "Primary malignant neoplasm of bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93725000",
+        "display": "Primary malignant neoplasm of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93726004",
+        "display": "Primary malignant neoplasm of brain stem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93727008",
+        "display": "Primary malignant neoplasm of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93728003",
+        "display": "Primary malignant neoplasm of broad ligament"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93729006",
+        "display": "Primary malignant neoplasm of bronchus of left lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93730001",
+        "display": "Primary malignant neoplasm of bronchus of left upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93731002",
+        "display": "Primary malignant neoplasm of bronchus of right lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93732009",
+        "display": "Primary malignant neoplasm of bronchus of right middle lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93733004",
+        "display": "Primary malignant neoplasm of bronchus of right upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93734005",
+        "display": "Primary malignant neoplasm of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93737003",
+        "display": "Primary malignant neoplasm of calcaneus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93738008",
+        "display": "Primary malignant neoplasm of cardia of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93739000",
+        "display": "Primary malignant neoplasm of carina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93740003",
+        "display": "Primary malignant neoplasm of carotid body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93741004",
+        "display": "Primary malignant neoplasm of carpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93742006",
+        "display": "Primary malignant neoplasm of cartilage of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93743001",
+        "display": "Primary malignant neoplasm of cauda equina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93744007",
+        "display": "Primary malignant neoplasm of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93745008",
+        "display": "Primary malignant neoplasm of central portion of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93746009",
+        "display": "Primary malignant neoplasm of cerebellum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93747000",
+        "display": "Primary malignant neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93748005",
+        "display": "Primary malignant neoplasm of cerebral ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93749002",
+        "display": "Primary malignant neoplasm of cerebrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93751003",
+        "display": "Primary malignant neoplasm of cervical vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93753000",
+        "display": "Primary malignant neoplasm of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93754006",
+        "display": "Primary malignant neoplasm of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93755007",
+        "display": "Primary malignant neoplasm of choroid, primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93756008",
+        "display": "Primary malignant neoplasm of ciliary body (primary)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93757004",
+        "display": "Primary malignant neoplasm of clavicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93759001",
+        "display": "Primary malignant neoplasm of coccygeal body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93760006",
+        "display": "Primary malignant neoplasm of coccyx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93761005",
+        "display": "Primary malignant neoplasm of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93763008",
+        "display": "Primary malignant neoplasm of common bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93764002",
+        "display": "Primary malignant neoplasm of conjunctiva of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93766000",
+        "display": "Primary malignant neoplasm of cornea of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93767009",
+        "display": "Primary malignant neoplasm of cranial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93768004",
+        "display": "Primary malignant neoplasm of craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93769007",
+        "display": "Primary malignant neoplasm of cuboid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93770008",
+        "display": "Primary malignant neoplasm of cystic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93771007",
+        "display": "Primary malignant neoplasm of descending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93772000",
+        "display": "Primary malignant neoplasm of diaphragm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93773005",
+        "display": "Primary malignant neoplasm of dorsal surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93775003",
+        "display": "Primary malignant neoplasm of duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93776002",
+        "display": "Primary malignant neoplasm of ectopic female breast tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93777006",
+        "display": "Primary malignant neoplasm of ectopic male breast tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93778001",
+        "display": "Primary malignant neoplasm of endocardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93779009",
+        "display": "Primary malignant neoplasm of endocervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93781006",
+        "display": "Primary malignant neoplasm of endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93782004",
+        "display": "Primary malignant neoplasm of epicardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93783009",
+        "display": "Primary malignant neoplasm of epididymis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93784003",
+        "display": "Primary malignant neoplasm of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93786001",
+        "display": "Primary malignant neoplasm of ethmoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93787005",
+        "display": "Primary malignant neoplasm of ethmoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93788000",
+        "display": "Primary malignant neoplasm of eustachian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93789008",
+        "display": "Primary malignant neoplasm of exocervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93792007",
+        "display": "Primary malignant neoplasm of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93793002",
+        "display": "Primary malignant neoplasm of facial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93796005",
+        "display": "Primary malignant neoplasm of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93797001",
+        "display": "Primary malignant neoplasm of female genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93798006",
+        "display": "Primary malignant neoplasm of femur"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93799003",
+        "display": "Primary malignant neoplasm of fibula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93800004",
+        "display": "Primary malignant neoplasm of first cuneiform bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93801000",
+        "display": "Primary malignant neoplasm of flank"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93802007",
+        "display": "Primary malignant neoplasm of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93803002",
+        "display": "Primary malignant neoplasm of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93804008",
+        "display": "Primary malignant neoplasm of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93806005",
+        "display": "Primary malignant neoplasm of frontal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93807001",
+        "display": "Primary malignant neoplasm of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93808006",
+        "display": "Primary malignant neoplasm of frontal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93809003",
+        "display": "Primary malignant neoplasm of fundus of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93812000",
+        "display": "Primary malignant neoplasm of gingival mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93814004",
+        "display": "Primary malignant neoplasm of glomus jugulare"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93815003",
+        "display": "Primary malignant neoplasm of glossopharyngeal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93816002",
+        "display": "Primary malignant neoplasm of glottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93817006",
+        "display": "Primary malignant neoplasm of great vessels"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93818001",
+        "display": "Primary malignant neoplasm of greater curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93820003",
+        "display": "Primary malignant neoplasm of hamate bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93821004",
+        "display": "Primary malignant neoplasm of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93824007",
+        "display": "Primary malignant neoplasm of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93825008",
+        "display": "Primary malignant neoplasm of heart"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93826009",
+        "display": "Primary malignant neoplasm of hepatic flexure of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93827000",
+        "display": "Primary malignant neoplasm of hilus of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93828005",
+        "display": "Primary malignant neoplasm of hypoglossal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93829002",
+        "display": "Primary malignant neoplasm of hypopharyngeal aspect of aryepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93830007",
+        "display": "Primary malignant neoplasm of hypopharyngeal aspect of interarytenoid fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93831006",
+        "display": "Primary malignant neoplasm of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93832004",
+        "display": "Primary malignant neoplasm of ileum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93833009",
+        "display": "Primary malignant neoplasm of ilium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93834003",
+        "display": "Primary malignant neoplasm of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93835002",
+        "display": "Primary malignant neoplasm of inner aspect of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93836001",
+        "display": "Primary malignant neoplasm of inner aspect of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93837005",
+        "display": "Primary malignant neoplasm of inner aspect of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93839008",
+        "display": "Primary malignant neoplasm of intra-abdominal organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93841009",
+        "display": "Primary malignant neoplasm of intrathoracic organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93842002",
+        "display": "Primary malignant neoplasm of ischium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93843007",
+        "display": "Primary malignant neoplasm of islets of Langerhans"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93844001",
+        "display": "Primary malignant neoplasm of isthmus of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93845000",
+        "display": "Primary malignant neoplasm of jaw"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93846004",
+        "display": "Primary malignant neoplasm of jejunum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93848003",
+        "display": "Primary malignant neoplasm of junctional zone of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93849006",
+        "display": "Primary malignant neoplasm of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93850006",
+        "display": "Primary malignant neoplasm of labia majora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93851005",
+        "display": "Primary malignant neoplasm of labia minora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93854002",
+        "display": "Primary malignant neoplasm of large intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93857009",
+        "display": "Primary malignant neoplasm of laryngeal commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93858004",
+        "display": "Primary malignant neoplasm of laryngeal surface of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93860002",
+        "display": "Primary malignant neoplasm of lateral portion of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93861003",
+        "display": "Primary malignant neoplasm of lateral wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93862005",
+        "display": "Primary malignant neoplasm of lateral wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93863000",
+        "display": "Primary malignant neoplasm of lateral wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93864006",
+        "display": "Primary malignant neoplasm of left lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93865007",
+        "display": "Primary malignant neoplasm of left upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93867004",
+        "display": "Primary malignant neoplasm of lesser curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93868009",
+        "display": "Primary malignant neoplasm of lingual tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93870000",
+        "display": "Malignant neoplasm of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93871001",
+        "display": "Primary malignant neoplasm of long bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93872008",
+        "display": "Primary malignant neoplasm of long bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93874009",
+        "display": "Primary malignant neoplasm of lower inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93875005",
+        "display": "Primary malignant neoplasm of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93876006",
+        "display": "Primary malignant neoplasm of lower outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93878007",
+        "display": "Primary malignant neoplasm of lumbar vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93879004",
+        "display": "Primary malignant neoplasm of lunate bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93880001",
+        "display": "Primary malignant neoplasm of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93882009",
+        "display": "Primary malignant neoplasm of main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93883004",
+        "display": "Primary malignant neoplasm of major salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93884005",
+        "display": "Primary malignant neoplasm of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93885006",
+        "display": "Primary malignant neoplasm of male genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93886007",
+        "display": "Primary malignant neoplasm of mandible"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93887003",
+        "display": "Primary malignant neoplasm of mastoid air cells"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93888008",
+        "display": "Primary malignant neoplasm of maxilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93889000",
+        "display": "Primary malignant neoplasm of maxillary sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93890009",
+        "display": "Primary malignant neoplasm of Meckel's diverticulum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93891008",
+        "display": "Primary malignant neoplasm of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93892001",
+        "display": "Primary malignant neoplasm of metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93893006",
+        "display": "Primary malignant neoplasm of metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93894000",
+        "display": "Primary malignant neoplasm of middle ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93898002",
+        "display": "Primary malignant neoplasm of multiple endocrine glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93899005",
+        "display": "Primary malignant neoplasm of muscle of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93900000",
+        "display": "Primary malignant neoplasm of muscle of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93901001",
+        "display": "Primary malignant neoplasm of muscle of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93902008",
+        "display": "Primary malignant neoplasm of muscle of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93903003",
+        "display": "Primary malignant neoplasm of muscle of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93904009",
+        "display": "Primary malignant neoplasm of muscle of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93905005",
+        "display": "Primary malignant neoplasm of muscle of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93906006",
+        "display": "Primary malignant neoplasm of muscle of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93907002",
+        "display": "Primary malignant neoplasm of muscle of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93908007",
+        "display": "Primary malignant neoplasm of muscle of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93909004",
+        "display": "Primary malignant neoplasm of muscle of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93910009",
+        "display": "Primary malignant neoplasm of muscle of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93911008",
+        "display": "Primary malignant neoplasm of muscle of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93912001",
+        "display": "Primary malignant neoplasm of muscle of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93913006",
+        "display": "Primary malignant neoplasm of muscle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93914000",
+        "display": "Primary malignant neoplasm of myocardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93915004",
+        "display": "Primary malignant neoplasm of myometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93916003",
+        "display": "Primary malignant neoplasm of nasal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93917007",
+        "display": "Primary malignant neoplasm of nasal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93918002",
+        "display": "Primary malignant neoplasm of nasal concha"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93920004",
+        "display": "Primary malignant neoplasm of navicular bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93922007",
+        "display": "Primary malignant neoplasm of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93923002",
+        "display": "Primary malignant neoplasm of nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93924008",
+        "display": "Primary malignant neoplasm of nipple of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93925009",
+        "display": "Primary malignant neoplasm of nipple of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93926005",
+        "display": "Primary malignant neoplasm of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93927001",
+        "display": "Primary malignant neoplasm of occipital bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93928006",
+        "display": "Primary malignant neoplasm of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93929003",
+        "display": "Primary malignant neoplasm of oculomotor nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93930008",
+        "display": "Primary malignant neoplasm of olfactory nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93931007",
+        "display": "Primary malignant neoplasm of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93932000",
+        "display": "Primary malignant neoplasm of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93933005",
+        "display": "Primary malignant neoplasm of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93934004",
+        "display": "Primary malignant neoplasm of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93936002",
+        "display": "Primary malignant neoplasm of palatine bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93939009",
+        "display": "Primary malignant neoplasm of pancreatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93940006",
+        "display": "Primary malignant neoplasm of para-aortic body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93941005",
+        "display": "Primary malignant neoplasm of paraganglion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93942003",
+        "display": "Primary malignant neoplasm of parametrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93943008",
+        "display": "Primary malignant neoplasm of parathyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93944002",
+        "display": "Primary malignant neoplasm of paraurethral glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93945001",
+        "display": "Primary malignant neoplasm of parietal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93946000",
+        "display": "Primary malignant neoplasm of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93947009",
+        "display": "Primary malignant neoplasm of parietal peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93948004",
+        "display": "Primary malignant neoplasm of parietal pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93950007",
+        "display": "Primary malignant neoplasm of patella"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93951006",
+        "display": "Primary malignant neoplasm of pelvic bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93952004",
+        "display": "Primary malignant neoplasm of pelvic peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93953009",
+        "display": "Primary malignant neoplasm of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93955002",
+        "display": "Primary malignant neoplasm of periadrenal tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93956001",
+        "display": "Primary malignant neoplasm of perianal skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93957005",
+        "display": "Primary malignant neoplasm of pericardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93958000",
+        "display": "Primary malignant neoplasm of perirenal tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93959008",
+        "display": "Primary malignant neoplasm of phalanx of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93960003",
+        "display": "Primary malignant neoplasm of phalanx of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93961004",
+        "display": "Primary malignant neoplasm of pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93962006",
+        "display": "Primary malignant neoplasm of pineal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93963001",
+        "display": "Primary malignant neoplasm of pisiform bone of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93964007",
+        "display": "Primary malignant neoplasm of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93966009",
+        "display": "Primary malignant neoplasm of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93967000",
+        "display": "Primary malignant neoplasm of postcricoid region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93968005",
+        "display": "Primary malignant neoplasm of posterior hypopharyngeal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93969002",
+        "display": "Primary malignant neoplasm of posterior mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93970001",
+        "display": "Primary malignant neoplasm of posterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93971002",
+        "display": "Primary malignant neoplasm of posterior wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93972009",
+        "display": "Primary malignant neoplasm of posterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93973004",
+        "display": "Primary malignant neoplasm of presacral region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93974005",
+        "display": "Primary malignant neoplasm of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93975006",
+        "display": "Primary malignant neoplasm of pubis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93976007",
+        "display": "Primary malignant neoplasm of pyloric antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93977003",
+        "display": "Primary malignant neoplasm of pylorus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93978008",
+        "display": "Primary malignant neoplasm of pyriform sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93979000",
+        "display": "Primary malignant neoplasm of radius"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93980002",
+        "display": "Primary malignant neoplasm of rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93981003",
+        "display": "Primary malignant neoplasm of rectouterine pouch"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93982005",
+        "display": "Primary malignant neoplasm of rectovaginal septum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93983000",
+        "display": "Primary malignant neoplasm of rectovesical septum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93984006",
+        "display": "Primary malignant neoplasm of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93985007",
+        "display": "Primary malignant neoplasm of renal pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93986008",
+        "display": "Primary malignant neoplasm of respiratory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93987004",
+        "display": "Primary malignant neoplasm of retina of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93989001",
+        "display": "Primary malignant neoplasm of retromolar area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93990005",
+        "display": "Primary malignant neoplasm of rib"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93991009",
+        "display": "Primary malignant neoplasm of right lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93992002",
+        "display": "Primary malignant neoplasm of right middle lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93993007",
+        "display": "Primary malignant neoplasm of right upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93994001",
+        "display": "Primary malignant neoplasm of round ligament of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93995000",
+        "display": "Primary malignant neoplasm of sacrococcygeal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93996004",
+        "display": "Primary malignant neoplasm of sacrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93997008",
+        "display": "Primary malignant neoplasm of scapula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93998003",
+        "display": "Primary malignant neoplasm of sclera of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94000008",
+        "display": "Primary malignant neoplasm of sebaceous gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94001007",
+        "display": "Primary malignant neoplasm of second cuneiform bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94002000",
+        "display": "Primary malignant neoplasm of septum of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94003005",
+        "display": "Primary malignant neoplasm of short bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94004004",
+        "display": "Primary malignant neoplasm of short bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94005003",
+        "display": "Primary malignant neoplasm of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94006002",
+        "display": "Primary malignant neoplasm of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94007006",
+        "display": "Primary malignant neoplasm of skin of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94008001",
+        "display": "Primary malignant neoplasm of skin of ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94010004",
+        "display": "Primary malignant neoplasm of skin of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94011000",
+        "display": "Primary malignant neoplasm of skin of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94012007",
+        "display": "Primary malignant neoplasm of skin of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94013002",
+        "display": "Primary malignant neoplasm of skin of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94014008",
+        "display": "Primary malignant neoplasm of skin of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94015009",
+        "display": "Primary malignant neoplasm of skin of chest"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94016005",
+        "display": "Primary malignant neoplasm of skin of chin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94017001",
+        "display": "Primary malignant neoplasm of skin of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94018006",
+        "display": "Primary malignant neoplasm of skin of elbow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94019003",
+        "display": "Primary malignant neoplasm of skin of external auditory canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94020009",
+        "display": "Primary malignant neoplasm of skin of eyebrow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94021008",
+        "display": "Primary malignant neoplasm of skin of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94022001",
+        "display": "Primary malignant neoplasm of skin of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94023006",
+        "display": "Primary malignant neoplasm of skin of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94024000",
+        "display": "Primary malignant neoplasm of skin of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94025004",
+        "display": "Primary malignant neoplasm of skin of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94026003",
+        "display": "Primary malignant neoplasm of skin of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94027007",
+        "display": "Primary malignant neoplasm of skin of groin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94028002",
+        "display": "Primary malignant neoplasm of skin of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94029005",
+        "display": "Primary malignant neoplasm of skin of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94030000",
+        "display": "Primary malignant neoplasm of skin of knee"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94032008",
+        "display": "Primary malignant neoplasm of skin of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94033003",
+        "display": "Primary malignant neoplasm of skin of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94034009",
+        "display": "Primary malignant neoplasm of skin of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94035005",
+        "display": "Primary malignant neoplasm of skin of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94036006",
+        "display": "Primary malignant neoplasm of skin of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94037002",
+        "display": "Primary malignant neoplasm of skin of popliteal area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94038007",
+        "display": "Primary malignant neoplasm of skin of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94039004",
+        "display": "Primary malignant neoplasm of skin of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94040002",
+        "display": "Primary malignant neoplasm of skin of temporal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94041003",
+        "display": "Primary malignant neoplasm of skin of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94042005",
+        "display": "Primary malignant neoplasm of skin of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94043000",
+        "display": "Primary malignant neoplasm of skin of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94044006",
+        "display": "Primary malignant neoplasm of skin of umbilicus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94045007",
+        "display": "Primary malignant neoplasm of skin of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94046008",
+        "display": "Primary malignant neoplasm of skin of wrist"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94047004",
+        "display": "Primary malignant neoplasm of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94048009",
+        "display": "Primary malignant neoplasm of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94049001",
+        "display": "Primary malignant neoplasm of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94050001",
+        "display": "Primary malignant neoplasm of soft tissues of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94051002",
+        "display": "Primary malignant neoplasm of soft tissues of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94052009",
+        "display": "Primary malignant neoplasm of soft tissues of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94053004",
+        "display": "Primary malignant neoplasm of soft tissues of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94054005",
+        "display": "Primary malignant neoplasm of soft tissues of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94055006",
+        "display": "Primary malignant neoplasm of soft tissues of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94056007",
+        "display": "Primary malignant neoplasm of soft tissues of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94057003",
+        "display": "Primary malignant neoplasm of soft tissues of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94058008",
+        "display": "Primary malignant neoplasm of soft tissues of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94059000",
+        "display": "Primary malignant neoplasm of soft tissues of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94060005",
+        "display": "Primary malignant neoplasm of soft tissues of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94061009",
+        "display": "Primary malignant neoplasm of soft tissues of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94062002",
+        "display": "Primary malignant neoplasm of soft tissues of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94063007",
+        "display": "Primary malignant neoplasm of soft tissues of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94066004",
+        "display": "Primary malignant neoplasm of sphenoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94067008",
+        "display": "Primary malignant neoplasm of sphenoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94068003",
+        "display": "Primary malignant neoplasm of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94069006",
+        "display": "Primary malignant neoplasm of spinal meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94071006",
+        "display": "Primary malignant neoplasm of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94072004",
+        "display": "Primary malignant neoplasm of splenic flexure of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94073009",
+        "display": "Primary malignant neoplasm of sternum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94075002",
+        "display": "Primary malignant neoplasm of subglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94076001",
+        "display": "Primary malignant neoplasm of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94077005",
+        "display": "Primary malignant neoplasm of submaxillary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94078000",
+        "display": "Primary malignant neoplasm of superior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94079008",
+        "display": "Primary malignant neoplasm of supraclavicular region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94080006",
+        "display": "Primary malignant neoplasm of supraglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94081005",
+        "display": "Primary malignant neoplasm of sweat gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94082003",
+        "display": "Primary malignant neoplasm of tail of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94083008",
+        "display": "Primary malignant neoplasm of talus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94084002",
+        "display": "Primary malignant neoplasm of tarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94085001",
+        "display": "Primary malignant neoplasm of temporal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94086000",
+        "display": "Primary malignant neoplasm of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94087009",
+        "display": "Primary malignant neoplasm of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94089007",
+        "display": "Primary malignant neoplasm of the mesocolon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94090003",
+        "display": "Primary malignant neoplasm of omentum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94092006",
+        "display": "Primary malignant neoplasm of retroperitoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94093001",
+        "display": "Primary malignant neoplasm of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94094007",
+        "display": "Primary malignant neoplasm of third cuneiform bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94096009",
+        "display": "Primary malignant neoplasm of thymus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94097000",
+        "display": "Primary malignant neoplasm of thyroglossal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94098005",
+        "display": "Primary malignant neoplasm of thyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94099002",
+        "display": "Primary malignant neoplasm of tibia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94101009",
+        "display": "Primary malignant neoplasm of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94102002",
+        "display": "Primary malignant neoplasm of tonsillar fossa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94103007",
+        "display": "Primary malignant neoplasm of tonsillar pillar"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94104001",
+        "display": "Primary malignant neoplasm of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94105000",
+        "display": "Primary malignant neoplasm of transverse colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94107008",
+        "display": "Primary malignant neoplasm of trapezoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94108003",
+        "display": "Primary malignant neoplasm of trigeminal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94109006",
+        "display": "Primary malignant neoplasm of trigone of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94110001",
+        "display": "Primary malignant neoplasm of trochlear nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94111002",
+        "display": "Primary malignant neoplasm of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94112009",
+        "display": "Primary malignant neoplasm of ulna"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94113004",
+        "display": "Primary malignant neoplasm of undescended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94115006",
+        "display": "Primary malignant neoplasm of upper inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94116007",
+        "display": "Primary malignant neoplasm of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94117003",
+        "display": "Primary malignant neoplasm of upper outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94118008",
+        "display": "Primary malignant neoplasm of upper respiratory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94120006",
+        "display": "Primary malignant neoplasm of urachus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94121005",
+        "display": "Primary malignant neoplasm of ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94122003",
+        "display": "Primary malignant neoplasm of ureteric orifice of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94123008",
+        "display": "Primary malignant neoplasm of urethra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94124002",
+        "display": "Primary malignant neoplasm of urinary bladder neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94125001",
+        "display": "Primary malignant neoplasm of urinary system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94126000",
+        "display": "Primary malignant neoplasm of uterine adnexa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94128004",
+        "display": "Primary malignant neoplasm of uveal tract of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94129007",
+        "display": "Primary malignant neoplasm of uvula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94131003",
+        "display": "Primary malignant neoplasm of vagus nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94132005",
+        "display": "Primary malignant neoplasm of vallecula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94133000",
+        "display": "Primary malignant neoplasm of vas deferens"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94134006",
+        "display": "Primary malignant neoplasm of ventral surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94135007",
+        "display": "Primary malignant neoplasm of vermilion border of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94138009",
+        "display": "Primary malignant neoplasm of vestibule of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94139001",
+        "display": "Primary malignant neoplasm of vestibule of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94140004",
+        "display": "Primary malignant neoplasm of visceral pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94142007",
+        "display": "Primary malignant neoplasm of vomer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94143002",
+        "display": "Primary malignant neoplasm of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94144008",
+        "display": "Primary malignant neoplasm of Waldeyer's ring"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94145009",
+        "display": "Primary malignant neoplasm of zygomatic bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94148006",
+        "display": "Megakaryocytic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94686001",
+        "display": "Mixed cell type lymphosarcoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94687005",
+        "display": "Mixed cell type lymphosarcoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94688000",
+        "display": "Mixed cell type lymphosarcoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94690004",
+        "display": "Mixed cell type lymphosarcoma of lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94704006",
+        "display": "Multiple myeloma in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94707004",
+        "display": "Mycosis fungoides of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94708009",
+        "display": "Mycosis fungoides of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94709001",
+        "display": "Mycosis fungoides of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94710006",
+        "display": "Mycosis fungoides of lymph nodes of axilla AND/OR upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94711005",
+        "display": "Mycosis fungoides of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94714002",
+        "display": "Mycosis fungoides of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94715001",
+        "display": "Mycosis fungoides of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94716000",
+        "display": "Myeloid leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94718004",
+        "display": "Myeloid sarcoma in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94719007",
+        "display": "Myeloid sarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95186006",
+        "display": "Nodular lymphoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95187002",
+        "display": "Nodular lymphoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95188007",
+        "display": "Nodular lymphoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95192000",
+        "display": "Nodular lymphoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95193005",
+        "display": "Nodular lymphoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95194004",
+        "display": "Nodular lymphoma of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95209008",
+        "display": "Plasma cell leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95210003",
+        "display": "Plasma cell leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95214007",
+        "display": "Primary malignant neoplasm of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95224004",
+        "display": "Reticulosarcoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95225003",
+        "display": "Reticulosarcoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95226002",
+        "display": "Reticulosarcoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95230004",
+        "display": "Reticulosarcoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95231000",
+        "display": "Reticulosarcoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95260009",
+        "display": "SÃ©zary's disease of lymph nodes of head, face AND/OR neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95263006",
+        "display": "SÃ©zary's disease of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95264000",
+        "display": "SÃ©zary's disease of extranodal AND/OR solid organ site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109264009",
+        "display": "Overlapping malignant neoplasm of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109267002",
+        "display": "Overlapping malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109347009",
+        "display": "Overlapping malignant neoplasm of bone and articular cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109348004",
+        "display": "Overlapping malignant neoplasm of bone and articular cartilage of limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109349007",
+        "display": "Overlapping malignant neoplasm of connective and other soft tissues"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109356001",
+        "display": "Primary malignant neoplasm of unspecified site (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109359008",
+        "display": "Primary malignant neoplasm of independent multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109366009",
+        "display": "Overlapping malignant neoplasm of accessory sinuses"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109367000",
+        "display": "Overlapping malignant neoplasm of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109368005",
+        "display": "Overlapping malignant neoplasm of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109369002",
+        "display": "Overlapping malignant neoplasm of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109370001",
+        "display": "Primary malignant neoplasm of laryngeal cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109371002",
+        "display": "Overlapping malignant neoplasm of bronchus and lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109374005",
+        "display": "Overlapping malignant neoplasm of mediastinum and pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109378008",
+        "display": "Mesothelioma (malignant, clinical disorder) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109383000",
+        "display": "Malignant mesothelioma of pericardium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109384006",
+        "display": "Overlapping malignant neoplasm of heart, mediastinum and pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109385007",
+        "display": "Kaposi's sarcoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109386008",
+        "display": "Kaposi's sarcoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109388009",
+        "display": "Kaposi's sarcoma of palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109389001",
+        "display": "Kaposi's sarcoma of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109390005",
+        "display": "Kaposi's sarcoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109391009",
+        "display": "Kaposi's sarcoma of lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109392002",
+        "display": "Kaposi's sarcoma of multiple organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109821008",
+        "display": "Overlapping malignant neoplasm of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109822001",
+        "display": "Overlapping malignant neoplasm of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109823006",
+        "display": "Overlapping malignant neoplasm of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109824000",
+        "display": "Overlapping malignant neoplasm of major salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109828002",
+        "display": "Primary malignant neoplasm of salivary gland duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109830000",
+        "display": "Overlapping malignant neoplasm of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109831001",
+        "display": "Overlapping malignant neoplasm of palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109832008",
+        "display": "Overlapping malignant neoplasm of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109833003",
+        "display": "Overlapping malignant neoplasm of lip, oral cavity and pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109834009",
+        "display": "Primary malignant neoplasm of branchial cleft"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109835005",
+        "display": "Overlapping malignant neoplasm of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109836006",
+        "display": "Overlapping malignant neoplasm of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109837002",
+        "display": "Overlapping malignant neoplasm of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109838007",
+        "display": "Overlapping malignant neoplasm of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109839004",
+        "display": "Overlapping malignant neoplasm of rectum, anus and anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109840002",
+        "display": "Primary malignant neoplasm of cloacogenic zone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109841003",
+        "display": "Hepatocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109842005",
+        "display": "Intrahepatic bile duct carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109843000",
+        "display": "Hepatoblastoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109844006",
+        "display": "Angiosarcoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109847004",
+        "display": "Overlapping malignant neoplasm of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109848009",
+        "display": "Overlapping malignant neoplasm of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109851002",
+        "display": "Overlapping malignant neoplasm of retroperitoneum and peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109853004",
+        "display": "Mesothelioma of peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109854005",
+        "display": "Mesothelioma of parietal peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109855006",
+        "display": "Mesothelioma of pelvic peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109856007",
+        "display": "Mesothelioma of mesentery"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109858008",
+        "display": "Mesothelioma of omentum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109870007",
+        "display": "Overlapping malignant neoplasm of urinary system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109874003",
+        "display": "Overlapping malignant neoplasm of male genital organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109875002",
+        "display": "Overlapping malignant neoplasm of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109876001",
+        "display": "Primary malignant neoplasm of descended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109878000",
+        "display": "Overlapping malignant neoplasm of female genital organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109879008",
+        "display": "Overlapping malignant neoplasm of body of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109880006",
+        "display": "Overlapping malignant neoplasm of uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109882003",
+        "display": "Primary malignant neoplasm of fundus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109885001",
+        "display": "Overlapping malignant neoplasm of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109886000",
+        "display": "Overlapping malignant neoplasm of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109887009",
+        "display": "Overlapping malignant neoplasm of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109911004",
+        "display": "Overlapping malignant neoplasm of brain and other parts of the central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109912006",
+        "display": "Overlapping malignant neoplasm of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109915008",
+        "display": "Primary malignant neoplasm of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109918005",
+        "display": "Primary malignant neoplasm of peripheral nerves and peripheral autonomic nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109919002",
+        "display": "Overlapping malignant neoplasm of peripheral nerves and autonomic nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109921007",
+        "display": "Primary malignant neoplasm of peripheral nerve of head, face and/or neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109923005",
+        "display": "Primary malignant neoplasm of peripheral nerves of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109925003",
+        "display": "Primary malignant neoplasm of peripheral nerves of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109927006",
+        "display": "Primary malignant neoplasm of peripheral nerves of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109931000",
+        "display": "Primary malignant neoplasm of peripheral nerves of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109933002",
+        "display": "Primary malignant neoplasm of peripheral nerves of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109937001",
+        "display": "Primary malignant neoplasm of peripheral nerves of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109939003",
+        "display": "Primary malignant neoplasm of peripheral nerves of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109941002",
+        "display": "Primary malignant neoplasm of peripheral nerves of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109943004",
+        "display": "Primary malignant neoplasm of peripheral nerves of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109945006",
+        "display": "Primary malignant neoplasm of peripheral nerves of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109947003",
+        "display": "Primary malignant neoplasm of peripheral nerves of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109948008",
+        "display": "Overlapping malignant neoplasm of eye and adnexa (primary)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109951001",
+        "display": "Overlapping malignant neoplasm of multiple endocrine glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109962001",
+        "display": "Diffuse non-Hodgkin's lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109964000",
+        "display": "Diffuse non-Hodgkin's lymphoma, undifferentiated"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109966003",
+        "display": "Diffuse non-Hodgkin's lymphoma, immunoblastic (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109967007",
+        "display": "Diffuse non-Hodgkin's lymphoma, small cleaved cell (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109968002",
+        "display": "Diffuse non-Hodgkin's lymphoma, small cell (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109969005",
+        "display": "Diffuse non-Hodgkin's lymphoma, large cell (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109970006",
+        "display": "Follicular non-Hodgkin's lymphoma, small cleaved cell (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109971005",
+        "display": "Follicular non-Hodgkin's lymphoma, mixed small cleaved cell and large cell (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109972003",
+        "display": "Follicular non-Hodgkin's lymphoma, large cell (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109975001",
+        "display": "T-zone lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109976000",
+        "display": "Lymphoepithelioid lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109977009",
+        "display": "Peripheral T-cell lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109978004",
+        "display": "T-cell lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109979007",
+        "display": "B-cell lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109980005",
+        "display": "Malignant immunoproliferative disease (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109982002",
+        "display": "Alpha heavy chain disease (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109984001",
+        "display": "Gamma heavy chain disease (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109985000",
+        "display": "Immunoproliferative small intestinal disease (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109988003",
+        "display": "True histiocytic lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109989006",
+        "display": "Multiple myeloma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109991003",
+        "display": "Acute myelofibrosis (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109992005",
+        "display": "Vaquez's disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109994006",
+        "display": "Essential thrombocythemia (clinical disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109995007",
+        "display": "Myelodysplastic syndrome (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109996008",
+        "display": "Refractory anemia (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109998009",
+        "display": "Refractory anemia with sideroblasts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110000005",
+        "display": "Refractory anemia with excess blasts in transformation (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110002002",
+        "display": "Mast cell leukemia (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110004001",
+        "display": "Acute promyelocytic leukemia, FAB M3"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110005000",
+        "display": "Acute myelomonocytic leukemia, FAB M4"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110006004",
+        "display": "Prolymphocytic leukemia (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110007008",
+        "display": "Adult T-cell leukemia/lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "110013004",
+        "display": "Overlapping malignant neoplasm of tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118599009",
+        "display": "Hodgkin's disease (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118600007",
+        "display": "Malignant lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118601006",
+        "display": "Non-Hodgkin's lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118602004",
+        "display": "Hodgkin's granuloma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118605002",
+        "display": "Hodgkin's paragranuloma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118606001",
+        "display": "Hodgkin's sarcoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118607005",
+        "display": "Hodgkin lymphoma, lymphocyte-rich (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118608000",
+        "display": "Hodgkin's disease, nodular sclerosis (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118609008",
+        "display": "Hodgkin's disease, mixed cellularity (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118610003",
+        "display": "Hodgkin's disease, lymphocytic depletion (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118611004",
+        "display": "SÃ©zary's disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118612006",
+        "display": "Malignant histiocytosis (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118613001",
+        "display": "Hairy cell leukemia (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118614007",
+        "display": "Letterer-Siwe disease (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118615008",
+        "display": "Malignant mast cell tumor (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118617000",
+        "display": "Burkitt's lymphoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "118618005",
+        "display": "Mycosis fungoides (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "123313007",
+        "display": "Alpha heavy chain disease, enteric form"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "123842006",
+        "display": "Endocervical adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "123845008",
+        "display": "Adenocarcinoma of endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "127066000",
+        "display": "Familial polycythemia vera"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "127070008",
+        "display": "Malignant histiocytic disorder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "127218004",
+        "display": "Reactive follicular hyperplasia in the elderly"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "127220001",
+        "display": "Malignant lymphoma of lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "127225006",
+        "display": "Chronic myelomonocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "128466006",
+        "display": "Primary malignant neoplasm of articular cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "128875000",
+        "display": "Primary cutaneous CD30+ large T-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "134312002",
+        "display": "Odontogenic ghost cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187601000",
+        "display": "Malignant neoplasm of upper lip, lipstick area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187604008",
+        "display": "Malignant neoplasm of lower lip, external"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187606005",
+        "display": "Malignant tumor of upper labial mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187608006",
+        "display": "Malignant tumor of frenum of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187613005",
+        "display": "Malignant neoplasm of lower lip, buccal aspect"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187614004",
+        "display": "Malignant tumor of frenum of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187622006",
+        "display": "Malignant tumor of labial mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187631006",
+        "display": "Malignant neoplasm of base of tongue dorsal surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187633009",
+        "display": "Malignant neoplasm of dorsal surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187634003",
+        "display": "Malignant neoplasm of anterior 2/3 of tongue dorsal surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187635002",
+        "display": "Malignant neoplasm of midline of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187637005",
+        "display": "Malignant neoplasm of tongue, tip and lateral border"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187640005",
+        "display": "Malignant neoplasm of anterior 2/3 of tongue ventral surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187641009",
+        "display": "Malignant tumor of frenum linguae"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187644001",
+        "display": "Malignant tumor of junctional zone of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187652003",
+        "display": "Malignant tumor of anterior floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187653008",
+        "display": "Malignant neoplasm of lateral portion of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187658004",
+        "display": "Malignant tumor of vestibule of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187659007",
+        "display": "Malignant neoplasm of upper buccal sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187660002",
+        "display": "Malignant tumor of lower buccal sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187661003",
+        "display": "Malignant neoplasm of upper labial sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187662005",
+        "display": "Malignant tumor of lower labial sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187666008",
+        "display": "Malignant neoplasm of junction of hard and soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187675005",
+        "display": "Malignant tumor of tonsillar pillar"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187681002",
+        "display": "Malignant neoplasm of anterior epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187682009",
+        "display": "Malignant neoplasm of epiglottis, free border"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187683004",
+        "display": "Malignant neoplasm of glossoepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187685006",
+        "display": "Malignant neoplasm of junctional region of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187688008",
+        "display": "Malignant tumor of posterior wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187692001",
+        "display": "Malignant tumor of epipharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187693006",
+        "display": "Malignant neoplasm of posterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187694000",
+        "display": "Malignant tumor of adenoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187697007",
+        "display": "Malignant tumor of pharyngeal recess"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187698002",
+        "display": "Malignant tumor of opening of auditory tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187700006",
+        "display": "Malignant tumor of anterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187701005",
+        "display": "Malignant neoplasm of floor of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187708004",
+        "display": "Malignant tumor aryepiglottic fold - hypopharyngeal aspect"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187709007",
+        "display": "Malignant neoplasm of posterior pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187716008",
+        "display": "Malignant tumor of Waldeyer's ring"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187722004",
+        "display": "Malignant tumor of cervical part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187723009",
+        "display": "Malignant neoplasm of thoracic esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187724003",
+        "display": "Malignant tumor of abdominal part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187725002",
+        "display": "Malignant neoplasm of upper third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187726001",
+        "display": "Malignant tumor of middle third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187727005",
+        "display": "Malignant neoplasm of lower third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187732006",
+        "display": "Malignant neoplasm of cardia of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187733001",
+        "display": "Malignant neoplasm of cardiac orifice of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187734007",
+        "display": "Malignant neoplasm of cardio-esophageal junction of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187736009",
+        "display": "Malignant tumor of pylorus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187738005",
+        "display": "Malignant neoplasm of pyloric canal of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187740000",
+        "display": "Malignant tumor of pyloric antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187741001",
+        "display": "Malignant neoplasm of fundus of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187742008",
+        "display": "Malignant tumor of body of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187752007",
+        "display": "Malignant tumor of Meckel's diverticulum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187760008",
+        "display": "Malignant neoplasm of rectum, rectosigmoid junction and anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187769009",
+        "display": "Primary carcinoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187773007",
+        "display": "Malignant neoplasm of interlobular bile ducts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187776004",
+        "display": "Malignant neoplasm of intrahepatic canaliculi"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187777008",
+        "display": "Malignant neoplasm of intrahepatic gall duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187784000",
+        "display": "Malignant neoplasm of hepatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187786003",
+        "display": "Malignant neoplasm of sphincter of Oddi"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187791002",
+        "display": "Malignant tumor of body of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187792009",
+        "display": "Malignant neoplasm of tail of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187793004",
+        "display": "Malignant tumor of pancreatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187794005",
+        "display": "Malignant neoplasm of Islets of Langerhans"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187798008",
+        "display": "Malignant neoplasm of ectopic pancreatic tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187801002",
+        "display": "Malignant tumor of peritoneum and retroperitoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187803004",
+        "display": "Malignant neoplasm of perinephric tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187804005",
+        "display": "Malignant neoplasm of retrocecal tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187809000",
+        "display": "Malignant neoplasm of mesocolon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187810005",
+        "display": "Malignant neoplasm of mesocecum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187811009",
+        "display": "Malignant neoplasm of mesorectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187814001",
+        "display": "Malignant neoplasm of the pouch of Douglas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187821001",
+        "display": "Angiosarcoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187822008",
+        "display": "Fibrosarcoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187824009",
+        "display": "Malignant neoplasm, overlapping lesion of digestive system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187828007",
+        "display": "Malignant neoplasm of nasal cavities, middle ear and accessory sinuses"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187829004",
+        "display": "Malignant neoplasm of cartilage of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187830009",
+        "display": "Malignant neoplasm of nasal conchae"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187831008",
+        "display": "Malignant tumor of nasal vestibule"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187833006",
+        "display": "Malignant neoplasm of auditory tube, middle ear and mastoid air cells"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187834000",
+        "display": "Malignant tumor of Eustachian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187835004",
+        "display": "Malignant neoplasm of tympanic cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187836003",
+        "display": "Malignant tumor of tympanic antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187841006",
+        "display": "Malignant tumor of glottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187842004",
+        "display": "Malignant neoplasm of supraglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187843009",
+        "display": "Malignant neoplasm of arytenoid cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187844003",
+        "display": "Malignant neoplasm of cricoid cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187845002",
+        "display": "Malignant neoplasm of cuneiform cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187846001",
+        "display": "Malignant neoplasm of thyroid cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187853005",
+        "display": "Malignant neoplasm of cartilage of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187854004",
+        "display": "Malignant neoplasm of mucosa of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187857006",
+        "display": "Malignant neoplasm of carina of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187861000",
+        "display": "Malignant neoplasm of upper lobe bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187862007",
+        "display": "Malignant neoplasm of upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187865009",
+        "display": "Malignant neoplasm of middle lobe bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187869003",
+        "display": "Malignant neoplasm of lower lobe bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187870002",
+        "display": "Malignant neoplasm of lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187900002",
+        "display": "Malignant neoplasm of bones of skull and face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187903000",
+        "display": "Malignant neoplasm of malar bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187906008",
+        "display": "Malignant neoplasm of orbital bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187916000",
+        "display": "Malignant neoplasm of cervical vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187917009",
+        "display": "Malignant neoplasm of thoracic vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187918004",
+        "display": "Malignant neoplasm of lumbar vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187920001",
+        "display": "Malignant neoplasm of ribs, sternum and clavicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187925006",
+        "display": "Malignant neoplasm of costal cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187926007",
+        "display": "Malignant neoplasm of costovertebral joint"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187927003",
+        "display": "Malignant neoplasm of xiphoid process"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187929000",
+        "display": "Malignant neoplasm of scapula and long bones of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187932002",
+        "display": "Malignant neoplasm of humerus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187937008",
+        "display": "Malignant neoplasm of carpal bone - scaphoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187938003",
+        "display": "Malignant neoplasm of carpal bone - lunate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187939006",
+        "display": "Malignant neoplasm of carpal bone - triquetrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187940008",
+        "display": "Malignant neoplasm of carpal bone - pisiform"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187941007",
+        "display": "Malignant neoplasm of carpal bone - trapezium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187942000",
+        "display": "Malignant neoplasm of carpal bone - trapezoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187943005",
+        "display": "Malignant neoplasm of carpal bone - capitate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187944004",
+        "display": "Malignant neoplasm of carpal bone - hamate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187945003",
+        "display": "Malignant neoplasm of first metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187946002",
+        "display": "Malignant neoplasm of second metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187947006",
+        "display": "Malignant neoplasm of third metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187948001",
+        "display": "Malignant neoplasm of fourth metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187949009",
+        "display": "Malignant neoplasm of fifth metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187950009",
+        "display": "Malignant neoplasm of phalanges of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187952001",
+        "display": "Malignant neoplasm of pelvic bones, sacrum and coccyx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187956003",
+        "display": "Malignant neoplasm of sacral vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187957007",
+        "display": "Malignant neoplasm of coccygeal vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187967002",
+        "display": "Malignant neoplasm of calcaneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187968007",
+        "display": "Malignant neoplasm of medial cuneiform"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187969004",
+        "display": "Malignant neoplasm of intermediate cuneiform"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187970003",
+        "display": "Malignant neoplasm of lateral cuneiform"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187972006",
+        "display": "Malignant neoplasm of navicular"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187973001",
+        "display": "Malignant neoplasm of first metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187974007",
+        "display": "Malignant neoplasm of second metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187975008",
+        "display": "Malignant neoplasm of third metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187976009",
+        "display": "Malignant neoplasm of fourth metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187977000",
+        "display": "Malignant neoplasm of fifth metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187978005",
+        "display": "Malignant neoplasm of phalanges of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187987001",
+        "display": "Malignant neoplasm of cartilage of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187988006",
+        "display": "Malignant neoplasm of tarsus of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187989003",
+        "display": "Malignant neoplasm soft tissues of cervical spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187991006",
+        "display": "Malignant neoplasm of connective and soft tissue of upper limb and shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187992004",
+        "display": "Malignant neoplasm of connective and soft tissue of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187993009",
+        "display": "Malignant neoplasm of connective and soft tissue, upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187994003",
+        "display": "Malignant neoplasm of connective and soft tissue of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187995002",
+        "display": "Malignant neoplasm of connective and soft tissue of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187996001",
+        "display": "Malignant neoplasm of connective and soft tissue of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187997005",
+        "display": "Malignant neoplasm of connective and soft tissue of thumb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "187999008",
+        "display": "Malignant neoplasm of connective and soft tissue of hip and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188000002",
+        "display": "Malignant neoplasm of connective and soft tissue of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188001003",
+        "display": "Malignant neoplasm of connective and soft tissue of thigh and upper leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188002005",
+        "display": "Malignant neoplasm of connective and soft tissue of popliteal space"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188003000",
+        "display": "Malignant neoplasm of connective and soft tissue of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188004006",
+        "display": "Malignant neoplasm of connective and soft tissue of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188005007",
+        "display": "Malignant neoplasm of connective and soft tissue of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188006008",
+        "display": "Malignant neoplasm of connective and soft tissue of great toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188009001",
+        "display": "Malignant neoplasm of connective and soft tissue of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188010006",
+        "display": "Malignant neoplasm of connective and soft tissue of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188013008",
+        "display": "Malignant neoplasm of connective and soft tissues of thoracic spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188015001",
+        "display": "Malignant neoplasm of connective and soft tissue of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188016000",
+        "display": "Malignant neoplasm of connective and soft tissue of abdominal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188017009",
+        "display": "Malignant neoplasm of connective and soft tissues of lumbar spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188019007",
+        "display": "Malignant neoplasm of connective and soft tissue of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188020001",
+        "display": "Malignant neoplasm of connective and soft tissue of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188021002",
+        "display": "Malignant neoplasm of connective and soft tissue of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188022009",
+        "display": "Malignant neoplasm of connective and soft tissue of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188029000",
+        "display": "Kaposi's sarcoma of soft tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188030005",
+        "display": "Malignant melanoma of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188033007",
+        "display": "Malignant melanoma of auricle (ear)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188034001",
+        "display": "Malignant melanoma of external auditory meatus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188038003",
+        "display": "Malignant melanoma of chin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188040008",
+        "display": "Malignant melanoma of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188044004",
+        "display": "Malignant melanoma of scalp and/or neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188045003",
+        "display": "Malignant melanoma of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188046002",
+        "display": "Malignant melanoma of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188049009",
+        "display": "Malignant melanoma of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188050009",
+        "display": "Malignant melanoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188051008",
+        "display": "Malignant melanoma of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188052001",
+        "display": "Malignant melanoma of groin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188054000",
+        "display": "Malignant melanoma of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188055004",
+        "display": "Malignant melanoma of umbilicus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188060000",
+        "display": "Malignant melanoma of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188061001",
+        "display": "Malignant melanoma of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188062008",
+        "display": "Malignant melanoma of forearm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188063003",
+        "display": "Malignant melanoma of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188064009",
+        "display": "Malignant melanoma of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188065005",
+        "display": "Malignant melanoma of thumb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188068007",
+        "display": "Malignant melanoma of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188069004",
+        "display": "Malignant melanoma of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188070003",
+        "display": "Malignant melanoma of knee"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188071004",
+        "display": "Malignant melanoma of popliteal fossa area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188072006",
+        "display": "Malignant melanoma of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188073001",
+        "display": "Malignant melanoma of ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188074007",
+        "display": "Malignant melanoma of heel"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188075008",
+        "display": "Malignant melanoma of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188076009",
+        "display": "Malignant melanoma of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188077000",
+        "display": "Malignant melanoma of great toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188089003",
+        "display": "Malignant neoplasm of skin of ear and external auricular canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188090007",
+        "display": "Malignant neoplasm of skin of auricle (ear)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188091006",
+        "display": "Malignant neoplasm of skin of external auditory meatus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188095002",
+        "display": "Malignant neoplasm of skin of cheek, external"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188099008",
+        "display": "Malignant neoplasm of skin of nose (external)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188100000",
+        "display": "Malignant neoplasm of skin of temple"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188102008",
+        "display": "Malignant neoplasm of scalp and/or skin of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188103003",
+        "display": "Malignant neoplasm of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188107002",
+        "display": "Malignant neoplasm of skin of axillary fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188110009",
+        "display": "Malignant neoplasm of skin of abdominal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188121000",
+        "display": "Malignant neoplasm of skin of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188122007",
+        "display": "Malignant neoplasm of skin of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188125009",
+        "display": "Malignant neoplasm of skin of thumb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188132000",
+        "display": "Malignant neoplasm of skin of popliteal fossa area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188133005",
+        "display": "Malignant neoplasm of skin of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188135003",
+        "display": "Malignant neoplasm of skin of heel"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188138001",
+        "display": "Malignant neoplasm of skin of great toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188147009",
+        "display": "Malignant neoplasm of nipple and areola of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188151006",
+        "display": "Malignant neoplasm of central part of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188152004",
+        "display": "Malignant neoplasm of upper-inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188153009",
+        "display": "Malignant neoplasm of lower-inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188154003",
+        "display": "Malignant neoplasm of upper-outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188155002",
+        "display": "Malignant neoplasm of lower-outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188156001",
+        "display": "Malignant neoplasm of axillary tail of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188157005",
+        "display": "Malignant neoplasm, overlapping lesion of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188159008",
+        "display": "Malignant neoplasm of ectopic site of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188163001",
+        "display": "Malignant neoplasm of nipple and areola of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188168005",
+        "display": "Malignant neoplasm of ectopic site of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188176007",
+        "display": "Malignant neoplasm of endocervical canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188177003",
+        "display": "Malignant neoplasm of endocervical gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188180002",
+        "display": "Primary malignant neoplasm of overlapping sites of cervix uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188183000",
+        "display": "Malignant neoplasm of cervical stump"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188184006",
+        "display": "Malignant neoplasm of squamocolumnar junction of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188188009",
+        "display": "Choriocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188189001",
+        "display": "Malignant neoplasm of corpus uteri, excluding isthmus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188190005",
+        "display": "Malignant neoplasm of cornu of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188191009",
+        "display": "Malignant neoplasm of fundus of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188192002",
+        "display": "Malignant neoplasm of endometrium of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188193007",
+        "display": "Malignant neoplasm of myometrium of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188195000",
+        "display": "Malignant neoplasm of isthmus of uterine body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188204000",
+        "display": "Malignant neoplasm of round ligament"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188208002",
+        "display": "Malignant neoplasm of Gartner's duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188209005",
+        "display": "Malignant neoplasm of vaginal vault"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188211001",
+        "display": "Malignant neoplasm of greater vestibular (Bartholin's) gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188219004",
+        "display": "Malignant tumor of undescended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188220005",
+        "display": "Malignant neoplasm of ectopic testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188230001",
+        "display": "Malignant tumor of body of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188234005",
+        "display": "Malignant neoplasm of seminal vesicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188235006",
+        "display": "Malignant tumor of tunica vaginalis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188239000",
+        "display": "Malignant tumor of trigone of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188240003",
+        "display": "Malignant neoplasm of vault of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188241004",
+        "display": "Malignant neoplasm of lateral wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188242006",
+        "display": "Malignant neoplasm of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188243001",
+        "display": "Malignant neoplasm of posterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188244007",
+        "display": "Malignant tumor of bladder neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188245008",
+        "display": "Malignant neoplasm of ureteric orifice"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188247000",
+        "display": "Malignant neoplasm, overlapping lesion of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188250002",
+        "display": "Malignant neoplasm of kidney parenchyma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188252005",
+        "display": "Malignant neoplasm of renal calyx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188253000",
+        "display": "Malignant tumor of pelviureteric junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188256008",
+        "display": "Malignant neoplasm of overlapping lesion of urinary organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188261005",
+        "display": "Malignant neoplasm of eyeball excluding conjunctiva, cornea, retina and choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188263008",
+        "display": "Malignant neoplasm of ciliary body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188264002",
+        "display": "Malignant neoplasm of iris"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188265001",
+        "display": "Malignant neoplasm of crystalline lens"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188266000",
+        "display": "Malignant neoplasm of sclera"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188268004",
+        "display": "Malignant neoplasm of connective tissue of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188269007",
+        "display": "Malignant neoplasm of extraocular muscle of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188272000",
+        "display": "Malignant neoplasm of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188273005",
+        "display": "Malignant neoplasm of lacrimal sac"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188274004",
+        "display": "Malignant neoplasm of nasolacrimal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188280007",
+        "display": "Malignant neoplasm of cerebrum (excluding lobes and ventricles)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188281006",
+        "display": "Malignant neoplasm of basal ganglia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188282004",
+        "display": "Malignant neoplasm of cerebral cortex"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188283009",
+        "display": "Malignant neoplasm of corpus striatum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188285002",
+        "display": "Malignant neoplasm of globus pallidus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188286001",
+        "display": "Malignant tumor of hypothalamus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188287005",
+        "display": "Malignant neoplasm of thalamus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188289008",
+        "display": "Malignant neoplasm of hippocampus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188290004",
+        "display": "Malignant neoplasm of uncus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188292007",
+        "display": "Malignant tumor of choroid plexus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188293002",
+        "display": "Malignant neoplasm of floor of cerebral ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188295009",
+        "display": "Malignant neoplasm of cerebral peduncle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188296005",
+        "display": "Malignant neoplasm of medulla oblongata"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188297001",
+        "display": "Malignant neoplasm of midbrain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188298006",
+        "display": "Malignant neoplasm of pons"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188301005",
+        "display": "Malignant neoplasm of corpus callosum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188302003",
+        "display": "Malignant neoplasm of tapetum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188307009",
+        "display": "Malignant tumor of cranial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188308004",
+        "display": "Malignant neoplasm of olfactory bulb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188312005",
+        "display": "Malignant neoplasm of cerebral dura mater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188313000",
+        "display": "Malignant neoplasm of cerebral arachnoid mater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188315007",
+        "display": "Malignant neoplasm of cerebral pia mater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188317004",
+        "display": "Malignant neoplasm of spinal dura mater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188318009",
+        "display": "Malignant neoplasm of spinal arachnoid mater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188319001",
+        "display": "Malignant neoplasm of spinal pia mater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188321006",
+        "display": "Malignant neoplasm of peripheral nerves and autonomic nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188322004",
+        "display": "Malignant neoplasm of peripheral nerves of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188323009",
+        "display": "Malignant neoplasm of peripheral nerves of upper limb, including shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188324003",
+        "display": "Malignant neoplasm of peripheral nerves of lower limb, including hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188325002",
+        "display": "Malignant neoplasm of peripheral nerve of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188326001",
+        "display": "Malignant neoplasm of peripheral nerve of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188327005",
+        "display": "Malignant neoplasm of peripheral nerve of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188339002",
+        "display": "Malignant neoplasm of pituitary gland and craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188340000",
+        "display": "Malignant tumor of craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188361007",
+        "display": "Malignant neoplasm of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188366002",
+        "display": "Malignant tumor of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188478004",
+        "display": "Malignant neoplasms of independent (primary) multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188487008",
+        "display": "Lymphosarcoma and reticulosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188489006",
+        "display": "Reticulosarcoma of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188492005",
+        "display": "Reticulosarcoma of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188493000",
+        "display": "Reticulosarcoma of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188498009",
+        "display": "Lymphosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188500005",
+        "display": "Lymphosarcoma of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188501009",
+        "display": "Lymphosarcoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188502002",
+        "display": "Lymphosarcoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188503007",
+        "display": "Lymphosarcoma of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188504001",
+        "display": "Lymphosarcoma of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188505000",
+        "display": "Lymphosarcoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188506004",
+        "display": "Lymphosarcoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188507008",
+        "display": "Lymphosarcoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188511002",
+        "display": "Burkitt's lymphoma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188512009",
+        "display": "Burkitt's lymphoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188513004",
+        "display": "Burkitt's lymphoma of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188514005",
+        "display": "Burkitt's lymphoma of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188515006",
+        "display": "Burkitt's lymphoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188516007",
+        "display": "Burkitt's lymphoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188517003",
+        "display": "Burkitt's lymphoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188524002",
+        "display": "Hodgkin's paragranuloma of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188529007",
+        "display": "Hodgkin's paragranuloma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188531003",
+        "display": "Hodgkin's paragranuloma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188536008",
+        "display": "Hodgkin's granuloma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188537004",
+        "display": "Hodgkin's granuloma of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188538009",
+        "display": "Hodgkin's granuloma of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188541000",
+        "display": "Hodgkin's granuloma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188547001",
+        "display": "Hodgkin's sarcoma of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188548006",
+        "display": "Hodgkin's sarcoma of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188551004",
+        "display": "Hodgkin's sarcoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188554007",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188558005",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188559002",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188562004",
+        "display": "Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188565002",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188566001",
+        "display": "Hodgkin's disease, nodular sclerosis of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188567005",
+        "display": "Hodgkin's disease, nodular sclerosis of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188568000",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188569008",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188570009",
+        "display": "Hodgkin's disease, nodular sclerosis of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188572001",
+        "display": "Hodgkin's disease, nodular sclerosis of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188575004",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188576003",
+        "display": "Hodgkin's disease, mixed cellularity of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188577007",
+        "display": "Hodgkin's disease, mixed cellularity of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188578002",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188579005",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188580008",
+        "display": "Hodgkin's disease, mixed cellularity of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188582000",
+        "display": "Hodgkin's disease, mixed cellularity of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188585003",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188586002",
+        "display": "Hodgkin's disease, lymphocytic depletion of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188587006",
+        "display": "Hodgkin's disease, lymphocytic depletion of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188589009",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188590000",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188591001",
+        "display": "Hodgkin's disease, lymphocytic depletion of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188592008",
+        "display": "Hodgkin's disease, lymphocytic depletion of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188593003",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188609000",
+        "display": "Nodular lymphoma of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188612002",
+        "display": "Nodular lymphoma of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188613007",
+        "display": "Nodular lymphoma of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188627002",
+        "display": "Mycosis fungoides of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188631008",
+        "display": "Sezary's disease of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188632001",
+        "display": "Sezary's disease of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188633006",
+        "display": "Sezary's disease of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188634000",
+        "display": "Sezary's disease of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188635004",
+        "display": "Sezary's disease of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188637007",
+        "display": "Sezary's disease of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188641006",
+        "display": "Malignant histiocytosis of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188642004",
+        "display": "Malignant histiocytosis of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188662007",
+        "display": "Mast cell malignancy of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188665009",
+        "display": "Mast cell malignancy of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188666005",
+        "display": "Mast cell malignancy of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188668006",
+        "display": "Mast cell malignancy of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188669003",
+        "display": "Mast cell malignancy of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188672005",
+        "display": "Follicular non-Hodgkin's mixed small cleaved and large cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188674006",
+        "display": "Diffuse malignant lymphoma - small non-cleaved cell"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188675007",
+        "display": "Diffuse non-Hodgkin's small cleaved cell (diffuse) lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188676008",
+        "display": "Malignant lymphoma - mixed small and large cell"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188679001",
+        "display": "Diffuse non-Hodgkin's lymphoma undifferentiated (diffuse)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188691005",
+        "display": "Malignant immunoproliferative small intestinal disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188718006",
+        "display": "Extramedullary plasmacytoma (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188725004",
+        "display": "Lymphoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188726003",
+        "display": "Subacute lymphoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188728002",
+        "display": "Aleukemic lymphoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188732008",
+        "display": "Myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188734009",
+        "display": "Chronic neutrophilic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188736006",
+        "display": "Subacute myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188737002",
+        "display": "Chloroma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188741003",
+        "display": "Aleukemic myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188744006",
+        "display": "Histiocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188745007",
+        "display": "Chronic monocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188746008",
+        "display": "Subacute monocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188748009",
+        "display": "Aleukemic monocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188754005",
+        "display": "Thrombocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188768003",
+        "display": "Myelomonocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188770007",
+        "display": "Subacute myelomonocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189814006",
+        "display": "Pancreatoblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189815007",
+        "display": "Pulmonary blastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189847002",
+        "display": "Malignant teratoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189924002",
+        "display": "Pleomorphic xanthoastrocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "190030009",
+        "display": "Compound leukemias"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "190818004",
+        "display": "Waldenstrom's macroglobulinemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231829006",
+        "display": "Malignant tumor of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231831002",
+        "display": "Squamous cell carcinoma of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231832009",
+        "display": "Basal cell carcinoma of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231833004",
+        "display": "Sebaceous adenocarcinoma of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231834005",
+        "display": "Malignant melanoma of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231835006",
+        "display": "Kaposi's sarcoma of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "232075002",
+        "display": "Lymphoma of retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "235966007",
+        "display": "Cystadenocarcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "236513009",
+        "display": "Lymphoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "237832001",
+        "display": "Gastrointestinal hormone-secreting endocrine tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "237833006",
+        "display": "Carcinoid crisis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "238636003",
+        "display": "Malignant acanthosis nigricans"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "240163000",
+        "display": "Malignant neoplasm of nasopharyngeal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "240531002",
+        "display": "African Burkitt's lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253000007",
+        "display": "Neuroendocrine carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253001006",
+        "display": "Trabecular cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253003009",
+        "display": "Carcinoid bronchial adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253005002",
+        "display": "VIP-oma - Vasoactive intestinal peptide-secreting tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253017000",
+        "display": "Klatskin's tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253018005",
+        "display": "Fibrolamellar hepatocellular carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253096008",
+        "display": "Neuroectodermal tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254389005",
+        "display": "Carcinoma of vermilion border of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254390001",
+        "display": "Carcinoma of lipstick area of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254393004",
+        "display": "Carcinoma of frenum of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254398008",
+        "display": "Carcinoma of frenum of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254402004",
+        "display": "Carcinoma of frenum of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254404003",
+        "display": "Carcinoma of commissure of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254408000",
+        "display": "Malignant tumor of anterior two-thirds of tongue - lateral margin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254412006",
+        "display": "Malignant tumor of tip of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254417000",
+        "display": "Carcinoma of frenum linguae"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254423005",
+        "display": "Carcinoma of lingual tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254424004",
+        "display": "Carcinoma of upper gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254425003",
+        "display": "Carcinoma of lower gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254427006",
+        "display": "Carcinoma of anterior part of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254431000",
+        "display": "Carcinoma of lateral part of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254434008",
+        "display": "Carcinoma of hard palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254435009",
+        "display": "Carcinoma of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254436005",
+        "display": "Carcinoma of uvula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254437001",
+        "display": "Squamous cell carcinoma of buccal mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254441002",
+        "display": "Carcinoma of upper buccal sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254445006",
+        "display": "Carcinoma of lower buccal sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254450000",
+        "display": "Carcinoma of upper labial sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254454009",
+        "display": "Carcinoma of lower labial sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254457002",
+        "display": "Carcinoma of retromolar area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254459004",
+        "display": "Malignant tumor of anterior pillar of fauces"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254462001",
+        "display": "Carcinoma of parotid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254465004",
+        "display": "Carcinoma of submandibular gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254466003",
+        "display": "Carcinoma of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254474002",
+        "display": "Malignant tumor of nasal skeleton"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254478004",
+        "display": "Malignant tumor of inferior turbinate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254481009",
+        "display": "Malignant tumor of middle turbinate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254484001",
+        "display": "Malignant tumor of posterior margin of nasal septum and choanae"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254503007",
+        "display": "Malignant tumor of inferior surface of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254509006",
+        "display": "Malignant tumor of anterior commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254513004",
+        "display": "Malignant tumor of posterior commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254517003",
+        "display": "Malignant tumor of suprahyoid epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254520006",
+        "display": "Malignant tumor of infrahyoid epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254526000",
+        "display": "Malignant tumor of laryngeal ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254530002",
+        "display": "Malignant tumor of parapharyngeal space"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254535007",
+        "display": "Carcinoma of cervical part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254539001",
+        "display": "Carcinoma of thoracic part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254543002",
+        "display": "Carcinoma of abdominal part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254547001",
+        "display": "Carcinoma of upper third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254549003",
+        "display": "Carcinoma of middle third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254551004",
+        "display": "Carcinoma of lower third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254553001",
+        "display": "Carcinoma of cardia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254555008",
+        "display": "Carcinoma of fundus of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254557000",
+        "display": "Carcinoma of body of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254559002",
+        "display": "Carcinoma of pyloric antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254561006",
+        "display": "Carcinoma of pylorus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254563009",
+        "display": "Carcinoma of lesser curve of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254567005",
+        "display": "Carcinoma of greater curve of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254570009",
+        "display": "Carcinoma of duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254582000",
+        "display": "Adenocarcinoma of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254586002",
+        "display": "Malignant tumor of anorectal junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254601002",
+        "display": "Sarcoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254609000",
+        "display": "Carcinoma of ampulla of Vater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254611009",
+        "display": "Malignant tumor of endocrine pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254612002",
+        "display": "Carcinoma of endocrine pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254619006",
+        "display": "Adenoid cystic carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254620000",
+        "display": "Squamous cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254622008",
+        "display": "Squamous cell carcinoma of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254625005",
+        "display": "Malignant tumor of lung parenchyma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254626006",
+        "display": "Adenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254629004",
+        "display": "Large cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254631008",
+        "display": "Giant cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254632001",
+        "display": "Small cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254633006",
+        "display": "Oat cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254634000",
+        "display": "Squamous cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254635004",
+        "display": "Epithelioid hemangioendothelioma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254637007",
+        "display": "Non-small cell lung cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254638002",
+        "display": "Superior sulcus tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254645002",
+        "display": "Malignant mesothelioma of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254650008",
+        "display": "Malignant tumor of surface epithelium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254651007",
+        "display": "Squamous cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254652000",
+        "display": "SCC - Clear cell squamous cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254653005",
+        "display": "Spindle cell squamous carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254654004",
+        "display": "SCC - Acantholytic squamous cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254655003",
+        "display": "Plantar verrucous carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254701007",
+        "display": "Basal cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254702000",
+        "display": "BCC - Metatypical basal cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254703005",
+        "display": "Pinkus tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254707006",
+        "display": "Sweat gland carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254708001",
+        "display": "Eccrine porocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254709009",
+        "display": "Sweat gland adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254710004",
+        "display": "Basal cell carcinoma with eccrine differentiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254711000",
+        "display": "Adenoid cystic eccrine carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254712007",
+        "display": "Malignant syringoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254713002",
+        "display": "Mucoepidermoid carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254714008",
+        "display": "Mucinous eccrine carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254726003",
+        "display": "Malignant skin tumor with apocrine differentiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254727007",
+        "display": "Extramammary Paget's disease of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254730000",
+        "display": "Superficial spreading malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254731001",
+        "display": "Nodular melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254732008",
+        "display": "Acral lentiginous malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254733003",
+        "display": "Malignant melanoma arising in intradermal nevus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254734009",
+        "display": "Malignant melanoma arising in congenital nevus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254748009",
+        "display": "Cutaneous fibrosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254764001",
+        "display": "Peripheral neuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254771006",
+        "display": "Cutaneous leiomyosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254792006",
+        "display": "Proliferating angioendotheliomatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254794007",
+        "display": "Angiosarcoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254797000",
+        "display": "Malignant hemangiopericytoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254800003",
+        "display": "Epithelioid sarcoma of Enzinger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254820002",
+        "display": "Follicular atrophoderma and basal cell epitheliomata"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254824006",
+        "display": "Malignant tumor of mesothelial tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254829001",
+        "display": "Liposarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254837009",
+        "display": "Malignant tumor of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254838004",
+        "display": "CA - Carcinoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254839007",
+        "display": "Scirrhous carcinoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254840009",
+        "display": "Inflammatory carcinoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254841008",
+        "display": "Cancer en cuirasse"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254843006",
+        "display": "Familial cancer of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254844000",
+        "display": "Malignant phyllodes tumor of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254849005",
+        "display": "Malignant epithelial tumor of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254850005",
+        "display": "Serous papillary cystadenocarcinoma ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254851009",
+        "display": "Mucinous cystadenocarcinoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254852002",
+        "display": "Endometrioid carcinoma ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254856004",
+        "display": "Undifferentiated carcinoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254860001",
+        "display": "Malignant sex cord tumor of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254863004",
+        "display": "Granulosa cell tumor of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254869000",
+        "display": "Malignant germ cell tumor of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254870004",
+        "display": "Choriocarcinoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254872007",
+        "display": "Embryonal carcinoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254874008",
+        "display": "Dysgerminoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254876005",
+        "display": "Endodermal sinus tumor of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254877001",
+        "display": "Uterine sarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254878006",
+        "display": "Endometrial carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254886006",
+        "display": "Squamous cell carcinoma of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254887002",
+        "display": "Adenocarcinoma of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254888007",
+        "display": "Adenosquamous carcinoma of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254893005",
+        "display": "Carcinoma of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254895003",
+        "display": "Epithelioma of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254896002",
+        "display": "Malignant melanoma of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254897006",
+        "display": "Sarcoma of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254898001",
+        "display": "Paget's disease of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254900004",
+        "display": "Carcinoma of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254904008",
+        "display": "Carcinoma of glans penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254908006",
+        "display": "Malignant tumor of penile skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254909003",
+        "display": "Carcinoma of foreskin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254912000",
+        "display": "Regressed malignant testicular tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254915003",
+        "display": "Clear cell carcinoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254916002",
+        "display": "Cystadenocarcinoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254917006",
+        "display": "Papillary cystadenocarcinoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254918001",
+        "display": "Sarcoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254934003",
+        "display": "Malignant tumor of urethral stump"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254938000",
+        "display": "Astrocytic tumor of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254940005",
+        "display": "Oligodendroglioma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254948003",
+        "display": "Astrocytoma of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254950006",
+        "display": "Oligodendroglioma of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254955001",
+        "display": "Pituitary carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254969001",
+        "display": "Malignant tumor of olfactory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254972008",
+        "display": "Malignant tumor of optic nerve and sheath"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254973003",
+        "display": "Malignant astrocytoma of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254974009",
+        "display": "Malignant tumor of optic nerve sheath"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254975005",
+        "display": "Malignant meningioma of optic nerve sheath"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254980001",
+        "display": "Malignant tumor of acoustic vestibular nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254983004",
+        "display": "Malignant tumor of spinal nerve and sheath"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254986007",
+        "display": "Malignant tumor of peripheral nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254987003",
+        "display": "Adenoid cystic carcinoma of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254988008",
+        "display": "Adenocarcinoma of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254989000",
+        "display": "Malignant mixed tumor of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254993006",
+        "display": "Liposarcoma of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254994000",
+        "display": "Rhabdomyosarcoma of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254995004",
+        "display": "Malignant hemangiopericytoma of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254996003",
+        "display": "Malignant fibrous histiocytoma of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255003007",
+        "display": "Squamous cell carcinoma of conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255004001",
+        "display": "Malignant melanoma of conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255008003",
+        "display": "Squamous cell carcinoma of cornea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255012009",
+        "display": "Malignant melanoma of iris"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255015006",
+        "display": "Malignant melanoma of ciliary body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255016007",
+        "display": "Adenocarcinoma of pigmented epithelium of ciliary body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255017003",
+        "display": "Adenocarcinoma of non-pigmented epithelium of ciliary body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255021005",
+        "display": "Malignant melanoma of choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255028004",
+        "display": "Follicular thyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255029007",
+        "display": "Papillary thyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255030002",
+        "display": "Mixed follicular and papillary thyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255031003",
+        "display": "Anaplastic thyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255032005",
+        "display": "Medullary thyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255035007",
+        "display": "Adrenal carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255037004",
+        "display": "Parathyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255038009",
+        "display": "GRF-oma - Growth hormone releasing factor-secreting tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255039001",
+        "display": "Pancreatic polypeptidoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255040004",
+        "display": "Parathyroid hormone-related peptide-secreting tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255042007",
+        "display": "Gastric inhibitory peptide-secreting tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255052006",
+        "display": "Malignant tumor of unknown origin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255056009",
+        "display": "Malignant tumor of head and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255066001",
+        "display": "Carcinoma of genitourinary organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255067005",
+        "display": "Sarcoma of bone and connective tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255068000",
+        "display": "Carcinoma of bone, connective tissue, skin and breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255069008",
+        "display": "Carcinoma of lip, oral cavity and pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255070009",
+        "display": "Overlapping malignant neoplasm of oral cavity and lip and salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255071008",
+        "display": "Squamous cell carcinoma of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255072001",
+        "display": "Cancer of salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255073006",
+        "display": "Malignant tumor of ear, nose and throat"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255074000",
+        "display": "Malignant tumor of nasal cavity and nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255075004",
+        "display": "Malignant tumor of lateral nasal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255077007",
+        "display": "Malignant tumor of digestive organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255078002",
+        "display": "Malignant tumor of esophagus, stomach and duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255081007",
+        "display": "Carcinoma of cecum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255084004",
+        "display": "Squamous cell carcinoma of anal margin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255086002",
+        "display": "Carcinoma common bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255087006",
+        "display": "Malignant polyp of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255088001",
+        "display": "Malignant tumor of exocrine pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255090000",
+        "display": "Malignant neoplasm of carpal bones"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255091001",
+        "display": "Malignant neoplasm of metacarpal bones"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255093003",
+        "display": "Malignant tumor of epidermal appendage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255096006",
+        "display": "Malignant tumor of dermis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255107005",
+        "display": "Seminoma of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255108000",
+        "display": "Carcinoma of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255109008",
+        "display": "Transitional cell carcinoma of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255110003",
+        "display": "Adenocarcinoma of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255111004",
+        "display": "Squamous cell carcinoma of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255112006",
+        "display": "Malignant tumor of pituitary and hypothalamus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255114007",
+        "display": "Kaposi's sarcoma of conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255115008",
+        "display": "Kaposi's sarcoma of cornea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255128001",
+        "display": "Malignant infiltration of peripheral nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255129009",
+        "display": "Malignant infiltration of peripheral nerve plexus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255191003",
+        "display": "Localized malignant reticulohistiocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269459004",
+        "display": "Malignant tumor of lesser curve of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269460009",
+        "display": "Malignant tumor of greater curve of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269463006",
+        "display": "Malignant tumor of middle ear and mastoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269464000",
+        "display": "Malignant neoplasm of upper lobe, bronchus or lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269467007",
+        "display": "Malignant neoplasm of hand bones"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269469005",
+        "display": "Malignant neoplasm of soft tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269475001",
+        "display": "Malignant neoplasm of lymphatic and hemopoietic tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269476000",
+        "display": "Nodular lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269515006",
+        "display": "Carcinoma of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269516007",
+        "display": "Tongue carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269533000",
+        "display": "Carcinoma of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269544008",
+        "display": "Carcinoma of the rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269578002",
+        "display": "Malignant melanoma of head and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269579005",
+        "display": "Malignant melanoma of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269580008",
+        "display": "Malignant melanoma of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269581007",
+        "display": "Malignant melanoma of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271323007",
+        "display": "Malignant neoplasm of lip, oral cavity and pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271467005",
+        "display": "Malignant neoplasm of bone, connective tissue, skin and breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271468000",
+        "display": "Malignant neoplasm of genitourinary organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271568003",
+        "display": "Malig neoplasm of lower lip, oral aspect"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271943005",
+        "display": "Carcinoma of base of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "274084007",
+        "display": "Palate carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "274085008",
+        "display": "Tonsil carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "274087000",
+        "display": "Malignant melanoma of eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "274902006",
+        "display": "Mixed hepatocellular and bile duct carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "274905008",
+        "display": "Malignant lymphoma - lymphocytic, intermediate differentiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275394001",
+        "display": "Carcinoma ventral surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275395000",
+        "display": "Carcinoma anterior 2/3 tongue ventrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275396004",
+        "display": "Carcinoma of anterior two-thirds of tongue - dorsal surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275397008",
+        "display": "Carcinoma of midline of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275399006",
+        "display": "Malignant tumor of lipstick area of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275490009",
+        "display": "Carcinoma of tongue base - dorsal surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276419004",
+        "display": "Malignant tumor of corpus spongiosum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276420005",
+        "display": "Malignant tumor of corpus cavernosum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276738009",
+        "display": "Primary signet ring cell carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276750003",
+        "display": "Malignant tumor of skin with pilar differentiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276751004",
+        "display": "Amelanotic malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276797002",
+        "display": "Malignant tumor of fibrous tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276803003",
+        "display": "Adenocarcinoma of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276804009",
+        "display": "Squamous cell carcinoma of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276809004",
+        "display": "EGC - Early gastric cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276810009",
+        "display": "Late gastric cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276811008",
+        "display": "Gastric lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276815004",
+        "display": "Lymphoma of intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276821000",
+        "display": "Malignant melanoma of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276822007",
+        "display": "Malignant melanoma of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276826005",
+        "display": "Malignant glioma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276827001",
+        "display": "Malignant glioma of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276828006",
+        "display": "Glioblastoma multiforme of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276829003",
+        "display": "Glioblastoma multiforme of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276836002",
+        "display": "Primary cerebral lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276860003",
+        "display": "Squamous cell carcinoma of scrotum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276870001",
+        "display": "Carcinoma of fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276876007",
+        "display": "Carcinoma of Bartholin's gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276952000",
+        "display": "Squamous cell carcinoma of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276953005",
+        "display": "SCC - Squamous cell carcinoma of gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276954004",
+        "display": "Squamous cell carcinoma of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276962007",
+        "display": "Squamous cell carcinoma of palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276975007",
+        "display": "Carcinoma of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277156006",
+        "display": "Malignant tumor of external ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277461004",
+        "display": "Anaplastic astrocytoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277474005",
+        "display": "B-cell chronic lymphocytic leukemia variant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277505007",
+        "display": "Medulloblastoma of cerebellum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277530005",
+        "display": "Malignant melanoma of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277543005",
+        "display": "Malignant white blood cell disorder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277545003",
+        "display": "T-cell chronic lymphocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277549009",
+        "display": "Chronic lymphocytic prolymphocytic leukemia syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277550009",
+        "display": "Richter's syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277551008",
+        "display": "Splenic lymphoma with villous lymphocytes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277567002",
+        "display": "T-cell prolymphocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277568007",
+        "display": "Hairy cell leukemia variant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277569004",
+        "display": "Large granular lymphocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277570003",
+        "display": "Lymphoma with spill"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277571004",
+        "display": "B-cell acute lymphoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277572006",
+        "display": "Acute pre B-cell lymphoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277573001",
+        "display": "Common acute lymphoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277574007",
+        "display": "Null cell acute lymphoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277575008",
+        "display": "T-cell acute lymphoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277579002",
+        "display": "Light chain myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277580004",
+        "display": "Non-secretory myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277587001",
+        "display": "JCML - Juvenile chronic myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277589003",
+        "display": "Atypical chronic myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277597005",
+        "display": "Myelodysplastic syndrome with isolated del(5q) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277601005",
+        "display": "Acute monocytoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277602003",
+        "display": "Acute megakaryoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277604002",
+        "display": "Acute eosinophilic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277609007",
+        "display": "Hodgkin's disease, lymphocytic predominance - diffuse"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277610002",
+        "display": "Hodgkin's disease, nodular sclerosis - lymphocytic predominance"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277611003",
+        "display": "Hodgkin's disease, nodular sclerosis - mixed cellularity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277612005",
+        "display": "Hodgkin's disease, nodular sclerosis - lymphocytic depletion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277613000",
+        "display": "Cutaneous/peripheral T-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277614006",
+        "display": "Prethymic and thymic T-cell lymphoma/leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277615007",
+        "display": "Low grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277616008",
+        "display": "Diffuse low grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277617004",
+        "display": "High grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277618009",
+        "display": "Follicular low grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277619001",
+        "display": "B-cell prolymphocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277622004",
+        "display": "Mucosa-associated lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277623009",
+        "display": "Monocytoid B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277624003",
+        "display": "Follicular malignant lymphoma - mixed cell type"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277625002",
+        "display": "Follicular non-Hodgkin's small cleaved cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277626001",
+        "display": "Diffuse high grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277627005",
+        "display": "Nodular high grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277628000",
+        "display": "Diffuse malignant lymphoma - large cleaved cell"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277629008",
+        "display": "Diffuse malignant lymphoma - large non-cleaved cell"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277632006",
+        "display": "Diffuse malignant lymphoma - centroblastic polymorphic"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277642008",
+        "display": "Low grade T-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277643003",
+        "display": "High grade T-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277654008",
+        "display": "Enteropathy-associated T-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277664004",
+        "display": "Malignant lymphoma of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277782009",
+        "display": "Malignant peritoneal local recurrence"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278024000",
+        "display": "Rhabdomyosarcoma of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278042005",
+        "display": "Malignant teratoma of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278043000",
+        "display": "Malignant seminoma of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278044006",
+        "display": "Malignant neuroma of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278046008",
+        "display": "Sarcoma of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278050001",
+        "display": "Sarcoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278052009",
+        "display": "Malignant lymphoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278054005",
+        "display": "Lobular carcinoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278055006",
+        "display": "Malignant Leydig cell tumor of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278060005",
+        "display": "Endometrioid carcinoma of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278189009",
+        "display": "Hypergranular promyelocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278453007",
+        "display": "Acute biphenotypic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278491007",
+        "display": "Mixed seminoma teratoma of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "280959007",
+        "display": "Malignant tumor of lacrimal drainage structure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281560004",
+        "display": "Neuroblastoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281562007",
+        "display": "Adrenal neuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281563002",
+        "display": "Thoracic neuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281564008",
+        "display": "Pelvic neuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281565009",
+        "display": "Paraspinal neuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281566005",
+        "display": "Abdominothoracic neuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "281702006",
+        "display": "Tibial adamantinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285307007",
+        "display": "Squamous cell carcinoma of skin of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285308002",
+        "display": "Squamous cell carcinoma of skin of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285309005",
+        "display": "Squamous cell carcinoma of skin of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285310000",
+        "display": "Carcinoma of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285312008",
+        "display": "Carcinoma of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285420006",
+        "display": "IgA myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285421005",
+        "display": "IgG myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285422003",
+        "display": "Immunoglobulin D myeloma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285432005",
+        "display": "Carcinoma of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285769009",
+        "display": "Acute promyelocytic leukemia - hypogranular variant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285776004",
+        "display": "Intermediate grade B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285839005",
+        "display": "M4Eo - Acute myelomonocytic leukemia - eosinophilic variant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286887005",
+        "display": "Carcinoma liver/biliary system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286889008",
+        "display": "Carcinoma of upper limb bones/scapula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286890004",
+        "display": "Carcinoma of lower limb bones"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286891000",
+        "display": "Carcinoma of skin of head/neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286893002",
+        "display": "Carcinoma of breast - upper, inner quadrant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286894008",
+        "display": "Carcinoma of breast - lower, inner quadrant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286895009",
+        "display": "Carcinoma of breast - upper, outer quadrant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286896005",
+        "display": "Carcinoma breast - lower, outer quadrant"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286897001",
+        "display": "Carcinoma of breast - axillary tail"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286899003",
+        "display": "Carcinoma genital organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "300988009",
+        "display": "Transitional cell carcinoma of ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "301756000",
+        "display": "Adenocarcinoma of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302815008",
+        "display": "Malignant tumor of frenum of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302816009",
+        "display": "Malignant tumor of soft tissue of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302823005",
+        "display": "Alpha cell adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302837001",
+        "display": "LMM - Lentigo maligna melanoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302841002",
+        "display": "Malignant lymphoma, lymphocytic, well differentiated"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302842009",
+        "display": "Diffuse malignant lymphoma - centroblastic"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302845006",
+        "display": "Nodular malignant lymphoma, lymphocytic - well differentiated"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302847003",
+        "display": "Rhabdomyosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302848008",
+        "display": "Nodular malignant lymphoma, lymphocytic - intermediate differentiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302849000",
+        "display": "Nephroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302851001",
+        "display": "Synovial sarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302855005",
+        "display": "Subacute leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "302856006",
+        "display": "Aleukemic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303012000",
+        "display": "Malignant tumor of posterior wall of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303017006",
+        "display": "Malignant lymphoma, convoluted cell type"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303055001",
+        "display": "Malignant lymphoma, follicular center cell"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303056000",
+        "display": "Malignant lymphoma, follicular center cell, cleaved"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303057009",
+        "display": "Malignant lymphoma, follicular center cell, non-cleaved"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "304545002",
+        "display": "Adenocarcinoma of ileum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307216009",
+        "display": "Perforated carcinoma of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307219002",
+        "display": "Retroperitoneal sarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307340003",
+        "display": "Monosomy 7 syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307341004",
+        "display": "Atypical hairy cell leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307502000",
+        "display": "Squamous cell carcinoma of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307576001",
+        "display": "Osteosarcoma of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307591004",
+        "display": "Malignant mastocytosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307592006",
+        "display": "Basophilic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307599002",
+        "display": "Sebaceous adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307603002",
+        "display": "Malignant blue nevus of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307608006",
+        "display": "Ewing's sarcoma of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307609003",
+        "display": "Adamantinoma of long bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307610008",
+        "display": "Pilomatrix carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307617006",
+        "display": "Neutrophilic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307622006",
+        "display": "Prolymphocytic lymphosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307623001",
+        "display": "Malignant lymphoma - lymphoplasmacytic"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307624007",
+        "display": "Diffuse malignant lymphoma - centroblastic-centrocytic"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307625008",
+        "display": "Malignant lymphoma - centrocytic"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307633009",
+        "display": "Hodgkin's disease, lymphocytic depletion, diffuse fibrosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307634003",
+        "display": "Hodgkin's disease, lymphocytic depletion, reticular type"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307635002",
+        "display": "Hodgkin's disease, nodular sclerosis - cellular phase"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307636001",
+        "display": "Malignant lymphoma, mixed lymphocytic-histiocytic, nodular"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307637005",
+        "display": "Germinoblastoma, follicular"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307646004",
+        "display": "Malignant lymphoma, lymphocytic, poorly differentiated, nodular"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307647008",
+        "display": "Malignant lymphoma, centroblastic type, follicular"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307649006",
+        "display": "Microglioma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307650006",
+        "display": "Histiocytic medullary reticulosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307651005",
+        "display": "Myelosclerosis with myeloid metaplasia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "308121000",
+        "display": "Follicular non-Hodgkin's lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "309245001",
+        "display": "Adenocarcinoma of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "310498001",
+        "display": "Malignant melanoma of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "310504009",
+        "display": "Primary malignant neoplasm of unknown site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "310526005",
+        "display": "Malignant tumor of soft tissue of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "310599006",
+        "display": "Malignant neoplasm of canthus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "311779007",
+        "display": "Malignant neoplasm of skin of scapular region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312104005",
+        "display": "Cholangiocarcinoma of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312111009",
+        "display": "Carcinoma of ascending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312112002",
+        "display": "Carcinoma of transverse colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312113007",
+        "display": "Carcinoma of descending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312114001",
+        "display": "Carcinoma of hepatic flexure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312115000",
+        "display": "Carcinoma of splenic flexure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "312949007",
+        "display": "Retinal pigment epithelial adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313248004",
+        "display": "Malignant melanoma of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313249007",
+        "display": "Malignant neoplasm of upper eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313250007",
+        "display": "Malignant neoplasm of lower eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313353007",
+        "display": "Squamous cell carcinoma of bronchus in left lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313354001",
+        "display": "Squamous cell carcinoma of bronchus in left upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313355000",
+        "display": "Squamous cell carcinoma of bronchus in right lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313356004",
+        "display": "Squamous cell carcinoma of bronchus in right middle lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313357008",
+        "display": "Squamous cell carcinoma of bronchus in right upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313427003",
+        "display": "Lambda light chain myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313428008",
+        "display": "Seminoma of undescended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313429000",
+        "display": "Seminoma of descended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314191009",
+        "display": "Cystadenocarcinoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314951005",
+        "display": "Local recurrence of malignant tumor of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314952003",
+        "display": "Local recurrence of malignant tumor of buccal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314953008",
+        "display": "Local recurrence of malignant tumor of thyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314954002",
+        "display": "Local recurrence of malignant tumor of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314955001",
+        "display": "Local recurrence of malignant tumor of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314960002",
+        "display": "Local recurrence of malignant tumor of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314961003",
+        "display": "Local recurrence of malignant tumor of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314962005",
+        "display": "Local recurrence of malignant tumor of gallbladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314963000",
+        "display": "Local recurrence of malignant tumor of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314964006",
+        "display": "Local recurrence of malignant tumor of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314965007",
+        "display": "Local recurrence of malignant tumor of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314966008",
+        "display": "Local recurrence of malignant tumor of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314967004",
+        "display": "Local recurrence of malignant tumor of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314968009",
+        "display": "Local recurrence of malignant tumor of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314969001",
+        "display": "Local recurrence of malignant tumor of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314970000",
+        "display": "Local recurrence of malignant tumor of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314973003",
+        "display": "Local recurrence of malignant tumor of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314974009",
+        "display": "Local recurrence of malignant tumor of soft tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314975005",
+        "display": "Local recurrence of malignant tumor of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314976006",
+        "display": "Local recurrence of malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315058005",
+        "display": "Hereditary nonpolyposis colon cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "326072005",
+        "display": "Carcinoma of head of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359631009",
+        "display": "Acute myeloid leukemia, minimal differentiation, FAB M0"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359640008",
+        "display": "Acute myeloid leukemia without maturation, FAB M1"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359648001",
+        "display": "Acute myeloid leukemia with maturation, FAB M2"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363348004",
+        "display": "Malignant tumor of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363349007",
+        "display": "Malignant tumor of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363350007",
+        "display": "Malignant tumor of cecum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363351006",
+        "display": "Malignant tumor of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363352004",
+        "display": "Malignant tumor of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363353009",
+        "display": "Malignant tumor of gallbladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363354003",
+        "display": "Malignant tumor of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363355002",
+        "display": "Malignant tumor of adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363358000",
+        "display": "Malignant tumor of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363359008",
+        "display": "Malignant tumor of middle ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363360003",
+        "display": "Malignant tumor of anterior two-thirds of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363363001",
+        "display": "Malignant tumor of soft tissue of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363364007",
+        "display": "Malignant tumor of soft tissue of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363365008",
+        "display": "Malignant tumor of soft tissue of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363366009",
+        "display": "Malignant tumor of soft tissue of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363367000",
+        "display": "Malignant tumor of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363368005",
+        "display": "Carcinoma of body of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363369002",
+        "display": "Carcinoma of tail of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363370001",
+        "display": "Malignant neoplasm of mesentery"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363372009",
+        "display": "Malignant tumor of vermilion border of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363373004",
+        "display": "Malignant tumor of vermilion border of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363374005",
+        "display": "Malignant tumor of commissure of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363375006",
+        "display": "Malignant tumor of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363376007",
+        "display": "Malignant tumor of base of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363377003",
+        "display": "Malignant tumor of lingual tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363378008",
+        "display": "Malignant tumor of major salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363379000",
+        "display": "Malignant tumor of parotid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363380002",
+        "display": "Malignant tumor of submandibular gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363381003",
+        "display": "Malignant tumor of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363382005",
+        "display": "Malignant tumor of gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363383000",
+        "display": "Malignant tumor of upper gingiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363384006",
+        "display": "Malignant tumor of lower gingiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363385007",
+        "display": "Malignant tumor of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363386008",
+        "display": "Malignant tumor of buccal mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363387004",
+        "display": "Malignant tumor of hard palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363388009",
+        "display": "Malignant tumor of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363389001",
+        "display": "Malignant tumor of uvula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363390005",
+        "display": "Malignant tumor of palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363391009",
+        "display": "Malignant tumor of retromolar area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363392002",
+        "display": "Malignant tumor of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363393007",
+        "display": "Malignant tumor of tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363394001",
+        "display": "Malignant tumor of tonsillar fossa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363395000",
+        "display": "Malignant tumor of vallecula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363396004",
+        "display": "Malignant tumor of branchial cleft"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363398003",
+        "display": "Malignant tumor of lateral wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363399006",
+        "display": "Malignant tumor of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363400004",
+        "display": "Malignant tumor of postcricoid region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363401000",
+        "display": "Malignant tumor of pyriform fossa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363402007",
+        "display": "Malignant tumor of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363403002",
+        "display": "Malignant tumor of duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363404008",
+        "display": "Malignant tumor of jejunum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363405009",
+        "display": "Malignant tumor of ileum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363406005",
+        "display": "Malignant tumor of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363407001",
+        "display": "Malignant tumor of hepatic flexure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363408006",
+        "display": "Malignant tumor of transverse colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363409003",
+        "display": "Malignant tumor of descending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363410008",
+        "display": "Malignant tumor of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363411007",
+        "display": "Malignant tumor of appendix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363412000",
+        "display": "Malignant tumor of ascending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363413005",
+        "display": "Malignant tumor of splenic flexure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363414004",
+        "display": "Malignant tumor of rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363415003",
+        "display": "Malignant tumor of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363416002",
+        "display": "Malignant tumor of extrahepatic bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363417006",
+        "display": "Malignant tumor of ampulla of Vater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363418001",
+        "display": "Malignant tumor of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363419009",
+        "display": "Malignant tumor of head of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363420003",
+        "display": "Malignant retroperitoneal tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363421004",
+        "display": "Malignant neoplasm of omentum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363422006",
+        "display": "Malignant tumor of nasal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363423001",
+        "display": "Malignant tumor of nasal septum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363424007",
+        "display": "Malignant tumor of mastoid air cells"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363425008",
+        "display": "Malignant tumor of maxillary sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363426009",
+        "display": "Malignant tumor of ethmoid sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363427000",
+        "display": "Malignant tumor of frontal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363428005",
+        "display": "Malignant tumor of sphenoid sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363429002",
+        "display": "Malignant tumor of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363430007",
+        "display": "Malignant tumor of subglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363431006",
+        "display": "Malignant tumor of laryngeal cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363432004",
+        "display": "Malignant tumor of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363433009",
+        "display": "Malignant tumor of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363434003",
+        "display": "Malignant tumor of thymus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363435002",
+        "display": "Malignant tumor of heart"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363436001",
+        "display": "Malignant tumor of endocardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363437005",
+        "display": "Malignant tumor of myocardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363438000",
+        "display": "Malignant tumor of vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363439008",
+        "display": "Malignant tumor of soft tissue of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363440005",
+        "display": "Malignant tumor of soft tissue of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363441009",
+        "display": "Malignant tumor of soft tissue of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363443007",
+        "display": "Malignant tumor of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363444001",
+        "display": "Malignant tumor of fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363445000",
+        "display": "Malignant tumor of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363446004",
+        "display": "Malignant neoplasm of labia majora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363447008",
+        "display": "Malignant neoplasm of labia minora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363449006",
+        "display": "Malignant tumor of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363450006",
+        "display": "Malignant tumor of foreskin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363451005",
+        "display": "Malignant tumor of glans penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363452003",
+        "display": "Malignant tumor of epididymis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363453008",
+        "display": "Malignant tumor of spermatic cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363454002",
+        "display": "Malignant tumor of scrotum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363456000",
+        "display": "Malignant tumor of urachus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363457009",
+        "display": "Malignant tumor of renal pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363458004",
+        "display": "Malignant tumor of ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363459007",
+        "display": "Malignant tumor of urethra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363460002",
+        "display": "Malignant tumor of paraurethral gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363461003",
+        "display": "Malignant tumor of eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363462005",
+        "display": "Malignant tumor of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363463000",
+        "display": "Malignant tumor of conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363464006",
+        "display": "Malignant tumor of cornea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363465007",
+        "display": "Malignant tumor of retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363466008",
+        "display": "Malignant tumor of choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363467004",
+        "display": "Malignant neoplasm of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363468009",
+        "display": "Malignant neoplasm of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363469001",
+        "display": "Malignant neoplasm of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363470000",
+        "display": "Malignant neoplasm of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363471001",
+        "display": "Malignant neoplasm of cerebral ventricles"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363473003",
+        "display": "Malignant neoplasm of brainstem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363474009",
+        "display": "Malignant neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363475005",
+        "display": "Malignant tumor of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363476006",
+        "display": "Malignant neoplasm of spinal meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363477002",
+        "display": "Malignant neoplasm of cauda equina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363478007",
+        "display": "Malignant tumor of thyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363481002",
+        "display": "Malignant tumor of parathyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363482009",
+        "display": "Malignant tumor of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363483004",
+        "display": "Malignant tumor of pineal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363484005",
+        "display": "Malignant tumor of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363485006",
+        "display": "Malignant tumor of minor salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363486007",
+        "display": "Malignant tumor of vocal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363487003",
+        "display": "Malignant tumor of aryepiglottic fold - laryngeal aspect"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363488008",
+        "display": "Malignant tumor of false cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363489000",
+        "display": "Malignant tumor of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363490009",
+        "display": "Malignant tumor of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363491008",
+        "display": "Malignant tumor of cloacogenic zone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363492001",
+        "display": "Malignant tumor of peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363493006",
+        "display": "Malignant tumor of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363494000",
+        "display": "Malignant tumor of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363495004",
+        "display": "Malignant tumor of muscle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363496003",
+        "display": "Malignant tumor of soft tissue of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363497007",
+        "display": "Malignant tumor of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363498002",
+        "display": "Malignant tumor of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363499005",
+        "display": "Malignant tumor of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363500001",
+        "display": "Multiple malignancy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363501002",
+        "display": "Malignant tumor of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363502009",
+        "display": "Malignant tumor of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363503004",
+        "display": "Malignant tumor of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363504005",
+        "display": "Malignant tumor of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363505006",
+        "display": "Malignant tumor of oral cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363506007",
+        "display": "Malignant tumor of nasal sinuses"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363507003",
+        "display": "Malignant tumor of pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363508008",
+        "display": "Malignant tumor of intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363509000",
+        "display": "Malignant tumor of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363510005",
+        "display": "Malignant tumor of large intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363514001",
+        "display": "Malignant tumor of female genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363515000",
+        "display": "Malignant tumor of male genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363516004",
+        "display": "Malignant tumor of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363517008",
+        "display": "Malignant tumor of urinary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363518003",
+        "display": "Malignant tumor of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "363745004",
+        "display": "Primary malignant neoplasm of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369448007",
+        "display": "Malignant tumor involving rectum by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369449004",
+        "display": "Malignant tumor involving rectum by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369450004",
+        "display": "Malignant tumor involving rectum by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369451000",
+        "display": "Malignant tumor involving rectum by direct extension from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369452007",
+        "display": "Malignant tumor involving rectum by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369453002",
+        "display": "Malignant tumor involving rectum by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369454008",
+        "display": "Malignant tumor involving rectum by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369463005",
+        "display": "Malignant tumor involving ureter by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369465003",
+        "display": "Malignant tumor involving urethra by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369466002",
+        "display": "Malignant tumor involving urethra by direct extension from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369469009",
+        "display": "Malignant tumor involving bladder by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369470005",
+        "display": "Malignant tumor involving bladder by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369471009",
+        "display": "Malignant tumor involving bladder by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369472002",
+        "display": "Malignant tumor involving bladder by direct extension from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369473007",
+        "display": "Malignant tumor involving bladder by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369474001",
+        "display": "Malignant tumor involving bladder by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369475000",
+        "display": "Malignant tumor involving bladder by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369483006",
+        "display": "Malignant tumor involving vasa deferentia by direct extension from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369485004",
+        "display": "Malignant tumor involving prostate by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369487007",
+        "display": "Primary malignant neoplasm of seminal vesicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369489005",
+        "display": "Malignant tumor involving seminal vesicle by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369490001",
+        "display": "Malignant tumor involving seminal vesicle by direct extension from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369493004",
+        "display": "Malignant tumor involving uterine corpus by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369494005",
+        "display": "Malignant tumor involving uterine corpus by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369495006",
+        "display": "Malignant tumor involving uterine corpus by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369496007",
+        "display": "Malignant tumor involving uterine corpus by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369497003",
+        "display": "Malignant tumor involving uterine cervix by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369498008",
+        "display": "Malignant tumor involving uterine cervix by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369499000",
+        "display": "Malignant tumor involving uterine cervix by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369503006",
+        "display": "Malignant tumor involving vagina by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369504000",
+        "display": "Malignant tumor involving vagina by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369505004",
+        "display": "Malignant tumor involving vagina by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369506003",
+        "display": "Malignant tumor involving vagina by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369507007",
+        "display": "Malignant tumor involving vulva by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369508002",
+        "display": "Malignant tumor involving vulva by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369509005",
+        "display": "Malignant tumor involving vulva by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369510000",
+        "display": "Malignant tumor involving vulva by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369511001",
+        "display": "Malignant tumor involving vulva by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369512008",
+        "display": "Malignant tumor involving vagina by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369513003",
+        "display": "Primary malignant neoplasm of left fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369515005",
+        "display": "Malignant tumor involving left fallopian tube by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369516006",
+        "display": "Malignant tumor involving left fallopian tube by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369517002",
+        "display": "Malignant tumor involving left fallopian tube by direct extension from right fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369518007",
+        "display": "Malignant tumor involving left fallopian tube by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369519004",
+        "display": "Malignant tumor involving left fallopian tube by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369520005",
+        "display": "Primary malignant neoplasm of right fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369522002",
+        "display": "Primary malignant neoplasm of left ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369524001",
+        "display": "Malignant tumor involving left ovary by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369525000",
+        "display": "Malignant tumor involving left ovary by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369526004",
+        "display": "Malignant tumor involving left ovary by direct extension from right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369527008",
+        "display": "Malignant tumor involving left ovary by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369528003",
+        "display": "Malignant tumor involving left ovary by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369529006",
+        "display": "Primary malignant neoplasm of right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369531002",
+        "display": "Malignant tumor involving right ovary by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369532009",
+        "display": "Malignant tumor involving right ovary by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369533004",
+        "display": "Malignant tumor involving right ovary by direct extension from left ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369534005",
+        "display": "Malignant tumor involving right ovary by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369541004",
+        "display": "Malignant tumor involving left fallopian tube by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369547000",
+        "display": "Malignant tumor involving right fallopian tube by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369548005",
+        "display": "Malignant tumor involving right fallopian tube by direct extension from left fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369549002",
+        "display": "Malignant tumor involving right fallopian tube by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369550002",
+        "display": "Malignant tumor involving right fallopian tube by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369551003",
+        "display": "Malignant tumor involving right fallopian tube by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369552005",
+        "display": "Malignant tumor involving right fallopian tube by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369559001",
+        "display": "Malignant tumor involving left ovary by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369566000",
+        "display": "Malignant tumor involving right ovary by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369567009",
+        "display": "Malignant tumor involving right ovary by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369579009",
+        "display": "Malignant tumor involving uterine corpus by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369580007",
+        "display": "Malignant tumor involving vagina by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369587005",
+        "display": "Malignant tumor involving vulva by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369594008",
+        "display": "Malignant tumor involving an organ by direct extension from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369595009",
+        "display": "Malignant tumor involving an organ by direct extension from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369596005",
+        "display": "Malignant tumor involving an organ by direct extension from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369597001",
+        "display": "Malignant tumor involving an organ by direct extension from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369598006",
+        "display": "Malignant tumor involving an organ by direct extension from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369599003",
+        "display": "Malignant tumor involving an organ by direct extension from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369600000",
+        "display": "Malignant tumor involving an organ by direct extension from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369601001",
+        "display": "Malignant tumor involving an organ by direct extension from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "370511006",
+        "display": "Vaccine-induced fibrosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "370967009",
+        "display": "Retinoblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "370987005",
+        "display": "Anaplastic astrocytoma of spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371012000",
+        "display": "Acute lymphoblastic leukemia, transitional pre-B-cell (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371134001",
+        "display": "Malignant lymphoma, large cell, polymorphous, immunoblastic (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371962007",
+        "display": "Primary malignant neoplasm of abdominal esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371963002",
+        "display": "Primary malignant neoplasm of adrenal cortex (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371964008",
+        "display": "Malignant neoplasm of adrenal cortex (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371965009",
+        "display": "Malignant neoplasm of adrenal medulla (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371966005",
+        "display": "Primary malignant neoplasm of adrenal medulla (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371967001",
+        "display": "Primary malignant neoplasm of ampulla of Vater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371968006",
+        "display": "Primary malignant neoplasm of anterior two-thirds of tongue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371969003",
+        "display": "Primary malignant neoplasm of apex of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371970002",
+        "display": "Primary malignant neoplasm of biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371971003",
+        "display": "Primary malignant neoplasm of body of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371972005",
+        "display": "Malignant neoplasm of body of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371973000",
+        "display": "Malignant neoplasm of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371974006",
+        "display": "Malignant neoplasm of border of tongue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371975007",
+        "display": "Primary malignant neoplasm of border of tongue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371976008",
+        "display": "Primary malignant neoplasm of buccal mucosa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371977004",
+        "display": "Primary malignant neoplasm of cecum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371978009",
+        "display": "Primary malignant neoplasm of cervical esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371979001",
+        "display": "Malignant neoplasm of clitoris (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371980003",
+        "display": "Primary malignant neoplasm of clitoris (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371981004",
+        "display": "Primary malignant neoplasm of commissure of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371982006",
+        "display": "Malignant neoplasm of endocrine gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371983001",
+        "display": "Primary malignant neoplasm of endocrine gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371984007",
+        "display": "Primary malignant neoplasm of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371986009",
+        "display": "Primary malignant neoplasm of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371987000",
+        "display": "Primary malignant neoplasm of fallopian tube (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371988005",
+        "display": "Primary malignant neoplasm of false vocal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371989002",
+        "display": "Primary malignant neoplasm of glans penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371990006",
+        "display": "Primary malignant neoplasm of gum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371991005",
+        "display": "Primary malignant neoplasm of hard palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371992003",
+        "display": "Primary malignant neoplasm of intestinal tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371993008",
+        "display": "Primary malignant neoplasm of lacrimal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371994002",
+        "display": "Primary malignant neoplasm of laryngeal aspect of aryepiglottic fold (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371995001",
+        "display": "Primary malignant neoplasm of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371996000",
+        "display": "Primary malignant neoplasm of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371997009",
+        "display": "Primary malignant neoplasm of lower gum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371998004",
+        "display": "Primary malignant neoplasm of lower third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "371999007",
+        "display": "Primary malignant neoplasm of middle third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372000001",
+        "display": "Primary malignant neoplasm of minor salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372001002",
+        "display": "Primary malignant neoplasm of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372002009",
+        "display": "Primary malignant neoplasm of palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372003004",
+        "display": "Primary malignant neoplasm of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372004005",
+        "display": "Primary malignant neoplasm of parotid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372005006",
+        "display": "Primary malignant neoplasm of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372006007",
+        "display": "Primary malignant neoplasm of prepuce (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372007003",
+        "display": "Primary malignant neoplasm of retrocecal tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372008008",
+        "display": "Primary malignant neoplasm of scaphoid bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372009000",
+        "display": "Primary malignant neoplasm of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372010005",
+        "display": "Primary malignant neoplasm of soft tissues (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372011009",
+        "display": "Malignant tumor of soft tissue of upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372012002",
+        "display": "Primary malignant neoplasm of soft tissues of upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372013007",
+        "display": "Primary malignant neoplasm of spermatic cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372014001",
+        "display": "Primary malignant neoplasm of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372015000",
+        "display": "Primary malignant neoplasm of the mesentery (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372016004",
+        "display": "Primary malignant neoplasm of the peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372017008",
+        "display": "Primary malignant neoplasm of thoracic esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372018003",
+        "display": "Malignant neoplasm of thoracic vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372019006",
+        "display": "Primary malignant neoplasm of thoracic vertebral column (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372020000",
+        "display": "Primary malignant neoplasm of tonsil (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372021001",
+        "display": "Primary malignant neoplasm of trapezium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372022008",
+        "display": "Primary malignant neoplasm of upper gum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372023003",
+        "display": "Primary malignant neoplasm of upper third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372024009",
+        "display": "Primary malignant neoplasm of uterine cervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372025005",
+        "display": "Primary malignant neoplasm of vagina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372026006",
+        "display": "Primary malignant neoplasm of vermilion border of lower lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372027002",
+        "display": "Primary malignant neoplasm of vermilion border of upper lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372028007",
+        "display": "Primary malignant neoplasm of vertebral column (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372030009",
+        "display": "Primary malignant neoplasm of vocal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372062007",
+        "display": "Malignant neoplasm of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372063002",
+        "display": "Malignant neoplasm of nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372064008",
+        "display": "Malignant neoplasm of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372065009",
+        "display": "Malignant neoplasm of main bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372087000",
+        "display": "Primary malignant neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372092003",
+        "display": "Primary malignant neoplasm of axillary tail of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372094002",
+        "display": "Malignant neoplasm of axillary tail of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372095001",
+        "display": "Malignant neoplasm of male breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372096000",
+        "display": "Carcinoma of male breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372097009",
+        "display": "Malignant neoplasm of endocervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372098004",
+        "display": "Carcinoma of endocervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372099007",
+        "display": "Malignant neoplasm of exocervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372100004",
+        "display": "Carcinoma of exocervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372101000",
+        "display": "Carcinoma of extrahepatic bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372103002",
+        "display": "Carcinoma of glottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372104008",
+        "display": "Carcinoma of subglottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372105009",
+        "display": "Carcinoma of supraglottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372106005",
+        "display": "Carcinoma of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372107001",
+        "display": "Primary malignant neoplasm of ribs, sternum and clavicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372108006",
+        "display": "Malignant neoplasm of bone of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372110008",
+        "display": "Primary malignant neoplasm of lower lobe, bronchus or lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372111007",
+        "display": "Carcinoma of lower lobe, bronchus or lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372115003",
+        "display": "Primary malignant neoplasm of pelvic bones, sacrum and coccyx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372116002",
+        "display": "Carcinoma of pelvic bones, sacrum and coccyx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372119009",
+        "display": "Primary malignant neoplasm of head of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372120003",
+        "display": "Carcinoma of main bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372121004",
+        "display": "Carcinoma of ribs and/or sternum and/or clavicle (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372122006",
+        "display": "Malignant neoplasm of skin head and neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372123001",
+        "display": "Primary malignant neoplasm of skin head and neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372124007",
+        "display": "Malignant neoplasm of skin of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372125008",
+        "display": "Carcinoma of skin of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372126009",
+        "display": "Malignant neoplasm of skin of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372127000",
+        "display": "Carcinoma of skin of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372128005",
+        "display": "Malignant neoplasm of skin of upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372129002",
+        "display": "Carcinoma of skin of upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372130007",
+        "display": "Malignant neoplasm of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372131006",
+        "display": "Malignant neoplasm of upper limb bones and scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372133009",
+        "display": "Primary malignant neoplasm of upper limb bones and scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372137005",
+        "display": "Primary malignant neoplasm of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372138000",
+        "display": "Carcinoma of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372139008",
+        "display": "Primary malignant neoplasm of gallbladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372140005",
+        "display": "Carcinoma of gallbladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372141009",
+        "display": "Carcinoma of vocal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372142002",
+        "display": "Carcinoma of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372143007",
+        "display": "Carcinoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372244006",
+        "display": "Malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373080008",
+        "display": "Malignant neoplasm of breast lower inner quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373081007",
+        "display": "Malignant neoplasm of breast lower outer quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373082000",
+        "display": "Malignant neoplasm of breast upper inner quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373083005",
+        "display": "Malignant neoplasm of breast upper outer quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373088001",
+        "display": "Primary malignant neoplasm of breast upper outer quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373089009",
+        "display": "Primary malignant neoplasm of breast upper inner quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373090000",
+        "display": "Primary malignant neoplasm of breast lower inner quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373091001",
+        "display": "Primary malignant neoplasm of breast lower outer quadrant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373168002",
+        "display": "Reticulosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "373888000",
+        "display": "Extrauterine adenocarcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385478001",
+        "display": "Adenoma malignum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "389216001",
+        "display": "Diaphyseal medullary stenosis with bone malignancy (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "393563007",
+        "display": "Glioblastoma multiforme"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "396198006",
+        "display": "Small cell carcinoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "397008008",
+        "display": "Aggressive lymphadenopathic mastocytosis with eosinophilia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "397009000",
+        "display": "Mast cell malignancy (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "397011009",
+        "display": "Mast cell malignancy of lymph nodes (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "397015000",
+        "display": "Systemic mastocytosis with associated clonal hematological non-mast cell lineage disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "398623004",
+        "display": "Refractory anemia with excess blasts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "398903003",
+        "display": "Pleomorphic malignant fibrous histiocytoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399068003",
+        "display": "Malignant tumor of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399326009",
+        "display": "Malignant tumor of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399490008",
+        "display": "Adenocarcinoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399590005",
+        "display": "Squamous cell carcinoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399660006",
+        "display": "Ring melanoma of ciliary body (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399884001",
+        "display": "Primary malignant neoplasm of blood vessel of upper arm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399897004",
+        "display": "Basal cell carcinoma of postauricular skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399934007",
+        "display": "Basal cell carcinoma of preauricular skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399954008",
+        "display": "Basal cell carcinoma of earlobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400001003",
+        "display": "Primary cutaneous lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400057007",
+        "display": "Basal cell carcinoma of pinnal sulcus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400074007",
+        "display": "Primary malignant neoplasm of blood vessel of lower leg (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400122007",
+        "display": "Primary cutaneous T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400173004",
+        "display": "Eccrine carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400174005",
+        "display": "Basal cell carcinoma of antihelix of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400175006",
+        "display": "Myxofibrosarcoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402494003",
+        "display": "Basal cell carcinoma of lower eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402495002",
+        "display": "Basal cell carcinoma of medial canthus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402496001",
+        "display": "Basal cell carcinoma of lateral canthus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402497005",
+        "display": "Basal cell carcinoma of root of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402498000",
+        "display": "Basal cell carcinoma of dorsum of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402499008",
+        "display": "Basal cell carcinoma of lateral side wall of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402500004",
+        "display": "Basal cell carcinoma of ala nasi (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402501000",
+        "display": "Basal cell carcinoma of supratip of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402502007",
+        "display": "Basal cell carcinoma of tip of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402503002",
+        "display": "Basal cell carcinoma of nasal columella (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402504008",
+        "display": "Basal cell carcinoma of nasolabial groove (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402505009",
+        "display": "Basal cell carcinoma of upper lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402506005",
+        "display": "Basal cell carcinoma of lower lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402507001",
+        "display": "Basal cell carcinoma of cheek (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402508006",
+        "display": "Basal cell carcinoma of chin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402509003",
+        "display": "Basal cell carcinoma of neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402510008",
+        "display": "Basal cell carcinoma of helix of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402511007",
+        "display": "Basal cell carcinoma of conchal bowl of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402512000",
+        "display": "Basal cell carcinoma of antitragus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402513005",
+        "display": "Basal cell carcinoma of tragus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402514004",
+        "display": "Basal cell carcinoma of obverse of pinna (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402515003",
+        "display": "Basal cell carcinoma of anterior chest (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402516002",
+        "display": "Basal cell carcinoma of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402517006",
+        "display": "Basal cell carcinoma of upper back (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402518001",
+        "display": "Basal cell carcinoma of lower back (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402519009",
+        "display": "Basal cell carcinoma of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402520003",
+        "display": "Basal cell carcinoma of hand (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402521004",
+        "display": "Basal cell carcinoma of upper extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402522006",
+        "display": "Basal cell carcinoma of lower extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402523001",
+        "display": "Basal cell carcinoma of truncal skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402524007",
+        "display": "Basal cell carcinoma - adamantinoid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402525008",
+        "display": "Basal cell carcinoma - adenoid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402526009",
+        "display": "Basal cell carcinoma - follicular (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402527000",
+        "display": "Basal cell carcinoma - infiltrative (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402528005",
+        "display": "Basal cell carcinoma - keratotic (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402529002",
+        "display": "Basal cell carcinoma - micronodular (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402530007",
+        "display": "Basal cell carcinoma with matrical differentiation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402531006",
+        "display": "Basal cell carcinoma with granular cell change (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402532004",
+        "display": "Basal cell carcinoma with monster cells (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402533009",
+        "display": "Basal cell carcinoma with sebaceous differentiation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402534003",
+        "display": "Basal cell carcinoma with signet ring change (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402536001",
+        "display": "Basal cell carcinoma - primary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402538000",
+        "display": "Recurrent basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402539008",
+        "display": "Basal cell carcinoma recurrent following excision (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402540005",
+        "display": "Basal cell carcinoma recurrent following Mohs' excision (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402541009",
+        "display": "Basal cell carcinoma recurrent following curettage (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402542002",
+        "display": "Basal cell carcinoma recurrent following cryosurgery (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402543007",
+        "display": "Basal cell carcinoma recurrent following radiotherapy (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402544001",
+        "display": "Basal cell carcinoma - first recurrence (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402545000",
+        "display": "Basal cell carcinoma - second recurrence (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402546004",
+        "display": "Basal cell carcinoma - third recurrence (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402547008",
+        "display": "Basal cell carcinoma - multiple recurrences (more than three times) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402558004",
+        "display": "Malignant melanoma (vertical growth phase) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402559007",
+        "display": "Congenital malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402560002",
+        "display": "Materno-fetal metastatic malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402561003",
+        "display": "Malignant melanoma of soft tissues (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402562005",
+        "display": "Malignant melanoma animal-type (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402564006",
+        "display": "Multiple primary malignant melanomata (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402636006",
+        "display": "Malignant neoplasm of nail apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402652009",
+        "display": "Malignant vascular tumor of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402815007",
+        "display": "Squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402816008",
+        "display": "Squamous cell carcinoma of anogenital area (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402817004",
+        "display": "Squamous cell carcinoma of nail apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402818009",
+        "display": "Basal cell carcinoma of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402819001",
+        "display": "Basal cell carcinoma of skin of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402820007",
+        "display": "Basal cell carcinoma of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402871009",
+        "display": "Malignant neoplasm of subcutaneous fibrous tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402873007",
+        "display": "Malignant fibrohistiocytic tumor of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402876004",
+        "display": "Malignant tumor of nerve sheath origin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402880009",
+        "display": "Primary cutaneous large T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402881008",
+        "display": "Primary cutaneous B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402882001",
+        "display": "Hodgkin's disease affecting skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402910001",
+        "display": "Anogenital verrucous carcinoma of Buschke-LÃ¶wenstein (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402911002",
+        "display": "Penile verrucous carcinoma of Buschke-LÃ¶wenstein (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402912009",
+        "display": "Vulval verrucous carcinoma of Buschke-LÃ¶wenstein (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403274000",
+        "display": "Hypomelanosis surrounding malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403458008",
+        "display": "Localized skin involvement by breast carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403468003",
+        "display": "Squamous cell carcinoma of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403711001",
+        "display": "PUVA therapy-associated skin malignancy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403712008",
+        "display": "PUVA therapy-associated basal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403713003",
+        "display": "PUVA therapy-associated squamous cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403714009",
+        "display": "PUVA therapy-associated malignant melanoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403729006",
+        "display": "Radiation-induced skin malignancy (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403742006",
+        "display": "Arsenic-induced skin malignancy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403889000",
+        "display": "Verrucous carcinoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403890009",
+        "display": "Squamous cell carcinoma of vulva due to lichen sclerosus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403891008",
+        "display": "Squamous cell carcinoma of scalp (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403892001",
+        "display": "Squamous cell carcinoma of skin of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403893006",
+        "display": "Squamous cell carcinoma of forehead (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403894000",
+        "display": "Squamous cell carcinoma of skin of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403895004",
+        "display": "Squamous cell carcinoma of foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403896003",
+        "display": "Squamous cell carcinoma of hand (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403897007",
+        "display": "Squamous cell carcinoma of upper extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403898002",
+        "display": "Squamous cell carcinoma of skin of lower extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403899005",
+        "display": "Squamous cell carcinoma of skin of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403900000",
+        "display": "Spindle cell squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403901001",
+        "display": "Acantholytic squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403902008",
+        "display": "Adenosquamous cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403903003",
+        "display": "Signet ring squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403904009",
+        "display": "Verrucous squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403905005",
+        "display": "Multiple squamous cell carcinomata (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403909004",
+        "display": "Pigmented basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403910009",
+        "display": "Circumscribed solid basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403911008",
+        "display": "Nodulo-ulcerative basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403912001",
+        "display": "Cystic basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403913006",
+        "display": "Morpheic basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403914000",
+        "display": "Superficial basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403915004",
+        "display": "Basal cell carcinoma of scalp (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403916003",
+        "display": "Basal cell carcinoma of forehead (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403917007",
+        "display": "Basal cell carcinoma of temple (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403918002",
+        "display": "Basal cell carcinoma of glabella (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403919005",
+        "display": "Basal cell carcinoma of upper eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403920004",
+        "display": "Minimal deviation malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403921000",
+        "display": "Borderline malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403922007",
+        "display": "Balloon cell malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403923002",
+        "display": "Spindle cell malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403924008",
+        "display": "Desmoplastic malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403925009",
+        "display": "Neurotropic malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403926005",
+        "display": "Malignant melanoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403927001",
+        "display": "Malignant melanoma of nail apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403929003",
+        "display": "Trichilemmal carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403939009",
+        "display": "Eccrine ductal carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403940006",
+        "display": "Clear cell eccrine hidradenocarcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403941005",
+        "display": "Malignant cylindroma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403942003",
+        "display": "Malignant eccrine spiradenoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403943008",
+        "display": "Malignant chondroid syringoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403944002",
+        "display": "Small cell eccrine carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403946000",
+        "display": "Paget's disease of nipple (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403947009",
+        "display": "Perianal Paget's disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403949007",
+        "display": "Apocrine adenocarcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403950007",
+        "display": "Moll's gland adenocarcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403951006",
+        "display": "Ceruminous gland adenocarcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403954003",
+        "display": "Mixed eccrine/pilar adnexal carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403955002",
+        "display": "Undifferentiated adnexal carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403977003",
+        "display": "Angiosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403978008",
+        "display": "Kaposi's sarcoma - sporadic (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403979000",
+        "display": "Endemic Kaposi sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403981003",
+        "display": "Epithelioid hemangioendothelioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403986008",
+        "display": "Lymphangiosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403996004",
+        "display": "Infantile fibrosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404014008",
+        "display": "Malignant fibrous histiocytoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404015009",
+        "display": "Superficial malignant fibrous histiocytoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404016005",
+        "display": "Giant cell malignant fibrous histiocytoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404017001",
+        "display": "Inflammatory malignant fibrous histiocytoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404037002",
+        "display": "Malignant peripheral nerve sheath tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404038007",
+        "display": "Epithelioid malignant nerve sheath tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404039004",
+        "display": "Melanotic malignant nerve sheath tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404040002",
+        "display": "Malignant Triton tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404041003",
+        "display": "Malignant granular cell tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404045007",
+        "display": "Epithelioid leiomyosarcoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404046008",
+        "display": "Myxoid leiomyosarcoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404047004",
+        "display": "Cutaneous leiomyosarcoma with granular cell change (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404051002",
+        "display": "Embryonal rhabdomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404052009",
+        "display": "Botryoid rhabdomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404053004",
+        "display": "Alveolar rhabdomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404054005",
+        "display": "Pleomorphic rhabdomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404055006",
+        "display": "Spindle cell rhabdomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404056007",
+        "display": "Alveolar soft part sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404067008",
+        "display": "Adipocytic liposarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404068003",
+        "display": "Sclerosing liposarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404069006",
+        "display": "Myxoid liposarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404071006",
+        "display": "Pleomorphic liposarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404072004",
+        "display": "Dedifferentiated liposarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404073009",
+        "display": "Spindle cell liposarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404077005",
+        "display": "Extraskeletal osteosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404079008",
+        "display": "Extraskeletal myxoid chondrosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404080006",
+        "display": "Extraskeletal mesenchymal chondrosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404081005",
+        "display": "Yolk sac tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404087009",
+        "display": "Carcinosarcoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404088004",
+        "display": "Low-grade fibromyxoid sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404089007",
+        "display": "Extrarenal rhabdoid tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404106004",
+        "display": "Lymphomatoid papulosis with Hodgkin's disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404107008",
+        "display": "Patch/plaque stage mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404108003",
+        "display": "Poikilodermatous mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404109006",
+        "display": "Follicular mucinosis type mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404110001",
+        "display": "Hypomelanotic mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404111002",
+        "display": "Lymphomatoid papulosis-associated mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404112009",
+        "display": "Granulomatous mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404113004",
+        "display": "Tumor stage mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404114005",
+        "display": "Erythrodermic mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404115006",
+        "display": "Bullous mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404116007",
+        "display": "Mycosis fungoides with systemic infiltration (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404117003",
+        "display": "Spongiotic mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404118008",
+        "display": "Syringotropic mycosis fungoides (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404119000",
+        "display": "Pagetoid reticulosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404120006",
+        "display": "Localized pagetoid reticulosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404121005",
+        "display": "Generalized pagetoid reticulosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404126000",
+        "display": "CD-30 positive pleomorphic large T-cell cutaneous lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404127009",
+        "display": "CD-30 positive T-immunoblastic cutaneous lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404128004",
+        "display": "CD-30 negative cutaneous T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404129007",
+        "display": "CD-30 negative anaplastic large T-cell cutaneous lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404130002",
+        "display": "CD-30 negative pleomorphic large T-cell cutaneous lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404131003",
+        "display": "CD-30 negative T-immunoblastic cutaneous lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404133000",
+        "display": "Subcutaneous panniculitic cutaneous T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404134006",
+        "display": "Anaplastic large T-cell systemic malignant lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404135007",
+        "display": "Angiocentric NK/T-cell malignant lymphoma involving skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404136008",
+        "display": "Aggressive NK-cell leukemia involving skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404137004",
+        "display": "Precursor B-cell lymphoblastic lymphoma involving skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404138009",
+        "display": "Small lymphocytic B-cell lymphoma involving skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404140004",
+        "display": "Primary cutaneous marginal zone B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404141000",
+        "display": "Primary cutaneous immunocytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404142007",
+        "display": "Primary cutaneous plasmacytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404143002",
+        "display": "Crosti's lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404144008",
+        "display": "Primary cutaneous diffuse large cell B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404147001",
+        "display": "Follicular center B-cell lymphoma (nodal/systemic with skin involvement) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404148006",
+        "display": "Diffuse large B-cell lymphoma (nodal/systemic with skin involvement) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404149003",
+        "display": "Lymphoplasmacytic B-cell lymphoma, nodal/systemic with skin involvement (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404150003",
+        "display": "Mantle cell B-cell lymphoma (nodal/systemic with skin involvement) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404155008",
+        "display": "Granulocytic sarcoma affecting skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404169008",
+        "display": "Malignant histiocytosis involving skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404172001",
+        "display": "Mast cell leukemia affecting skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404664002",
+        "display": "Malignant optic glioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404810003",
+        "display": "5-HT secreting neuroendocrine tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "405546008",
+        "display": "Malignant pericardial effusion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "405822008",
+        "display": "Squamous cell carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "405945003",
+        "display": "Malignant neoplasm of metatarsal bone of foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408642003",
+        "display": "Transitional cell carcinoma of kidney (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408643008",
+        "display": "Infiltrating duct carcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408644002",
+        "display": "Adenocarcinoma of duodenum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408645001",
+        "display": "Adenocarcinoma of large intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408646000",
+        "display": "Adenocarcinoma of liver (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408647009",
+        "display": "Adenocarcinoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408648004",
+        "display": "Squamous cell carcinoma of epiglottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "408649007",
+        "display": "Squamous cell carcinoma of pharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413389003",
+        "display": "Accelerated phase chronic myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413441006",
+        "display": "Acute monocytic leukemia, FAB M5b (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413442004",
+        "display": "Acute monocytic/monoblastic leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413445002",
+        "display": "Adenocarcinoma of appendix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413446001",
+        "display": "Adenocarcinoma of cecum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413537009",
+        "display": "Angioimmunoblastic T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413587002",
+        "display": "Smoldering multiple myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413656006",
+        "display": "Blastic phase chronic myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413842007",
+        "display": "Chronic myeloid leukemia in lymphoid blast crisis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413843002",
+        "display": "Chronic myeloid leukemia in myeloid blast crisis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "413847001",
+        "display": "Chronic phase chronic myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "414166008",
+        "display": "Extranodal NK/T-cell lymphoma, nasal type"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "414553000",
+        "display": "Kappa light chain myeloma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "414780005",
+        "display": "Mucosa-associated lymphoid tissue (MALT) lymphoma of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "414785000",
+        "display": "Multiple solitary plasmacytomas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415110002",
+        "display": "Plasma cell myeloma/plasmacytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415112005",
+        "display": "Plasmacytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415177008",
+        "display": "Primary malignant neoplasm of ear, nose AND/OR throat (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415283002",
+        "display": "Refractory anemia with excess blasts-1"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415284008",
+        "display": "Refractory anemia with excess blasts-2"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415285009",
+        "display": "Refractory cytopenia with multilineage dysplasia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415286005",
+        "display": "Refractory cytopenia with multilineage dysplasia and ringed sideroblasts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "415287001",
+        "display": "Relapsing chronic myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "416769008",
+        "display": "Malignant teratoma of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "416842003",
+        "display": "Malignant sacral teratoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "416901002",
+        "display": "Malignant medulloepithelioma of ciliary body (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "417181009",
+        "display": "Hormone receptor positive malignant neoplasm of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "417417007",
+        "display": "Malignant teratoma of undescended testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "417554000",
+        "display": "Malignant teratoma of descended testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "417570003",
+        "display": "Gestational choriocarcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "418372008",
+        "display": "Squamous cell carcinoma of mucous membrane of lower lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "419052002",
+        "display": "Malignant tumor of urinary system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "419240004",
+        "display": "Squamous cell carcinoma of mucous membrane of upper lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "419842002",
+        "display": "Squamous cell carcinoma of oral mucous membrane (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "420302007",
+        "display": "Reticulosarcoma with AIDS (acquired immunodeficiency syndrome)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "420519005",
+        "display": "Malignant lymphoma of the eye region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "420524008",
+        "display": "Kaposi's sarcoma with acquired immunodeficiency syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "420788006",
+        "display": "Intraocular non-Hodgkin malignant lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "420890002",
+        "display": "Precursor T cell lymphoblastic leukemia/lymphoblastic lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "421246008",
+        "display": "Precursor T-cell lymphoblastic lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "421249001",
+        "display": "Malignant tumor of vermilion border of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "421283008",
+        "display": "Primary lymphoma of brain with acquired immunodeficiency syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422282000",
+        "display": "Malignant neoplasm with acquired immunodeficiency syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422378004",
+        "display": "Squamous cell carcinoma of bridge of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422541001",
+        "display": "Undifferentiated carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422572002",
+        "display": "Squamous cell carcinoma of chin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422599000",
+        "display": "Squamous cell carcinoma of back (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422676009",
+        "display": "Squamous cell carcinoma of ala nasi (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422691006",
+        "display": "Squamous cell carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422736007",
+        "display": "Primary malignant neoplasm of peripheral nerve (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422758009",
+        "display": "Carcinoma of nasal meatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422833009",
+        "display": "Adenoid cystic carcinoma of salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422853008",
+        "display": "Lymphoma of retroperitoneal space (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422886007",
+        "display": "Olfactory neuroblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422968005",
+        "display": "Non-small cell carcinoma of lung, TNM stage 3 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423005002",
+        "display": "Primary malignant neoplasm of lacrimal gland duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423038006",
+        "display": "Polymorphous low grade adenocarcinoma of salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423050000",
+        "display": "Large cell carcinoma of lung, TNM stage 2 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423106003",
+        "display": "Adenocarcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423121009",
+        "display": "Non-small cell carcinoma of lung, TNM stage 4 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423158009",
+        "display": "Hurthle cell carcinoma of thyroid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423189008",
+        "display": "Adenoid cystic carcinoma of submandibular gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423195009",
+        "display": "Primary malignant neoplasm of lacrimal drainage system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423280002",
+        "display": "Malignant melanoma of skin of canthus of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423284006",
+        "display": "Squamous cell carcinoma of skin of neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423295000",
+        "display": "Squamous cell carcinoma of lung, TNM stage 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423318000",
+        "display": "Adenoid cystic carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423325007",
+        "display": "Basal cell carcinoma of external auditory canal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423349005",
+        "display": "Carcinoma of tip of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423424005",
+        "display": "Mucoepidermoid carcinoma of submandibular gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423425006",
+        "display": "Malignant neoplasm of skin of eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423447006",
+        "display": "Malignant melanoma of skin of lower eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423463003",
+        "display": "Basal cell carcinoma of back (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423464009",
+        "display": "Squamous cell carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423468007",
+        "display": "Squamous cell carcinoma of lung, TNM stage 2 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423494003",
+        "display": "Malignant melanoma of skin of upper eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423506005",
+        "display": "Squamous cell carcinoma of external auditory canal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423535002",
+        "display": "Basal cell carcinoma of chest wall (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423600008",
+        "display": "Large cell carcinoma of lung, TNM stage 4 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423607006",
+        "display": "Adenocarcinoma of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423610004",
+        "display": "Rhabdomyosarcoma of connective or soft tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423615009",
+        "display": "Adenoid cystic carcinoma of parotid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423627007",
+        "display": "Sarcoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423673009",
+        "display": "Malignant melanoma of retina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423691004",
+        "display": "Malignant neoplasm of gum and contiguous sites (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423700001",
+        "display": "Squamous cell carcinoma of auricle of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423708008",
+        "display": "Mucoepidermoid carcinoma of salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423746001",
+        "display": "Adenocarcinoma of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423793008",
+        "display": "Mucoepidermoid carcinoma of parotid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423807009",
+        "display": "Primary leiomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423812005",
+        "display": "Sarcoma of head and neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423829008",
+        "display": "Invasive vulval Paget's disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423896007",
+        "display": "Squamous cell carcinoma of tip of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423973006",
+        "display": "Carcinoma of uterine cervix, invasive (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424132000",
+        "display": "Non-small cell carcinoma of lung, TNM stage 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424151006",
+        "display": "Anaplastic glioma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424190005",
+        "display": "Malignant melanoma of unknown origin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424260006",
+        "display": "Squamous cell carcinoma of nasolabial fold (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424276002",
+        "display": "Malignant glioma of brainstem (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424302003",
+        "display": "Malignant melanoma of skin of lower lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424334007",
+        "display": "Malignant tumor of spinal cord, intramedullary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424413001",
+        "display": "Sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424440001",
+        "display": "Adenocarcinoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424487008",
+        "display": "Malignant melanoma of skin of upper lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424549003",
+        "display": "Malignant tumor of spinal cord, extramedullary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424666005",
+        "display": "Basal cell carcinoma of auricle of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424779008",
+        "display": "Primary Kaposi's sarcoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424849005",
+        "display": "Primary sarcoma of tongue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424938000",
+        "display": "Large cell carcinoma of lung, TNM stage 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424952003",
+        "display": "Sarcoma of soft tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424970000",
+        "display": "Large cell carcinoma of lung, TNM stage 3 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425048006",
+        "display": "Non-small cell carcinoma of lung, TNM stage 2 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425066001",
+        "display": "Carcinoma of urinary bladder, invasive (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425127006",
+        "display": "Carcinoma ex pleomorphic adenoma of parotid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425148008",
+        "display": "Squamous cell carcinoma of temple (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425178004",
+        "display": "Adenocarcinoma of rectosigmoid junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425225007",
+        "display": "Malignant mixed tumor of salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425230006",
+        "display": "Squamous cell carcinoma of lung, TNM stage 3 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425231005",
+        "display": "Carcinoma of urinary bladder, superficial (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425376008",
+        "display": "Squamous cell carcinoma of lung, TNM stage 4 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425657001",
+        "display": "Osteosclerotic myeloma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425688002",
+        "display": "Philadelphia chromosome-positive acute lymphoblastic leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425749006",
+        "display": "Subacute myeloid leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425869007",
+        "display": "Acute promyelocytic leukemia, FAB M3, in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425941003",
+        "display": "Pre B-cell acute lymphoblastic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426071002",
+        "display": "Hodgkin's disease in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426124006",
+        "display": "Acute myeloid leukemia with maturation, FAB M2, in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426217000",
+        "display": "Aleukemic leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426248008",
+        "display": "Aleukemic lymphoid leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426336007",
+        "display": "Solitary osseous myeloma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426370008",
+        "display": "Subacute lymphoid leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426642002",
+        "display": "Erythroleukemia, FAB M6 in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426885008",
+        "display": "Hodgkin's disease, lymphocytic depletion of lymph nodes of head (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426964009",
+        "display": "Non-small cell lung cancer, positive for epidermal growth factor receptor expression (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427038005",
+        "display": "Non-small cell lung cancer, negative for epidermal growth factor receptor expression (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427056005",
+        "display": "Subacute leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427141003",
+        "display": "Malignant lymphoma in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427492003",
+        "display": "Hormone refractory prostate cancer (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427642009",
+        "display": "T-cell acute lymphoblastic leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427658007",
+        "display": "Acute myelomonocytic leukemia, FAB M4, in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427685000",
+        "display": "HER2-positive carcinoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428061005",
+        "display": "Malignant neoplasm of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428100006",
+        "display": "Malignant neoplasm of thoracic cavity structure (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428281000",
+        "display": "Malignant neoplasm of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428322007",
+        "display": "Malignant neoplasm of uterine adnexa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428905002",
+        "display": "Malignant neoplasm of gastrointestinal tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "429033009",
+        "display": "Malignant neoplasm of cerebrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "429114002",
+        "display": "Malignant basal cell neoplasm of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "430338009",
+        "display": "Smoldering chronic lymphocytic leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "430556008",
+        "display": "Malignant neoplasm of genital structure (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "430621000",
+        "display": "Malignant neoplasm of lower respiratory tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "431396003",
+        "display": "Human epidermal growth factor 2 negative carcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "432328008",
+        "display": "Neuroblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "433067002",
+        "display": "Adamantinoma of femur (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "438946002",
+        "display": "Siewert type I adenocarcinoma of esophagogastric junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "439478008",
+        "display": "Siewert type III adenocarcinoma of esophagogastric junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "440173001",
+        "display": "Nonsquamous nonsmall cell neoplasm of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "440397000",
+        "display": "Primary osteosarcoma of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "440422002",
+        "display": "Asymptomatic multiple myeloma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "440501006",
+        "display": "Siewert type II adenocarcinoma of esophagogastric junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "440525003",
+        "display": "Primary small cell neoplasm of thymus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "440527006",
+        "display": "Primary squamous cell carcinoma of naris (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "441313008",
+        "display": "Indolent multiple myeloma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "441535001",
+        "display": "Adenocarcinoma of head and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "441559006",
+        "display": "Mantle cell lymphoma of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "441962003",
+        "display": "Large cell lymphoma of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "442537007",
+        "display": "Non-Hodgkin lymphoma associated with Human immunodeficiency virus infection"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443136000",
+        "display": "Malignant neoplasm of skin of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443250000",
+        "display": "Malignant fibromatous neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443261008",
+        "display": "Oxyphilic adenocarcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443333004",
+        "display": "Medulloblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443439001",
+        "display": "Malignant fibrous histiocytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443487006",
+        "display": "Mantle cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443488001",
+        "display": "Malignant neoplasm of anorectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443520009",
+        "display": "Chondrosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443648003",
+        "display": "Malignant neoplasm of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443675005",
+        "display": "Seminoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443679004",
+        "display": "Malignant neoplasm of skeletal system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443719001",
+        "display": "Leiomyosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443936004",
+        "display": "Oligodendroglioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443937008",
+        "display": "Mixed glioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443961001",
+        "display": "Malignant adenomatous neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444374006",
+        "display": "Type C thymoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444596001",
+        "display": "Malignant thymoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444597005",
+        "display": "Extranodal marginal zone lymphoma of mucosa-associated lymphoid tissue of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444604002",
+        "display": "Carcinoma of breast with ductal and lobular features (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444712000",
+        "display": "Mucinous carcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444910004",
+        "display": "Primary mediastinal (thymic) large B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444911000",
+        "display": "Acute myeloid leukemia with t(9:11)(p22;q23); MLLT3-MLL (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "445105005",
+        "display": "Blastic plasmacytoid dendritic cell neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "445227008",
+        "display": "Juvenile myelomonocytic leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "445238008",
+        "display": "Malignant carcinoid tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "445269007",
+        "display": "Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue (MALT-lymphoma)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "445406001",
+        "display": "Hepatosplenic T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "445448008",
+        "display": "Acute myeloid leukemia with myelodysplasia-related changes (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "446022000",
+        "display": "Malignant epithelial neoplasm of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "446189008",
+        "display": "Primary malignant neoplasm of extrahepatic bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "446807009",
+        "display": "Primary malignant neoplasm of perihilar bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "446939001",
+        "display": "Chordoma of clivus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447100004",
+        "display": "Marginal zone lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447109003",
+        "display": "Primary malignant neoplasm of intrahepatic bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447266004",
+        "display": "Sarcoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447389009",
+        "display": "Leiomyosarcoma of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447390000",
+        "display": "Adenosarcoma of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447416008",
+        "display": "Primary malignant neoplasm of distal bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447656001",
+        "display": "Lymphoma of pylorus of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447658000",
+        "display": "Lymphoma of fundus of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447705002",
+        "display": "Malignant germ cell neoplasm of posterior mediastinum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447706001",
+        "display": "Leiomyosarcoma of scalp (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447707005",
+        "display": "Leiomyosarcoma of cardia of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447708000",
+        "display": "Malignant germ cell neoplasm of anterior mediastinum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447712006",
+        "display": "Malignant melanoma of skin of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447730004",
+        "display": "Chordoma of sacrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447738006",
+        "display": "Paget's disease of skin of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447757002",
+        "display": "Angiosarcoma of cheek (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447766003",
+        "display": "Lymphoma of pyloric antrum of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447781009",
+        "display": "Malignant epithelial neoplasm of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447782002",
+        "display": "Malignant epithelial neoplasm of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447783007",
+        "display": "Sarcoma of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447784001",
+        "display": "Sarcoma of axillary tail of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447785000",
+        "display": "Leiomyosarcoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447792005",
+        "display": "Chondrosarcoma of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447800002",
+        "display": "Adenocarcinoma of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447804006",
+        "display": "Leiomyosarcoma of connective tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447805007",
+        "display": "Lymphoma of greater curvature of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447806008",
+        "display": "Lymphoma of cardia of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447882007",
+        "display": "Malignant epithelial neoplasm of vulva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447883002",
+        "display": "Malignant neoplasm of carotid body (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447885009",
+        "display": "Sarcoma of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447886005",
+        "display": "Adenocarcinoma of anorectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447949005",
+        "display": "Malignant epithelial neoplasm of cheek (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447951009",
+        "display": "Ewing's sarcoma of soft tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447989004",
+        "display": "Non-Hodgkin's lymphoma of extranodal site (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448139005",
+        "display": "Fibrosarcoma of connective tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448165009",
+        "display": "Squamous cell carcinoma arising in chronic ulcer (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448213004",
+        "display": "Diffuse non-Hodgkin's lymphoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448214005",
+        "display": "Malignant epithelial neoplasm of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448215006",
+        "display": "Malignant epithelial neoplasm of renal pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448216007",
+        "display": "Malignant epithelial neoplasm of thyroid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448217003",
+        "display": "Follicular non-Hodgkin's lymphoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448218008",
+        "display": "Malignant neoplasm of cerebellopontine angle (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448220006",
+        "display": "Non-Hodgkin's lymphoma of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448221005",
+        "display": "Sarcoma of fibula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448229007",
+        "display": "Leiomyosarcoma of lower esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448231003",
+        "display": "Follicular non-Hodgkin's lymphoma of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448233000",
+        "display": "Malignant neoplasm of urinary organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448248006",
+        "display": "Malignant neoplasm of axial suprasellar region of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448250003",
+        "display": "Malignant teratoma of pineal region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448254007",
+        "display": "Non-Hodgkin's lymphoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448257000",
+        "display": "Sarcoma of male breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448258005",
+        "display": "Sarcoma of mesentery (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448259002",
+        "display": "Sarcoma of posterior mediastinum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448269008",
+        "display": "Lymphoma of lesser curvature of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448273006",
+        "display": "Malignant melanoma of skin of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448274000",
+        "display": "Malignant neoplasm of connective tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448298007",
+        "display": "Malignant melanoma of skin of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448299004",
+        "display": "Malignant neoplasm of mastoid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448300007",
+        "display": "Malignant melanoma of skin of vulva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448314007",
+        "display": "Malignant epithelial neoplasm of spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448315008",
+        "display": "Malignant epithelial neoplasm of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448317000",
+        "display": "Follicular non-Hodgkin's lymphoma of soft tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448319002",
+        "display": "Diffuse non-Hodgkin's lymphoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448354009",
+        "display": "Non-Hodgkin's lymphoma of intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448371005",
+        "display": "Non-Hodgkin's lymphoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448372003",
+        "display": "Non-Hodgkin's lymphoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448376000",
+        "display": "Non-Hodgkin's lymphoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448377009",
+        "display": "Sarcoma of sacrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448378004",
+        "display": "Sarcoma of bone of foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448384001",
+        "display": "Non-Hodgkin's lymphoma of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448386004",
+        "display": "Non-Hodgkin's lymphoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448387008",
+        "display": "Non-Hodgkin's lymphoma of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448388003",
+        "display": "Sarcoma of lower outer quadrant of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448401007",
+        "display": "Choriocarcinoma of placenta (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448408001",
+        "display": "Sarcoma of upper inner quadrant of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448435005",
+        "display": "Sarcoma lower inner quadrant of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448436006",
+        "display": "Sarcoma of central portion of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448447004",
+        "display": "Non-Hodgkin's lymphoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448449001",
+        "display": "Sarcoma of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448450001",
+        "display": "Sarcoma of omentum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448451002",
+        "display": "Sarcoma upper outer quadrant of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448465000",
+        "display": "Diffuse non-Hodgkin's lymphoma of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448468003",
+        "display": "Diffuse non-Hodgkin's lymphoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448509007",
+        "display": "Transglottic malignant neoplasm of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448553002",
+        "display": "Lymphoma of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448554008",
+        "display": "Liposarcoma of connective tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448555009",
+        "display": "Lymphoma of body of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448558006",
+        "display": "Malignant neoplasm of maxillofacial bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448559003",
+        "display": "Malignant teratoma of retroperitoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448560008",
+        "display": "Diffuse non-Hodgkin's lymphoma of extranodal site (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448561007",
+        "display": "Follicular non-Hodgkin's lymphoma of extranodal site (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448607004",
+        "display": "Diffuse non-Hodgkin's lymphoma of uterine cervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448609001",
+        "display": "Diffuse non-Hodgkin's lymphoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448663003",
+        "display": "Diffuse non-Hodgkin's lymphoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448664009",
+        "display": "Malignant epithelial neoplasm of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448665005",
+        "display": "Malignant epithelial neoplasm of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448666006",
+        "display": "Follicular non-Hodgkin's lymphoma of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448668007",
+        "display": "Malignant neoplasm of mandible (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448669004",
+        "display": "Malignant neoplasm of soft tissue of orbit (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448670003",
+        "display": "Malignant neoplasm of posterior mediastinum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448672006",
+        "display": "Follicular non-Hodgkin's lymphoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448674007",
+        "display": "Malignant neoplasm of parametrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448675008",
+        "display": "Malignant neoplasm of digestive system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448709005",
+        "display": "Non-Hodgkin's lymphoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448710000",
+        "display": "Sarcoma of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448711001",
+        "display": "Sarcoma of back (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448712008",
+        "display": "Sarcoma of femur (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448738008",
+        "display": "Non-Hodgkin's lymphoma of soft tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448774004",
+        "display": "Non-Hodgkin's lymphoma of uterine cervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448775003",
+        "display": "Sarcoma of radius (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448776002",
+        "display": "Sarcoma of vertebra (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448863000",
+        "display": "Malignant epithelial neoplasm of pineal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448864006",
+        "display": "Malignant epithelial neoplasm of ureter (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448865007",
+        "display": "Follicular non-Hodgkin's lymphoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448867004",
+        "display": "Diffuse non-Hodgkin's lymphoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448868009",
+        "display": "Malignant neoplasm of lateral wall of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448882009",
+        "display": "Malignant neoplasm of intraabdominal organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448930008",
+        "display": "Squamous cell carcinoma of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448931007",
+        "display": "Squamous cell carcinoma of shoulder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448952004",
+        "display": "Infiltrating duct carcinoma of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448954003",
+        "display": "Malignant epithelial neoplasm of urethra (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448988009",
+        "display": "Malignant epithelial neoplasm of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448989001",
+        "display": "Malignant epithelial neoplasm of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448990005",
+        "display": "Malignant epithelial neoplasm of nasal cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448992002",
+        "display": "Malignant epithelial neoplasm of appendix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448993007",
+        "display": "Malignant epithelial neoplasm of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448994001",
+        "display": "Malignant epithelial neoplasm of upper rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448995000",
+        "display": "Follicular non-Hodgkin's lymphoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449034009",
+        "display": "Malignant neoplasm of anterior and lateral floor of mouth (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449053004",
+        "display": "Lymphoma of lower esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449054005",
+        "display": "Malignant epithelial neoplasm of fundus of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449055006",
+        "display": "Leiomyosarcoma of cardioesophageal junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449058008",
+        "display": "Follicular non-Hodgkin's lymphoma of tonsil (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449059000",
+        "display": "Follicular non-Hodgkin's lymphoma of uterine cervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449063007",
+        "display": "Follicular non-Hodgkin's lymphoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449065000",
+        "display": "Diffuse non-Hodgkin's lymphoma of nose (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449066004",
+        "display": "Malignant neoplasm of upper respiratory tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449067008",
+        "display": "Malignant neoplasm of parietal pleura (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449072004",
+        "display": "Lymphoma of gastrointestinal tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449073009",
+        "display": "Malignant epithelial neoplasm of body of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449074003",
+        "display": "Lymphoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449075002",
+        "display": "Lymphoma of cardioesophageal junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449077005",
+        "display": "Malignant epithelial neoplasm of maxilla (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449096009",
+        "display": "Malignant neoplasm of respiratory system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449100005",
+        "display": "Sarcoma of bone of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449101009",
+        "display": "Sarcoma of sternum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449108003",
+        "display": "Philadelphia chromosome positive chronic myelogenous leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449153001",
+        "display": "Adenocarcinoma of lower esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449156009",
+        "display": "Malignant epithelial neoplasm of floor of mouth (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449173006",
+        "display": "Diffuse non-Hodgkin's lymphoma of tonsil (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449176003",
+        "display": "Diffuse non-Hodgkin's lymphoma of intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449177007",
+        "display": "Diffuse non-Hodgkin's lymphoma of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449206007",
+        "display": "Sarcoma of tibia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449207003",
+        "display": "Sarcoma of humerus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449208008",
+        "display": "Sarcoma of coccyx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449211009",
+        "display": "Malignant epithelial neoplasm of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449216004",
+        "display": "Diffuse non-Hodgkin's lymphoma of soft tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449217008",
+        "display": "Diffuse non-Hodgkin's lymphoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449218003",
+        "display": "Lymphoma of sigmoid colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449219006",
+        "display": "Follicular non-Hodgkin's lymphoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449220000",
+        "display": "Diffuse follicle center lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449221001",
+        "display": "Diffuse non-Hodgkin's lymphoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449222008",
+        "display": "Follicular non-Hodgkin's lymphoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449223003",
+        "display": "Malignant neoplasm of alveolus of maxilla (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449224009",
+        "display": "Malignant neoplasm of anterior mediastinum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449248000",
+        "display": "Nasopharyngeal carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449253005",
+        "display": "Malignant epithelial neoplasm of hypothalamus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449254004",
+        "display": "Malignant epithelial neoplasm of pharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449259009",
+        "display": "Malignant neoplasm of broad ligament of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449260004",
+        "display": "Malignant neoplasm of alveolus dentalis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449267001",
+        "display": "Sarcoma of mandible (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449268006",
+        "display": "Sarcoma of clavicle (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449269003",
+        "display": "Sarcoma of rib (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449292003",
+        "display": "Non-Hodgkin's lymphoma of tonsil (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449293008",
+        "display": "Sarcoma of connective tissue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449294002",
+        "display": "Sarcoma of scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449295001",
+        "display": "Sarcoma of skull (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449307001",
+        "display": "Follicular non-Hodgkin's lymphoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449308006",
+        "display": "Malignant neoplasm of visceral pleura (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449309003",
+        "display": "Malignant neoplasm of skin of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449318001",
+        "display": "Non-Hodgkin's lymphoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449377002",
+        "display": "Malignant neoplasm of pelvic peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449386007",
+        "display": "Philadelphia chromosome negative chronic myelogenous leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449416001",
+        "display": "Malignant epithelial neoplasm of skin of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449417005",
+        "display": "Malignant epithelial neoplasm of nasal septum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449418000",
+        "display": "Follicular non-Hodgkin's lymphoma of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449419008",
+        "display": "Follicular non-Hodgkin's lymphoma of intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449420002",
+        "display": "Malignant neoplasm of cerebellum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449472007",
+        "display": "Malignant epithelial neoplasm of alveolus dentalis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449487002",
+        "display": "Malignant epithelial neoplasm of mandible (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449497006",
+        "display": "Sarcoma of pelvic peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449578008",
+        "display": "Malignant neoplasm of alveolus of mandible (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449627008",
+        "display": "Malignant neoplasm of long bone of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449628003",
+        "display": "Malignant neoplasm of long bone of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449634005",
+        "display": "Primary malignant neoplasm of skin of lower leg (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449635006",
+        "display": "Primary malignant neoplasm of lower leg (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449636007",
+        "display": "Malignant melanoma of skin of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449637003",
+        "display": "Malignant melanoma of skin of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449803009",
+        "display": "Primary malignant neoplasm of dome of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "609515005",
+        "display": "Epithelioid trophoblastic tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "697993003",
+        "display": "SNUC - sinonasal undifferentiated carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698011002",
+        "display": "Keratinizing squamous cell carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698040004",
+        "display": "Malignant melanoma of nasal cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698041000",
+        "display": "Malignant melanoma of vestibule of mouth (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698042007",
+        "display": "Malignant melanoma of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698043002",
+        "display": "Malignant melanoma of floor of mouth (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698044008",
+        "display": "Malignant melanoma of palatine arch"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698045009",
+        "display": "Malignant melanoma of buccal mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698048006",
+        "display": "Nasopharyngeal carcinoma type 2b"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698200003",
+        "display": "Large cell Ewing sarcoma of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698285005",
+        "display": "Malignant melanoma of ethmoid sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698286006",
+        "display": "Malignant melanoma of palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698287002",
+        "display": "Malignant melanoma of gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698288007",
+        "display": "Malignant melanoma of maxillary sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "698646006",
+        "display": "Acute monoblastic leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699028006",
+        "display": "Primitive neuroectodermal tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699317002",
+        "display": "Paratesticular malignant tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699318007",
+        "display": "Supratentorial primitive neuroectodermal tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699354006",
+        "display": "Sarcoma of orbit (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699355007",
+        "display": "Leiomyosarcoma of orbit (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699356008",
+        "display": "Endometrial stromal sarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699357004",
+        "display": "Low grade endometrial stromal sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699358009",
+        "display": "High grade endometrial stromal sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699657009",
+        "display": "Hepatosplenic gamma-delta cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699659007",
+        "display": "Glandular malignant peripheral nerve sheath tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699704002",
+        "display": "Classic medulloblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699818003",
+        "display": "T-cell large granular lymphocytic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "700057001",
+        "display": "Emberger syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "700423003",
+        "display": "Pancreatic adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "700488005",
+        "display": "Malignant sex cord tumor of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702368000",
+        "display": "Carcinosarcoma of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702369008",
+        "display": "Carcinosarcoma of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702391001",
+        "display": "Renal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702405001",
+        "display": "Malignant granulosa cell tumor of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702446006",
+        "display": "Core binding factor acute myeloid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702467006",
+        "display": "Malignant tumor of augmented bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702476004",
+        "display": "Therapy-related myelodysplastic syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702786004",
+        "display": "Follicular non-Hodgkin's lymphoma diffuse follicle center sub-type grade 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702977001",
+        "display": "Follicular non-Hodgkin lymphoma diffuse follicle center cell sub-type grade 2"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "703228009",
+        "display": "Non-small cell lung cancer with mutation in epidermal growth factor receptor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "703230006",
+        "display": "Non-small cell lung cancer without mutation in epidermal growth factor receptor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "703387000",
+        "display": "Acute myeloid leukemia with normal karyotype (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "703429003",
+        "display": "Malignant optic glioma of adulthood"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "703625002",
+        "display": "Kaposi sarcoma not associated with acquired immunodeficiency syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "705061009",
+        "display": "Childhood myelodysplastic syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "706970001",
+        "display": "Triple negative malignant neoplasm of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707337006",
+        "display": "Primary adenocarcinoma of accessory sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707339009",
+        "display": "Primary adenocarcinoma of maxillary sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707342003",
+        "display": "Primary adenocarcinoma of ethmoidal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707343008",
+        "display": "Primary adenocarcinoma of frontal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707344002",
+        "display": "Primary adenocarcinoma of sphenoidal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707345001",
+        "display": "Primary carcinoma of accessory sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707346000",
+        "display": "Primary carcinoma of ethmoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707347009",
+        "display": "Primary carcinoma of maxillary sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707348004",
+        "display": "Primary carcinoma of sphenoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707349007",
+        "display": "Primary carcinoma of frontal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707350007",
+        "display": "Malignant melanoma of accessory sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707353009",
+        "display": "Primary squamous cell carcinoma of accessory sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707354003",
+        "display": "Primary squamous cell carcinoma of maxillary sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707355002",
+        "display": "Primary squamous cell carcinoma of sphenoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707356001",
+        "display": "Primary squamous cell carcinoma of frontal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707357005",
+        "display": "Primary squamous cell carcinoma of laryngeal cartilage (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707358000",
+        "display": "Primary squamous cell carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707359008",
+        "display": "Primary squamous cell carcinoma of ethmoidal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707360003",
+        "display": "Primary lymphoepithelial carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707361004",
+        "display": "Malignant melanoma of frontal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707362006",
+        "display": "Malignant melanoma of sphenoidal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707377003",
+        "display": "Primary signet ring cell carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707378008",
+        "display": "Primary myoepithelial carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707379000",
+        "display": "Primary mucoepidermoid carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707380002",
+        "display": "Primary salivary gland type carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707383000",
+        "display": "Mucinous cystadenocarcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707384006",
+        "display": "Primary solid carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707385007",
+        "display": "Primary undifferentiated carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707386008",
+        "display": "Primary acinar cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707388009",
+        "display": "Primary squamous cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707389001",
+        "display": "Clear cell squamous cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707390005",
+        "display": "Primary basaloid squamous cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707391009",
+        "display": "Papillary squamous cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707392002",
+        "display": "Primary giant cell carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707393007",
+        "display": "Primary adenosquamous carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707394001",
+        "display": "Spindle cell carcinoma of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707395000",
+        "display": "Primary adenocarcinoma of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707396004",
+        "display": "Primary oxyphilic adenocarcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707397008",
+        "display": "Primary basal cell adenocarcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707398003",
+        "display": "Primary polymorphous low grade adenocarcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707399006",
+        "display": "Primary papillary adenocarcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707400004",
+        "display": "Primary mucinous adenocarcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707401000",
+        "display": "Primary clear cell adenocarcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707402007",
+        "display": "Primary adenocarcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707403002",
+        "display": "Primary fetal adenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707404008",
+        "display": "Primary mixed subtype adenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707405009",
+        "display": "Primary adenosquamous carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707406005",
+        "display": "Mucoepidermoid carcinoma of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707407001",
+        "display": "Primary signet ring cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707408006",
+        "display": "Primary small cell non-keratinising squamous cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707409003",
+        "display": "Primary acinar cell carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707410008",
+        "display": "Primary solid carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707411007",
+        "display": "Primary papillary adenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707421004",
+        "display": "Primary undifferentiated carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707422006",
+        "display": "Primary spindle cell squamous cell carcinoma of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707423001",
+        "display": "Primary basaloid carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707424007",
+        "display": "Primary adenosquamous cell carcinoma of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707425008",
+        "display": "Primary adenoid squamous cell carcinoma of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707426009",
+        "display": "Primary papillary squamous cell carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707427000",
+        "display": "Primary verrucous carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707429002",
+        "display": "Overlapping squamous cell carcinoma of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707430007",
+        "display": "Overlapping squamous cell carcinoma of laryngeal cartilage (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707451005",
+        "display": "Primary adenocarcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707452003",
+        "display": "Primary mucinous adenocarcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707453008",
+        "display": "Primary clear cell squamous cell carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707454002",
+        "display": "Primary basaloid squamous cell carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707455001",
+        "display": "Primary papillary squamous cell carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707456000",
+        "display": "Primary undifferentiated carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707457009",
+        "display": "Primary spindle cell carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707458004",
+        "display": "Primary pleomorphic carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707460002",
+        "display": "Primary pseudosarcomatous carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707464006",
+        "display": "Primary myoepithelial carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707465007",
+        "display": "Primary mucoepidermoid carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707466008",
+        "display": "Primary adenoid cystic carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707467004",
+        "display": "Primary salivary gland type carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707468009",
+        "display": "Primary mixed mucinous and non-mucinous bronchiolo-alveolar carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707469001",
+        "display": "Primary non-mucinous bronchiolo-alveolar carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707470000",
+        "display": "Primary mucinous bronchiolo-alveolar carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707471001",
+        "display": "Primary clear cell adenocarcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707472008",
+        "display": "Primary papillary adenocarcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707473003",
+        "display": "Primary mucinous adenocarcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707475005",
+        "display": "Primary adenocarcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707479004",
+        "display": "Primary adenocarcinoma of subglottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707481002",
+        "display": "Primary basaloid squamous cell carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707482009",
+        "display": "Primary papillary squamous cell carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707483004",
+        "display": "Primary undifferentiated carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707484005",
+        "display": "Primary adenoid squamous cell carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707485006",
+        "display": "Primary adenosquamous carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707486007",
+        "display": "Primary basaloid carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707487003",
+        "display": "Primary giant cell carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707489000",
+        "display": "Primary spindle cell squamous cell carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707490009",
+        "display": "Verrucous carcinoma of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707491008",
+        "display": "Primary lymphoepithelial carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707492001",
+        "display": "Primary squamous cell carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707493006",
+        "display": "Primary lymphoepithelial carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707494000",
+        "display": "Primary verrucous carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707495004",
+        "display": "Primary squamous cell adenoid carcinoma of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707528007",
+        "display": "Primary squamous cell carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707529004",
+        "display": "Overlapping squamous cell carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707531008",
+        "display": "Primary squamous cell carcinoma of branchial cleft"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707532001",
+        "display": "Squamous cell carcinoma of posterior wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707535004",
+        "display": "Primary squamous cell carcinoma of lateral wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707537007",
+        "display": "Primary squamous cell carcinoma of anterior surface of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707538002",
+        "display": "Primary squamous cell carcinoma of vallecula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707539005",
+        "display": "Primary adenoid cystic carcinoma of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707575007",
+        "display": "Primary squamous cell carcinoma of supraglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707576008",
+        "display": "Primary squamous cell carcinoma of subglottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707579001",
+        "display": "Primary basaloid squamous cell carcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707580003",
+        "display": "Primary basaloid carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707581004",
+        "display": "Primary papillary squamous cell carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707582006",
+        "display": "Spindle cell squamous cell carcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707583001",
+        "display": "Primary adenosquamous carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707584007",
+        "display": "Primary lymphoepithelial carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707585008",
+        "display": "Primary squamous cell carcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707586009",
+        "display": "Primary myoepithelial carcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707587000",
+        "display": "Primary carcinoma ex pleomorphic adenoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707588005",
+        "display": "Primary epithelial-myoepithelial carcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707589002",
+        "display": "Primary cystadenocarcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707590006",
+        "display": "Primary acinar cell carcinoma of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707591005",
+        "display": "Primary mucoepidermoid carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707592003",
+        "display": "Primary infiltrating duct carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707593008",
+        "display": "Primary salivary gland-type tumour of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707595001",
+        "display": "Primary mucinous cystadenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707596000",
+        "display": "Carcinosarcoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707627009",
+        "display": "Salivary gland-type tumor of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707628004",
+        "display": "Overlapping squamous cell carcinoma of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707660007",
+        "display": "Primary giant cell carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707662004",
+        "display": "Primary basaloid squamous cell carcinoma of larynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707664003",
+        "display": "Primary squamous cell carcinoma of glottis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707670009",
+        "display": "Pleuropulmonary blastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707671008",
+        "display": "Pleuro-pulmonary blastoma type I"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707672001",
+        "display": "Pleuro-pulmonary blastoma type II"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707673006",
+        "display": "Pleuro-pulmonary blastoma type III"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707674000",
+        "display": "Primary malignant epithelial neoplasm of trachea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707686002",
+        "display": "Primary squamous cell carcinoma of posterior wall of hypopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707697002",
+        "display": "Primary squamous cell carcinoma of hypopharyngeal aspect of aryepiglottic fold (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707703001",
+        "display": "Primary squamous cell carcinoma of postcricoid region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707704007",
+        "display": "Primary squamous cell carcinoma of pyriform sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "707705008",
+        "display": "Nonkeratinizing carcinoma of the nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "708054009",
+        "display": "Malignant neoplasm after immunosuppressive therapy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "708504008",
+        "display": "Periosteal osteosarcoma of jaw"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "708921005",
+        "display": "Carcinoma of central portion of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "708971008",
+        "display": "Diffuse sclerosing papillary thyroid carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "709031009",
+        "display": "Malignant neoplasm of superior wall of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "709471005",
+        "display": "Periodontitis co-occurrent with leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "709517003",
+        "display": "Malignant carcinoid tumor of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "709830006",
+        "display": "Malignant carcinoid tumor of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "710195004",
+        "display": "Malignant odontogenic neoplasm of lower jaw"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "710196003",
+        "display": "Malignant odontogenic tumor of upper jaw"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "711414003",
+        "display": "Primary clear cell adenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "712525007",
+        "display": "Malignant neoplasm of short bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "712750007",
+        "display": "Malignant neoplasm of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713038003",
+        "display": "Overlapping primary malignant neoplasm of bone and articular cartilage of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713189001",
+        "display": "Malignant insulinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713290004",
+        "display": "Malignant ameloblastoma of mandible"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713293002",
+        "display": "Malignant germ cell neoplasm of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713325002",
+        "display": "Primary cerebral lymphoma co-occurrent with human immunodeficiency virus infection"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713327005",
+        "display": "Malignant meningioma of meninges of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713483007",
+        "display": "Reticulosarcoma co-occurrent with human immunodeficiency virus infection"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713516007",
+        "display": "Primary effusion lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713572001",
+        "display": "Malignant neoplastic disease co-occurrent with human immunodeficiency virus infection"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713573006",
+        "display": "Malignant carcinoid tumor of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713574000",
+        "display": "Malignant carcinoid tumor of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713609000",
+        "display": "Invasive carcinoma of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713646001",
+        "display": "Malignant germ cell tumor of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713718006",
+        "display": "Diffuse non-Hodgkin's immunoblastic lymphoma co-occurrent with human immunodeficiency virus infection"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "713897006",
+        "display": "Burkitt lymphoma co-occurrent with human immunodeficiency virus infection (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "714251006",
+        "display": "Philadelphia chromosome-negative precursor B-cell acute lymphoblastic leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "714463003",
+        "display": "Primary effusion lymphoma co-occurrent with infection caused by Human herpesvirus 8 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715412008",
+        "display": "Familial malignant neoplasm of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715414009",
+        "display": "Familial malignant neoplasm of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715664005",
+        "display": "Interdigitating dendritic cell sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715901002",
+        "display": "Ependymoblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715903004",
+        "display": "Medulloepithelioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715904005",
+        "display": "Pineal parenchymal tumor of intermediate differentiation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715950008",
+        "display": "Anaplastic lymphoma kinase positive large B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716274007",
+        "display": "Nodular basal cell carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716586009",
+        "display": "Epstein-Barr virus associated gastric carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716588005",
+        "display": "Primary non-gestational choriocarcinoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716593008",
+        "display": "Carcinoma of salivary gland type of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716647001",
+        "display": "Mixed oligoastrocytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716648006",
+        "display": "Embryonal sarcoma of liver (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716649003",
+        "display": "Extraovarian primary peritoneal carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716651004",
+        "display": "Leiomyosarcoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716652006",
+        "display": "Primary hepatic neuroendocrine carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716653001",
+        "display": "Neuroendocrine carcinoma of thymus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716655008",
+        "display": "Aggressive systemic mastocytosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716657000",
+        "display": "Familial papillary thyroid carcinoma with renal papillary neoplasia syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716659002",
+        "display": "Squamous cell carcinoma of head and neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716788007",
+        "display": "Epstein-Barr virus positive diffuse large B-cell lymphoma of elderly (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716855006",
+        "display": "Theca steroid producing cell malignant neoplasm of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716859000",
+        "display": "Hereditary diffuse carcinoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717731002",
+        "display": "Basal cell carcinoma of vulva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717734005",
+        "display": "Papillary thyroid carcinoma with renal papillary neoplasia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717735006",
+        "display": "Renal cell carcinoma of kidney except renal pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717736007",
+        "display": "Familial renal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717916003",
+        "display": "Neuroendocrine carcinoma of appendix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717921000",
+        "display": "Poorly-differentiated neuroendocrine carcinoma of thymus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717922007",
+        "display": "Well-differentiated neuroendocrine carcinoma of thymus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717968005",
+        "display": "Melanoma and neural system tumor syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "718200007",
+        "display": "Primary pulmonary lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "718220008",
+        "display": "Hereditary breast and ovarian cancer syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "718604008",
+        "display": "Small cell neuroendocrine carcinoma of bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "719052006",
+        "display": "Recurrent squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721303001",
+        "display": "Refractory neutropenia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721304007",
+        "display": "Refractory thrombocytopenia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721305008",
+        "display": "Acute myeloid leukemia due to recurrent genetic abnormality (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721306009",
+        "display": "Therapy related acute myeloid leukemia and myelodysplastic syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721308005",
+        "display": "Acute leukemia of ambiguous lineage (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721310007",
+        "display": "Aggressive natural killer-cell leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721311006",
+        "display": "Systemic Epstein-Barr virus positive T-cell lymphoproliferative disease of childhood (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721313009",
+        "display": "Indeterminate dendritic cell neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721314003",
+        "display": "Fibroblastic reticular cell neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721540005",
+        "display": "Primary adnexal carcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721541009",
+        "display": "Primary malignant sarcoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721546004",
+        "display": "Primary adenocarcinoma of ciliary epithelium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721547008",
+        "display": "Primary adenocarcinoma of epithelium of iris (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721548003",
+        "display": "Primary malignant neoplasm of lacrimal apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721549006",
+        "display": "Primary adenocarcinoma of lacrimal apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721555001",
+        "display": "Follicular lymphoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721556000",
+        "display": "Primary adenocarcinoma of palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721557009",
+        "display": "Primary adenocarcinoma of parotid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721558004",
+        "display": "Primary adenocarcinoma of cystic duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721559007",
+        "display": "Primary adenocarcinoma of common bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721560002",
+        "display": "Primary adenocarcinoma of nasal cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721561003",
+        "display": "Primary adenocarcinoma of middle ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721562005",
+        "display": "Primary adenocarcinoma overlapping lesion of retroperitoneum peritoneum and omentum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721563000",
+        "display": "Primary malignant melanoma of vagina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721567004",
+        "display": "Primary malignant neoplasm of placenta (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721568009",
+        "display": "Primary adenocarcinoma of parametrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721569001",
+        "display": "Primary adenocarcinoma of uterine ligament (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721574009",
+        "display": "Primary rhabdomyosarcoma of male genital organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721575005",
+        "display": "Primary angiosarcoma of heart (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721576006",
+        "display": "Primary angiosarcoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721577002",
+        "display": "Primary liposarcoma of soft tissue of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721578007",
+        "display": "Primary liposarcoma of male genital organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721579004",
+        "display": "Primary synovial sarcoma of soft tissue of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721580001",
+        "display": "Primary myosarcoma of omentum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721602000",
+        "display": "Primary embryonal carcinoma of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721603005",
+        "display": "Primary choriocarcinoma of testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721604004",
+        "display": "Primary squamous cell carcinoma of overlapping lesion of male genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721605003",
+        "display": "Primary squamous cell carcinoma of overlapping lesion of accessory sinuses"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721606002",
+        "display": "Primary adenocarcinoma of overlapping lesion of accessory sinuses"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721607006",
+        "display": "Primary undifferentiated carcinoma of oropharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721617001",
+        "display": "Primary adenocarcinoma of lower third of esophagus due to Barrett esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721618006",
+        "display": "Primary squamous cell carcinoma of upper third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721619003",
+        "display": "Primary squamous cell carcinoma of middle third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721620009",
+        "display": "Primary squamous cell carcinoma of lower third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721621008",
+        "display": "Primary squamous cell carcinoma of overlapping lesion of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721622001",
+        "display": "Primary adenocarcinoma of upper third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721623006",
+        "display": "Primary adenocarcinoma of middle third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721624000",
+        "display": "Primary adenocarcinoma of overlapping lesion of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721625004",
+        "display": "Primary neuroendocrine carcinoma of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721626003",
+        "display": "Primary malignant neuroendocrine neoplasm of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721627007",
+        "display": "Malignant melanoma of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721628002",
+        "display": "Primary adenocarcinoma of esophagogastric junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721629005",
+        "display": "Linitis plastica of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721630000",
+        "display": "Primary adenocarcinoma of cardia of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721632008",
+        "display": "Primary adenocarcinoma of pyloric antrum of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721633003",
+        "display": "Primary adenocarcinoma of overlapping lesion of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721634009",
+        "display": "Primary malignant neuroendocrine neoplasm of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721635005",
+        "display": "Primary malignant neuroendocrine neoplasm of cardia of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721636006",
+        "display": "Primary malignant neuroendocrine neoplasm of body of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721637002",
+        "display": "Primary malignant neuroendocrine neoplasm of pyloric antrum of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721638007",
+        "display": "Primary neuroendocrine carcinoma of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721639004",
+        "display": "Primary neuroendocrine carcinoma of cardia of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721640002",
+        "display": "Primary neuroendocrine carcinoma of body of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721641003",
+        "display": "Primary neuroendocrine carcinoma of pyloric antrum of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721642005",
+        "display": "Primary neuroendocrine carcinoma of overlapping lesion of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721643000",
+        "display": "Primary malignant mesenchymal neoplasm of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721644006",
+        "display": "Primary malignant neuroendocrine neoplasm of duodenum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721645007",
+        "display": "Primary neuroendocrine carcinoma of duodenum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721669006",
+        "display": "Primary adenocarcinoma of overlapping lesion of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721670007",
+        "display": "Primary malignant neuroendocrine neoplasm of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721671006",
+        "display": "Primary neuroendocrine carcinoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721672004",
+        "display": "Primary mucinous adenocarcinoma of appendix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721673009",
+        "display": "Primary malignant neuroendocrine neoplasm of appendix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721695008",
+        "display": "Primary adenocarcinoma of ascending colon and right flexure (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721696009",
+        "display": "Primary adenocarcinoma of transverse colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721697000",
+        "display": "Primary neuroendocrine carcinoma of colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721698005",
+        "display": "Primary malignant neuroendocrine neoplasm of colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721699002",
+        "display": "Primary adenocarcinoma of descending colon and splenic flexure (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721700001",
+        "display": "Primary malignant neuroendocrine neoplasm of rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721701002",
+        "display": "Primary neuroendocrine carcinoma of rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721709000",
+        "display": "Primary cloacogenic carcinoma of anal canal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721716004",
+        "display": "Primary cholangiocarcinoma of intrahepatic biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721718003",
+        "display": "Primary adenocarcinoma of ampulla of Vater (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721725005",
+        "display": "Primary adenocarcinoma of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721762007",
+        "display": "Adult T-cell leukemia/lymphoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722103009",
+        "display": "Hormone sensitive prostate cancer (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722112006",
+        "display": "Primary squamous cell carcinoma of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722229001",
+        "display": "Primary sarcoma of retroperitoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722377004",
+        "display": "Paraganglioma and gastric stromal sarcoma syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722425009",
+        "display": "Reactive oxygen species 1 positive non-small cell lung cancer (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722444002",
+        "display": "Primary giant cell sarcoma of retroperitoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722445001",
+        "display": "Primary giant cell sarcoma of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722509001",
+        "display": "Primary rhabdomyosarcoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722510006",
+        "display": "Primary rhabdomyosarcoma of pharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722511005",
+        "display": "Primary rhabdomyosarcoma of respiratory organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722512003",
+        "display": "Primary rhabdomyosarcoma of intrathoracic organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722513008",
+        "display": "Primary leiomyosarcoma of retroperitoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722514002",
+        "display": "Primary leiomyosarcoma of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722515001",
+        "display": "Primary liposarcoma of retroperitoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722516000",
+        "display": "Primary liposarcoma of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722517009",
+        "display": "Primary malignant nerve sheath neoplasm of peripheral nervous system structure (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722518004",
+        "display": "Primary malignant nerve sheath neoplasm of autonomic nerve (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722519007",
+        "display": "Primary sarcoma of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722524005",
+        "display": "Primary invasive pleomorphic lobular carcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722527003",
+        "display": "Primary malignant neuroendocrine neoplasm of bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722528008",
+        "display": "Primary malignant neuroendocrine neoplasm of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722529000",
+        "display": "Primary malignant epithelial neoplasm of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722530005",
+        "display": "Primary squamous cell carcinoma of pharyngeal tonsil (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722533007",
+        "display": "Primary malignant neoplasm of esophagogastric junction (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722542000",
+        "display": "Primary squamous cell carcinoma of anal canal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722543005",
+        "display": "Primary malignant melanoma of anal canal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722665003",
+        "display": "Primary malignant melanoma of cornea (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722666002",
+        "display": "Primary squamous cell carcinoma of lacrimal apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722670005",
+        "display": "Primary thymic carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722672002",
+        "display": "Primary squamous cell carcinoma of root of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722673007",
+        "display": "Primary squamous cell carcinoma of lingual tonsil (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722674001",
+        "display": "Primary squamous cell carcinoma of parotid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722676004",
+        "display": "Primary squamous cell carcinoma of middle ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722677008",
+        "display": "Primary mesothelioma overlapping lesion of retroperitoneum peritoneum and omentum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722678003",
+        "display": "Primary squamous cell carcinoma of vagina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722679006",
+        "display": "Primary mucinous adenocarcinoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722680009",
+        "display": "Primary serous adenocarcinoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722681008",
+        "display": "Primary mixed adenocarcinoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722682001",
+        "display": "Primary small cell carcinoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722683006",
+        "display": "Primary neuroendocrine carcinoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722684000",
+        "display": "Primary low grade serous adenocarcinoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722685004",
+        "display": "Primary high grade serous adenocarcinoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722686003",
+        "display": "Primary serous carcinoma of uterine adnexa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722687007",
+        "display": "Primary mucinous carcinoma of uterine adnexa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722688002",
+        "display": "Carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722712000",
+        "display": "Occupational cancer of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722714004",
+        "display": "Primary mucoepidermoid carcinoma of lacrimal apparatus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722718001",
+        "display": "Primary malignant meningioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722795004",
+        "display": "Meningeal leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722827008",
+        "display": "Primary synovial sarcoma of respiratory organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722828003",
+        "display": "Primary synovial sarcoma of intrathoracic organ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722832009",
+        "display": "Primary solid papillary carcinoma with invasion of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722954005",
+        "display": "B-cell lymphoma unclassifiable with features intermediate between classical Hodgkin lymphoma and diffuse large B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723076008",
+        "display": "Primary myxofibrosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723077004",
+        "display": "Primary myosarcoma of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723173003",
+        "display": "Carcinosarcoma of uterine adnexa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723182009",
+        "display": "Primary squamous cell carcinoma of nasal cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723265000",
+        "display": "Primary squamous cell carcinoma of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723281005",
+        "display": "Primary malignant melanoma of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723301009",
+        "display": "Squamous non-small cell lung cancer (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723843005",
+        "display": "Primary chondrosarcoma of bone of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723844004",
+        "display": "Primary chondrosarcoma of articular cartilage of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723845003",
+        "display": "Primary chondrosarcoma of articular cartilage of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723846002",
+        "display": "Primary chondrosarcoma of bone of rib (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723847006",
+        "display": "Primary chondrosarcoma of articular cartilage of rib (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723848001",
+        "display": "Primary osteosarcoma of bone of jaw (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723849009",
+        "display": "Primary osteosarcoma of articular cartilage of jaw (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723850009",
+        "display": "Primary osteosarcoma of bone of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723851008",
+        "display": "Primary osteosarcoma of articular cartilage of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723852001",
+        "display": "Primary osteosarcoma of articular cartilage of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723853006",
+        "display": "Primary Ewing sarcoma of bone of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723854000",
+        "display": "Primary Ewing sarcoma of articular cartilage of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723855004",
+        "display": "Primary Ewing sarcoma of articular cartilage of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723856003",
+        "display": "Primary Ewing sarcoma of articular cartilage of rib (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723879002",
+        "display": "Primary adenocarcinoma of overlapping lesion of urinary organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723887001",
+        "display": "Primary Ewing sarcoma of bone of rib (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723889003",
+        "display": "B lymphoblastic leukemia lymphoma with t(9:22) (q34;q11.2); BCR-ABL 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724056005",
+        "display": "Malignant neoplasm of lower lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724058006",
+        "display": "Malignant neoplasm of upper lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724059003",
+        "display": "Malignant neoplasm of lower lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724060008",
+        "display": "Malignant neoplasm of right upper lobe of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724467001",
+        "display": "Primary squamous cell carcinoma of overlapping lesion of urinary organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724468006",
+        "display": "Primary transitional cell carcinoma of overlapping lesion of urinary organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724536000",
+        "display": "Primary adenocarcinoma of ileum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724537009",
+        "display": "Primary adenocarcinoma of jejunum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724552002",
+        "display": "Primary poorly differentiated carcinoma of thyroid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724553007",
+        "display": "Primary undifferentiated carcinoma of thyroid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724554001",
+        "display": "Primary malignant epithelial neoplasm of endocrine gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724644005",
+        "display": "Myeloid leukemia co-occurrent with Down syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724645006",
+        "display": "T-cell hystiocyte rich large B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724647003",
+        "display": "Diffuse large B-cell lymphoma co-occurrent with chronic inflammation caused by Epstein-Barr virus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724648008",
+        "display": "Plasmablastic lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724649000",
+        "display": "Langerhans cell sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724650000",
+        "display": "Primary follicular dendritic cell sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724805000",
+        "display": "Primary malignant neuroepitheliomatous neoplasm of peripheral nerve (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724806004",
+        "display": "Primary malignant neuroepitheliomatous neoplasm of autonomic nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724866001",
+        "display": "Primary malignant neoplasm of skin due to and following radiotherapy caused by ionizing radiation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "725390002",
+        "display": "Acute myeloid leukemia with t(8;16)(p11;p13) translocation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "725437002",
+        "display": "Chronic lymphocytic leukemia genetic mutation variant (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "726019003",
+        "display": "Familial malignant melanoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "726652005",
+        "display": "Malignant carcinoid tumor of thymus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "726653000",
+        "display": "Malignant carcinoid tumor of bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "726654006",
+        "display": "Malignant carcinoid tumor of colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "726721002",
+        "display": "Nodal marginal zone B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "732201008",
+        "display": "Carcinosarcoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733064004",
+        "display": "Osteosarcoma, limb anomalies, erythroid macrocytosis syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733134009",
+        "display": "Primary squamous cell carcinoma of paraurethral gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733135005",
+        "display": "Primary transitional cell carcinoma of paraurethral gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733136006",
+        "display": "Primary adenocarcinoma of urethra (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733144006",
+        "display": "Malignant epithelial neoplasm of bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733162002",
+        "display": "Primary malignant neuroendocrine neoplasm of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733163007",
+        "display": "Primary malignant neuroendocrine neoplasm of anal canal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733343005",
+        "display": "Primary squamous cell carcinoma of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733344004",
+        "display": "Primary squamous cell carcinoma of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733345003",
+        "display": "Primary squamous cell carcinoma of pharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733346002",
+        "display": "Primary mucinous cystic neoplasm with associated invasive carcinoma of perihilar bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733347006",
+        "display": "Primary mucinous cystic neoplasm with associated invasive carcinoma of cystic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733348001",
+        "display": "Primary malignant neuroendocrine neoplasm of cystic duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733349009",
+        "display": "Primary mucinous cystic neoplasm with associated invasive carcinoma of distal bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733350009",
+        "display": "Primary malignant neuroendocrine neoplasm of distal bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733351008",
+        "display": "Primary malignant neuroendocrine neoplasm of ampulla of Vater (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733352001",
+        "display": "Primary mucinous cystic neoplasm with associated invasive carcinoma of biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733353006",
+        "display": "Primary malignant neuroendocrine neoplasm of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733354000",
+        "display": "Primary adenocarcinoma of biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733355004",
+        "display": "Primary adenocarcinoma of digestive organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733356003",
+        "display": "Primary mucinous adenocarcinoma of digestive organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733357007",
+        "display": "Primary squamous cell carcinoma of intrathoracic organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733358002",
+        "display": "Primary squamous cell carcinoma of respiratory system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733359005",
+        "display": "Endometrial squamous cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733360000",
+        "display": "Endometrial undifferentiated carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733361001",
+        "display": "Primary mucinous adenocarcinoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733362008",
+        "display": "Primary adenocarcinoma of paraurethral gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733470002",
+        "display": "Bellini carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733471003",
+        "display": "Chromophobe renal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733598001",
+        "display": "Acute myeloid leukemia with t(6;9)(p23;q34) translocation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733603009",
+        "display": "Tubulocystic renal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733608000",
+        "display": "Papillary renal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733627006",
+        "display": "Primary cutaneous gamma-delta-positive T-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733834006",
+        "display": "Invasive carcinoma of uterine cervix co-occurrent with human immunodeficiency virus infection (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "733926004",
+        "display": "Ganglioneuroblastoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "734066005",
+        "display": "Diffuse large B-cell lymphoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "734099007",
+        "display": "Neuroblastoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "734522002",
+        "display": "Acute myeloid leukemia with FMS-like tyrosine kinase-3 mutation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "734884008",
+        "display": "Diarrhea co-occurrent and due to carcinoid syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735332000",
+        "display": "Primary cutaneous diffuse large cell B-cell lymphoma of lower extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735385007",
+        "display": "Microsatellite instability-high solid malignant tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735450006",
+        "display": "Primary malignant neuroepitheliomatous neoplasm of nasal cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735678002",
+        "display": "Primary chondrosarcoma of articular cartilage (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735679005",
+        "display": "Primary chondrosarcoma of bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735680008",
+        "display": "Primary osteosarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735718000",
+        "display": "Neonatal malabsorption co-occurrent and due to gastrointestinal hormone-secreting endocrine tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735735001",
+        "display": "Primary malignant neuroendocrine neoplasm of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735757008",
+        "display": "Primary ganglioneuroblastoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735916009",
+        "display": "Primary malignant neuroepithelial neoplasm of retina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735917000",
+        "display": "Primary malignant neoplasm of ocular adnexa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735918005",
+        "display": "Primary malignant neoplasm of lacrimal caruncle (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735919002",
+        "display": "Primary malignant neuroepithelial neoplasm of iris (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735920008",
+        "display": "Primary malignant neuroepithelial neoplasm of ciliary body (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "735921007",
+        "display": "Primary malignant neuroepithelial neoplasm of orbit (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "736322001",
+        "display": "Pediatric follicular lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737058005",
+        "display": "Mismatch repair deficient colorectal cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737308008",
+        "display": "Primary adenocarcinoma of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737309000",
+        "display": "Primary adenocarcinoma of submandibular gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737310005",
+        "display": "Primary squamous cell carcinoma of submandibular gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737311009",
+        "display": "Primary squamous cell carcinoma of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737312002",
+        "display": "Primary malignant neuroendocrine neoplasm of jejunum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737313007",
+        "display": "Primary malignant neuroendocrine neoplasm of ileum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "738527001",
+        "display": "Myeloid/lymphoid neoplasm associated with PDGFRA rearrangement"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "739301006",
+        "display": "Osteoporosis co-occurrent and due to multiple myeloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "761958009",
+        "display": "Malignant peripheral nerve sheath neoplasm with perineurial differentiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "762315004",
+        "display": "Therapy related acute myeloid leukemia due to and following administration of antineoplastic agent (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "762457009",
+        "display": "Astroblastoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "762458004",
+        "display": "Endometrial endometrioid adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "762665002",
+        "display": "Primary malignant neuroendocrine neoplasm of perihilar bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "762690000",
+        "display": "Classical Hodgkin lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763063001",
+        "display": "Adenoid basal carcinoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763064007",
+        "display": "Adenoid cystic carcinoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763131005",
+        "display": "Clear cell adenocarcinoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763309005",
+        "display": "Acute myeloid leukemia with nucleophosmin 1 somatic mutation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763408003",
+        "display": "Rhabdomyosarcoma of cervix uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763409006",
+        "display": "Rhabdomyosarcoma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763477007",
+        "display": "Primary lymphoid conjunctival tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763479005",
+        "display": "Metaplastic carcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763666008",
+        "display": "Splenic marginal zone B-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763771009",
+        "display": "Leiomyosarcoma of cervix uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763796007",
+        "display": "Megakaryoblastic acute myeloid leukemia with t(1;22)(p13;q13) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763884007",
+        "display": "Splenic diffuse red pulp small B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764694005",
+        "display": "Translocation renal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764735002",
+        "display": "Squamous cell carcinoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764737005",
+        "display": "Squamous cell carcinoma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764845008",
+        "display": "Adenocarcinoma of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764846009",
+        "display": "Adenocarcinoma of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764847000",
+        "display": "Adenosarcoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764855007",
+        "display": "Acute myeloid leukemia with CEBPA somatic mutations"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764856008",
+        "display": "Acquired cystic disease associated renal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764938007",
+        "display": "Lymphoepithelial carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764940002",
+        "display": "Inherited acute myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764951002",
+        "display": "Cervical carcinosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764952009",
+        "display": "Carcinosarcoma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764961009",
+        "display": "Hereditary clear cell renal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "764990003",
+        "display": "Mucinous tubular and spindle cell renal carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "765095002",
+        "display": "Renal medullary carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "765136002",
+        "display": "Primary cutaneous epidermotropic cytotoxic CD8 positive T-cell lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "765328000",
+        "display": "Classic mycosis fungoides"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "765740002",
+        "display": "Adenosarcoma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "765741003",
+        "display": "Adenocarcinoma of gallbladder and extrahepatic biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766045006",
+        "display": "Acute myeloid leukemia and myelodysplastic syndrome related to alkylating agent"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766046007",
+        "display": "Acute myeloid leukemia and myelodysplastic syndrome related to topoisomerase type 2 inhibitor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766048008",
+        "display": "Acute myeloid leukemia and myelodysplastic syndrome related to radiation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766247009",
+        "display": "Primitive neuroectodermal tumor of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766248004",
+        "display": "Primitive neuroectodermal tumor of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766757006",
+        "display": "Undifferentiated gastric carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766758001",
+        "display": "Undifferentiated carcinoma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766759009",
+        "display": "Vulvovaginal rhabdomyosarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766930002",
+        "display": "Glassy cell carcinoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766935007",
+        "display": "Primary bone lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766978002",
+        "display": "Squamous cell carcinoma of gallbladder and extrahepatic biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766979005",
+        "display": "Rectal squamous cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766980008",
+        "display": "Squamous cell carcinoma of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "766981007",
+        "display": "Squamous cell carcinoma of colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "767448007",
+        "display": "Pineoblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770402000",
+        "display": "Aleukemic mast cell leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770559003",
+        "display": "Leiomyosarcoma of body of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770601003",
+        "display": "Small cell carcinoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770602005",
+        "display": "Exocrine pancreatic squamous cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770684008",
+        "display": "Squamous cell carcinoma of liver and intrahepatic biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770685009",
+        "display": "Undifferentiated carcinoma of liver and intrahepatic biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770686005",
+        "display": "Malignant germ cell neoplasm of vagina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "771080008",
+        "display": "Hereditary site-specific ovarian cancer syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "772992009",
+        "display": "DTC - differentiated thyroid cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773283006",
+        "display": "Malignant germ cell neoplasm of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773284000",
+        "display": "Malignant germ cell neoplasm of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773537001",
+        "display": "Differentiation syndrome due to and following chemotherapy co-occurrent with acute promyelocytic leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773624006",
+        "display": "Primary ameloblastic carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773774000",
+        "display": "Poorly differentiated neuroendocrine carcinoma of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773775004",
+        "display": "High-grade neuroendocrine carcinoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "773995001",
+        "display": "Primary cutaneous anaplastic large cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "778066006",
+        "display": "Carcinofibroma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "780821007",
+        "display": "Invasive intraductal papillary-mucinous carcinoma of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "780844005",
+        "display": "Acute myeloid leukemia with inv(3)(q21q26.2) or t(3;3)(q21;q26.2); RPN1-EVI1"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "781382000",
+        "display": "Colorectal cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "782672006",
+        "display": "Extragonadal germinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "782697005",
+        "display": "Solid pseudopapillary carcinoma of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "782722002",
+        "display": "Global developmental delay, lung cysts, overgrowth, Wilms tumor syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "782827000",
+        "display": "Epithelioid sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "782915004",
+        "display": "Acquired hemophagocytic lymphohistiocytosis associated with malignant disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783006001",
+        "display": "Well-differentiated neuroendocrine tumor of the corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783056006",
+        "display": "Adenocarcinoma of paratestis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783155007",
+        "display": "Malignant epithelial neoplasm of salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783183009",
+        "display": "Salivary gland type carcinoma of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783615009",
+        "display": "Erythropoietic uroporphyria associated with myeloid malignancy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783704005",
+        "display": "Undifferentiated carcinoma of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783706007",
+        "display": "Serous cystadenocarcinoma of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783736003",
+        "display": "Malignant melanoma of mucous membrane"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783771003",
+        "display": "Pancreatic acinar cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "785807007",
+        "display": "Transitional cell carcinoma of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "785879009",
+        "display": "Mucinous cystadenocarcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "786038001",
+        "display": "Familial nonmedullary thyroid carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "786710002",
+        "display": "Solid tumor with neurotrophic receptor tyrosine kinase"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "787091002",
+        "display": "Adenocarcinoma of liver and intrahepatic biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788874003",
+        "display": "B-cell prolymphocytic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788972003",
+        "display": "Juvenile myelomonocytic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788979007",
+        "display": "Malignant pilonidal cyst"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788982002",
+        "display": "Mesothelioma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "789004008",
+        "display": "Parafollicular cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "789689004",
+        "display": "Malignant lymphomatoid granulomatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "789690008",
+        "display": "Malignant lymphomatoid granulomatosis of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "789721005",
+        "display": "Malignant middle ear paraganglioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "792907004",
+        "display": "Pancreatic ductal adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "816204007",
+        "display": "Nodular melanoma of mucous membrane (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "816205008",
+        "display": "Malignant pituitary blastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "818967003",
+        "display": "Medulloepithelioma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "822969007",
+        "display": "Acinar cell cystadenocarcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "822970008",
+        "display": "Acinar cell cystadenocarcinoma of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "823017009",
+        "display": "Infiltrating duct carcinoma of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "827162007",
+        "display": "Malignant immature teratoma of ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830055006",
+        "display": "Anaplastic lymphoma kinase negative non-small cell lung cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830057003",
+        "display": "Relapsing classical Hodgkin lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830060005",
+        "display": "Reactive oxygen species 1 negative non-small cell lung cancer (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830150003",
+        "display": "Malignant melanoma with B-Raf proto-oncogene, serine/threonine kinase V600E mutation (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830151004",
+        "display": "Anaplastic lymphoma kinase-positive non-small cell lung cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830196006",
+        "display": "Chordoma of cervical spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "833285007",
+        "display": "Chordoma of lumbar spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "833295000",
+        "display": "Chordoma of thoracic spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838340006",
+        "display": "B lymphoblastic leukemia lymphoma with t(5;14)(q31;q32); IL3-IGH"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838341005",
+        "display": "B lymphoblastic leukemia lymphoma with t(v;11q23); MLL rearranged"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838342003",
+        "display": "B lymphoblastic leukemia lymphoma with t(12;21) (p13;q22); TEL/AML1 (ETV6-RUNX1) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838343008",
+        "display": "B lymphoblastic leukemia lymphoma with t(1;19)(Q23;P13.3); E2A-PBX1 (TCF3/PBX1) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838344002",
+        "display": "B lymphoblastic leukemia lymphoma with hypodiploidy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838346000",
+        "display": "B lymphoblastic leukemia lymphoma with hyperdiploidy (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838349007",
+        "display": "Adenocarcinoma of Meckel diverticulum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838355002",
+        "display": "Acute myeloid leukemia with inv(16)(p13.1q22) or t(16;16)(p13.1;q22) CBFB-MYH11 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "840423002",
+        "display": "Diffuse large B-cell lymphoma of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "840424008",
+        "display": "Diffuse large B-cell lymphoma of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "840573001",
+        "display": "Carcinoma of epididymis and spermatic cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "860828007",
+        "display": "Gastrointestinal stromal neoplasm of overlapping lesion of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "860830009",
+        "display": "Gastrointestinal stromal neoplasm of overlapping lesion of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "860831008",
+        "display": "Epithelioid hemangioendothelioma of liver (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "860832001",
+        "display": "Extraskeletal myxoid chondrosarcoma of soft tissue of limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "860923004",
+        "display": "Primary osteosarcoma of articular cartilage of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "865951006",
+        "display": "Perihilar cholangiocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "865954003",
+        "display": "Adenocarcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866048009",
+        "display": "Mucinous cystic neoplasm with invasive carcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866050001",
+        "display": "Mixed germ cell neoplasm of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866052009",
+        "display": "Mixed ductal-neuroendocrine carcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866068003",
+        "display": "Malignant nerve sheath neoplasm of overlapping lesion of peripheral nerves and autonomic nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866069006",
+        "display": "Malignant nerve sheath neoplasm of peripheral nerve of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866070007",
+        "display": "Malignant mesenchymal neoplasm of bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866071006",
+        "display": "Malignant mesenchymal neoplasm of gallbladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866072004",
+        "display": "Malignant melanoma of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866073009",
+        "display": "Malignant melanoma of overlapping lesion of eye and adnexa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866079008",
+        "display": "Malignant melanoma of lacrimal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866080006",
+        "display": "Malignant germ cell neoplasm of heart"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866082003",
+        "display": "Malignant melanoma of lacrimal drainage system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866093001",
+        "display": "Malignant nerve sheath neoplasm of peripheral nerve of upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866094007",
+        "display": "Malignant nerve sheath neoplasm of peripheral nerve of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866095008",
+        "display": "Malignant nerve sheath neoplasm of peripheral nerve of thorax (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866096009",
+        "display": "Malignant nerve sheath neoplasm of peripheral nerve of head and neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866097000",
+        "display": "Malignant nerve sheath neoplasm of peripheral nerve of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866098005",
+        "display": "Large B-cell lymphoma arising in HHV8-associated multicentric Castleman disease"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866176003",
+        "display": "Clear cell adenocarcinoma of peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "870318006",
+        "display": "Osteosarcoma of bone of head (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "870327007",
+        "display": "Papillary squamous cell carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "870355006",
+        "display": "Neuroendocrine carcinoma of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "871843002",
+        "display": "Malignant neoplasm of connective and soft tissue of sacrococcygeal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878805009",
+        "display": "Renal granular cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878806005",
+        "display": "Second primary cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878807001",
+        "display": "HER2-positive gastric cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878808006",
+        "display": "Nongerminomatous germ cell tumor of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878857009",
+        "display": "Malignant lymphomatoid granulomatosis grade 3 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878858004",
+        "display": "Malignant lymphomatoid granulomatosis grade 3 of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "890528009",
+        "display": "Primary malignant neoplasm of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "890529001",
+        "display": "Primary malignant neoplasm of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "890534002",
+        "display": "Primary malignant neoplasm of bilateral lungs (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895111002",
+        "display": "Chordoma of vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895345000",
+        "display": "Primary malignant neoplasm of bilateral kidneys (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895354002",
+        "display": "Primary malignant neoplasm of left ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895355001",
+        "display": "Primary malignant neoplasm of right ureter (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895356000",
+        "display": "Primary malignant neoplasm of bilateral ureters (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895358004",
+        "display": "Primary malignant neoplasm of left testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895359007",
+        "display": "Primary malignant neoplasm of right testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "895361003",
+        "display": "Primary malignant neoplasm of bilateral testes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "898197001",
+        "display": "Adult T-cell leukemia/lymphoma in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "898198006",
+        "display": "T-cell prolymphocytic leukemia in remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010603001",
+        "display": "Primary mucoepidermoid carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010607000",
+        "display": "Primary lymphoepithelial carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010624006",
+        "display": "Primary salivary gland type neoplasm of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010631005",
+        "display": "Primary malignant melanoma of overlapping lesion of accessory sinuses"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010633008",
+        "display": "Primary papillary adenocarcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010656004",
+        "display": "Adenoid squamous cell carcinoma of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010669000",
+        "display": "Primary squamous cell carcinoma of superior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010674008",
+        "display": "Basaloid squamous cell carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010675009",
+        "display": "Squamous cell carcinoma of posterior wall of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010677001",
+        "display": "Primary squamous cell carcinomas of anterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010679003",
+        "display": "Primary squamous cell carcinoma of lateral wall of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010681001",
+        "display": "Primary squamous cell carcinoma of overlapping lesion of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1137644008",
+        "display": "Leiomyosarcoma of fundus of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1141621000",
+        "display": "Malignant epithelial neoplasm of pyriform fossa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1141626005",
+        "display": "Adenocarcinoma of pancreas with neuregulin 1 gene fusion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1141627001",
+        "display": "Non-small cell lung carcinoma with NRG1 fusion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144252005",
+        "display": "Malignant neoplasm of lateral border of tongue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144303008",
+        "display": "Leiomyosarcoma of pylorus of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144304002",
+        "display": "Leiomyosarcoma of pyloric antrum of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144305001",
+        "display": "Leiomyosarcoma of body of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144306000",
+        "display": "Leiomyosarcoma of lesser curvature of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144307009",
+        "display": "Leiomyosarcoma of greater curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144764001",
+        "display": "Malignant tumor of esophagus with NRG1 fusion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144891007",
+        "display": "Primary cholangiocarcinoma of extrahepatic bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144922006",
+        "display": "Thymoma type AB (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144924007",
+        "display": "Thymoma type B (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144928005",
+        "display": "Thymoma type A (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1144945000",
+        "display": "Adnexal carcinoma of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1145245004",
+        "display": "Carcinoma of meibomian gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148551007",
+        "display": "Infiltrating duct carcinoma of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148845007",
+        "display": "Follicular lymphoma grade 3b"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148847004",
+        "display": "Follicular non-Hodgkin's lymphoma in situ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148851002",
+        "display": "Follicular lymphoma grade IIIa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148852009",
+        "display": "Malignant cystic nephroma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148901006",
+        "display": "Squamous cell carcinoma of male genital (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148904003",
+        "display": "Spermatocytic seminoma of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148906001",
+        "display": "Acute myeloid leukemia with t(8;21)(q22;q22) RUNX1-RUNX1T1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1148931000",
+        "display": "Cystic renal cell carcinoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153336009",
+        "display": "Pediatric nodal marginal zone B cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153345005",
+        "display": "Refractory cytopenia with unilineage dysplasia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153346006",
+        "display": "Primary non Hodgkin malignant lymphoma of uveal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153347002",
+        "display": "Primary non Hodgkin malignant lymphoma of vitreoretinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153348007",
+        "display": "Primary effusion lymphoma due to human immune deficiency virus infection"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153349004",
+        "display": "Primary familial polycythemia due to erythropoietin receptor mutation"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153354008",
+        "display": "Malignant lymphoma of duodenum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153355009",
+        "display": "Malignant lymphoma of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153356005",
+        "display": "Lymphoma of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153357001",
+        "display": "Lymphoma of appendix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153377008",
+        "display": "Mixed phenotype acute leukemia with t(9;22) (q34;q11.2); BCR-ABL1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153379006",
+        "display": "Mixed phenotype acute leukemia with T-cell and myeloid lineage (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153381008",
+        "display": "Mixed phenotype acute leukemia with myeloid and B-cell lymphoid phenotypes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153382001",
+        "display": "Lymphoma of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153383006",
+        "display": "Lymphoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153421007",
+        "display": "Chondrosarcoma of sternum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153422000",
+        "display": "Chondrosarcoma of mandible"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153423005",
+        "display": "Chondrosarcoma of rib"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153424004",
+        "display": "Chondrosarcoma of bone of pelvic wall (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153425003",
+        "display": "Chondrosarcoma of clavicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153426002",
+        "display": "Chondrosarcoma of skull (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153427006",
+        "display": "Chondrosarcoma of vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156403002",
+        "display": "Composite Hodgkin and non-Hodgkin lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156404008",
+        "display": "Polyembryoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156406005",
+        "display": "Anaplastic oligodendroglioma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156409003",
+        "display": "Anaplastic ependymoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156410008",
+        "display": "Anaplastic oligoastrocytoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156413005",
+        "display": "Gliomatosis cerebri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156414004",
+        "display": "Giant cell glioblastoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156415003",
+        "display": "Protoplasmic astrocytoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156416002",
+        "display": "Gemistocytic astrocytoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156417006",
+        "display": "Fibrillary astrocytoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156418001",
+        "display": "Malignant rhabdoid tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156420003",
+        "display": "DSRCT - desmoplastic small round cell tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156452003",
+        "display": "Mixed germ cell tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156453008",
+        "display": "Chordoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156454002",
+        "display": "Embryonal carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156455001",
+        "display": "Pleomorphic xanthoastrocytoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156456000",
+        "display": "Pilomyxoid astrocytoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156459007",
+        "display": "Anaplastic ganglioglioma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156460002",
+        "display": "Desmoplastic nodular medulloblastoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156461003",
+        "display": "Gliosarcoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156469001",
+        "display": "Large cell medulloblastoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156471001",
+        "display": "Choroid plexus carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156472008",
+        "display": "Papillary tumor of pineal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156495004",
+        "display": "Dendritic cell sarcoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156783003",
+        "display": "Leiomyosarcoma of rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156785005",
+        "display": "Leiomyosarcoma of duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156786006",
+        "display": "Leiomyosarcoma of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156788007",
+        "display": "Leiomyosarcoma of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156795003",
+        "display": "Kaposi sarcoma of colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156797006",
+        "display": "Kaposi sarcoma of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156804004",
+        "display": "Peripheral neuroectodermal neoplasm of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156806002",
+        "display": "Primary malignant neoplasm of musculoskeletal system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156807006",
+        "display": "Peripheral neuroectodermal neoplasm of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156808001",
+        "display": "Malignant mixed MÃ¼llerian neoplasm of corpus uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156809009",
+        "display": "Malignant mesenchymal neoplasm of duodenum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156810004",
+        "display": "Malignant mesenchymal neoplasm of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156811000",
+        "display": "Malignant mesenchymal neoplasm of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156812007",
+        "display": "Malignant mesenchymal neoplasm of appendix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156833003",
+        "display": "Germinoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157060001",
+        "display": "Diffuse astrocytoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157061002",
+        "display": "Gliosarcoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157062009",
+        "display": "Giant cell glioblastoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157063004",
+        "display": "Malignant neoplasm of vertebral column region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157064005",
+        "display": "Gemistocytic astrocytoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157067003",
+        "display": "Malignant neoplasm of vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157068008",
+        "display": "Fibrillary astrocytoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157070004",
+        "display": "Pilomyxoid astrocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157071000",
+        "display": "Anaplastic ganglioglioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157072007",
+        "display": "Gliosarcoma of spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157141006",
+        "display": "Astroblastoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157157006",
+        "display": "Acute myeloid leukemia with 11q23 abnormality (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157162007",
+        "display": "Intravascular large B-cell lymphoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162264008",
+        "display": "Malignant lymphoma of uveal tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162280003",
+        "display": "Rhabdomyosarcoma of isthmus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162282006",
+        "display": "Rhabdomyosarcoma of myometrium of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162284007",
+        "display": "Rhabdomyosarcoma of endometrium of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162286009",
+        "display": "Rhabdomyosarcoma of fundus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162311007",
+        "display": "Sarcoma of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162346004",
+        "display": "Osteosarcoma of sternum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162348003",
+        "display": "Osteosarcoma of bone of vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162349006",
+        "display": "Osteosarcoma of bone of clavicle (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162351005",
+        "display": "Osteosarcoma of bone of rib"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162352003",
+        "display": "Osteosarcoma of articular cartilage of sternum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162353008",
+        "display": "Osteosarcoma of articular cartilage of vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162354002",
+        "display": "Osteosarcoma of articular cartilage of rib (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162361003",
+        "display": "Osteosarcoma of articular cartilage of clavicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162531007",
+        "display": "Acute myeloid leukemia in complete remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162855005",
+        "display": "Carcinoma of gallbladder and extrahepatic biliary tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1163357003",
+        "display": "Malignant neoplasm of oral cavity and lip and salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1163568002",
+        "display": "Primary malignant neoplasm of overlapping sites of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1172704005",
+        "display": "High grade B-cell lymphoma with MYC and BCL2 and/or BCL6 rearrangements"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1172793008",
+        "display": "Malignant schwannoma of nerve of gingival mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1177173001",
+        "display": "Congenital progressive bone marrow failure, B-cell immunodeficiency, skeletal dysplasia syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1179375008",
+        "display": "Adenocarcinoma of parathyroid gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1179377000",
+        "display": "Adenocarcinoma of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1179389003",
+        "display": "Adenocarcinoma of paraganglia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1179390007",
+        "display": "Adenocarcinoma of carotid body (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1179762006",
+        "display": "Malignant neoplasm of middle lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186614003",
+        "display": "Primary Kaposi's sarcoma of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186615002",
+        "display": "Primary Kaposi sarcoma of palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186616001",
+        "display": "Primary Kaposi sarcoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186629001",
+        "display": "Primary fibrolamellar hepatocellular carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186630006",
+        "display": "Primary liver cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186631005",
+        "display": "Primary hepatocholangiocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186735007",
+        "display": "MiNEN (mixed neuroendocrine-non neuroendocrine neoplasm) of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186869002",
+        "display": "Neuroendocrine carcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1187123005",
+        "display": "Mixed phenotype acute leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1187464007",
+        "display": "Clear cell sarcoma of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1187519007",
+        "display": "Malignant G cell neoplasm of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1187521002",
+        "display": "Malignant alpha cell neoplasm of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1187622004",
+        "display": "Nuclear protein in testis carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196839006",
+        "display": "Primary embryonal carcinoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196841007",
+        "display": "Primary desmoplastic mesothelioma of pleura (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196844004",
+        "display": "Primary malignant astrocytoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196846002",
+        "display": "Primary cystadenocarcinoma of intrahepatic bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196853006",
+        "display": "Primary carcinoma of bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196854000",
+        "display": "Primary carcinosarcoma of liver (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196856003",
+        "display": "Primary biphasic malignant mesothelioma of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196860000",
+        "display": "Primary anaplastic large cell medulloblastoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196874007",
+        "display": "Primary adenocarcinoma of bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196876009",
+        "display": "Primary acinar cell carcinoma of parotid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196879002",
+        "display": "Familial ovarian cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196881000",
+        "display": "Primary embryonal carcinoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196883002",
+        "display": "Primary epithelioid malignant mesothelioma of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196898000",
+        "display": "Primary malignant atypical teratoid rhabdoid neoplasm of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196900003",
+        "display": "B cell lymphoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196911006",
+        "display": "Primary adenocarcinoma of iris neuroepithelium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196998001",
+        "display": "Malignant perivascular epithelioid tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197011004",
+        "display": "Malignant neoplasm of intestine due to familial adenomatous polyposis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197204009",
+        "display": "Adult hepatocellular carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197258000",
+        "display": "Primary salivary gland type carcinoma of palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197259008",
+        "display": "Primary sarcomatoid malignant mesothelioma of pleura (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197260003",
+        "display": "Primary poorly differentiated endocrine carcinoma of body of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197263001",
+        "display": "Primary poorly differentiated endocrine carcinoma of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197266009",
+        "display": "Primary papillary carcinoma of corpus uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197268005",
+        "display": "Primary papillary carcinoma of cervix uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197275006",
+        "display": "Primary squamous cell carcinoma of fallopian tube (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197276007",
+        "display": "Primary squamous cell carcinoma of pharyngeal lymphoid ring (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197279000",
+        "display": "Primary solid pseudopapillary neoplasm of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197280002",
+        "display": "Endodermal sinus tumor of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197283000",
+        "display": "Primary mixed acinar endocrine-ductal carcinoma of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197286008",
+        "display": "Primary mixed acinar ductal carcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197294001",
+        "display": "Malignant melanoma arising in melanocytic nevus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197296004",
+        "display": "Primary malignant germ cell neoplasm of pleura (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197298003",
+        "display": "Primary malignant germ cell neoplasm of pineal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197307000",
+        "display": "Primary neuroendocrine carcinoma of gallbladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197332003",
+        "display": "Primary malignant melanoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197334002",
+        "display": "Malignant melanoma of uveal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197342001",
+        "display": "Primary teratocarcinoma of liver (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197343006",
+        "display": "Primary teratoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197344000",
+        "display": "T-cell lymphoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197349005",
+        "display": "Primary malignant paraganglioma of carotid body (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197350005",
+        "display": "Primary malignant MÃ¼llerian mixed neoplasm of cervix uteri (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197354001",
+        "display": "Primary malignant mesenchymal neoplasm of colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197355000",
+        "display": "Primary malignant mesenchymal neoplasm of rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197359006",
+        "display": "Familial colorectal cancer type X (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1201780008",
+        "display": "Chondrosarcoma of gingiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208349005",
+        "display": "Pediatric hepatocellular carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208451008",
+        "display": "Transitional cell carcinoma of upper urinary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208457007",
+        "display": "Small cell neuroendocrine carcinoma of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208459005",
+        "display": "Micropapillary urothelial carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208460000",
+        "display": "Spindle cell transitional cell carcinoma of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208461001",
+        "display": "Plasmacytoid urothelial carcinoma of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208483002",
+        "display": "Primary choriocarcinoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208741006",
+        "display": "SMARCA4-deficient undifferentiated neoplasm of thorax (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208744003",
+        "display": "Non-functioning neuroendocrine neoplasm of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1208745002",
+        "display": "Serotonin-producing neuroendocrine neoplasm of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217010007",
+        "display": "Human epidermal growth factor 2 expressing colorectal cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217020002",
+        "display": "Sarcomatoid urothelial carcinoma of ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217301006",
+        "display": "Precursor cell lymphoblastic lymphoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217383007",
+        "display": "RELA fusion-positive supratentorial ependymoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217490003",
+        "display": "Kaposi sarcoma of gingiva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217617009",
+        "display": "Kaposi sarcoma of internal part of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1222581000",
+        "display": "Lipid-rich urothelial carcinoma of urinary system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1222643003",
+        "display": "Hereditary malignant neuroendocrine tumor of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1229871006",
+        "display": "Primary squamous cell carcinoma of nasal cavity and paranasal sinus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1229988003",
+        "display": "Myeloid and/or lymphoid neoplasm with pericentriolar material 1-janus kinase 2 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1230318000",
+        "display": "Serous carcinoma of body of uterus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1231267007",
+        "display": "Primary malignant ependymoma of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1231381006",
+        "display": "Clear cell urothelial carcinoma of urinary system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1651000119109",
+        "display": "Primary adenocarcinoma of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1701000119104",
+        "display": "Primary adenocarcinoma of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "7391000119103",
+        "display": "Primary adenoid cystic carcinoma of nasopharynx (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "9541000119105",
+        "display": "Primary adenocarcinoma of gallbladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "11471000224106",
+        "display": "Diffuse intrinsic pontine glioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12281000132104",
+        "display": "Relapsing acute myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12291000132102",
+        "display": "Refractory AML (acute myelocytic leukemia)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12301000132103",
+        "display": "Acute lymphoid leukemia relapse (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12311000132101",
+        "display": "Refractory acute lymphoid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "18121000119104",
+        "display": "Primary squamous cell carcinoma of palatine tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "21851000119103",
+        "display": "Malignant pheochromocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "24111000119105",
+        "display": "Primary squamous cell carcinoma of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "29421000119105",
+        "display": "Adenocarcinoma in adenomatous polyp (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "45221000119105",
+        "display": "Primary invasive malignant neoplasm of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "61291000119103",
+        "display": "Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "61301000119102",
+        "display": "Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "61471000119100",
+        "display": "Basal cell carcinoma of naris"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "67811000119102",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "67821000119109",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 2 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "67831000119107",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 3 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "67841000119103",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 4 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "71101000119106",
+        "display": "Recurrent primary malignant neoplasm of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "71111000119109",
+        "display": "Recurrent primary malignant neoplasm of vulva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "72891000119103",
+        "display": "Kaposi sarcoma of viscus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "78411000119107",
+        "display": "Ewing sarcoma of bone of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "79281000119106",
+        "display": "Primary adenocarcinoma of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "82501000119102",
+        "display": "Anaplastic astrocytoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "84821000119100",
+        "display": "Primary follicular dendritic cell sarcoma of spleen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "87091000119101",
+        "display": "Malignant glioma of cerebrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "87111000119109",
+        "display": "Malignant glioma of hypothalamus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "87121000119102",
+        "display": "Malignant glioma of cerebellum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "87141000119108",
+        "display": "Primary malignant neoplasm of intramedullary spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "87151000119105",
+        "display": "Malignant glioma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "90811000119100",
+        "display": "Low grade malignant glioma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "90831000119105",
+        "display": "Grade 4 malignant glioma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91031000119108",
+        "display": "Primary chondrosarcoma of bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91041000119104",
+        "display": "Ewing sarcoma of bone structure of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91061000119100",
+        "display": "Primary chondrosarcoma of bone of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91081000119109",
+        "display": "Primary chondrosarcoma of bone of lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91131000119109",
+        "display": "Primary adenocarcinoma of vulva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91151000119103",
+        "display": "Primary squamous cell carcinoma of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91161000119101",
+        "display": "Primary adenocarcinoma of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91171000119107",
+        "display": "Primary undifferentiated large cell malignant neoplasm of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94291000119103",
+        "display": "Mucinous adenocarcinoma of gastrointestinal tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "96281000119107",
+        "display": "Overlapping malignant neoplasm of colon and rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "96291000119105",
+        "display": "Primary malignant inflammatory neoplasm of female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "99101000119101",
+        "display": "Primary adenocarcinoma of fallopian tube (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "99111000119103",
+        "display": "Primary adenocarcinoma of intestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "99121000119105",
+        "display": "Primary adenocarcinoma of vagina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "99131000119108",
+        "display": "Astrocytoma of cerebrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "100721000119109",
+        "display": "High grade astrocytoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "100731000119107",
+        "display": "Low grade astrocytoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "104981000119104",
+        "display": "Oligodendroglioma of cerebrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "105111000119109",
+        "display": "Primary squamous cell carcinoma of thymus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "105121000119102",
+        "display": "Squamous cell carcinoma of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107581000119103",
+        "display": "Astrocytoma of brain stem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107591000119100",
+        "display": "Primary squamous cell carcinoma of urethra (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107601000119107",
+        "display": "Primary transitional cell carcinoma of urethra (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107691000119101",
+        "display": "Non-seminomatous germ cell neoplasm of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107751000119102",
+        "display": "Primary malignant mixed Mullerian neoplasm of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107771000119106",
+        "display": "Primary malignant clear cell neoplasm of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107791000119107",
+        "display": "Primary adenosquamous carcinoma of endometrium (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116381000119105",
+        "display": "Ganglioneuroblastoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116691000119101",
+        "display": "Marginal zone lymphoma of spleen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116841000119105",
+        "display": "Marginal zone lymphoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116871000119103",
+        "display": "Mantle cell lymphoma of lymph nodes of multiple sites (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "117211000119105",
+        "display": "Peripheral T-cell lymphoma of lymph nodes of multiple sites (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "123631000119103",
+        "display": "Malignant poorly differentiated neuroendocrine carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "123691000119104",
+        "display": "Malignant carcinoid tumor of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "128041000119107",
+        "display": "Primary adenocarcinoma of distal third of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "130941000119107",
+        "display": "Primary chordoma of bone of skull (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "133531000119104",
+        "display": "Malignant neuroendocrine tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "133751000119102",
+        "display": "Lymphoma of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "133841000119105",
+        "display": "Merkel cell carcinoma of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "133871000119103",
+        "display": "Merkel cell carcinoma of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "133881000119100",
+        "display": "Merkel cell carcinoma of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "143291000119104",
+        "display": "Non-Hodgkin lymphoma in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "145831000119103",
+        "display": "Primary malignant germ cell neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "147101000119108",
+        "display": "Primary malignant astrocytoma of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "147131000119101",
+        "display": "Glioblastoma multiforme of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "148911000119107",
+        "display": "Primary malignant neoplasm of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "184741000119107",
+        "display": "Primary adenocarcinoma of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "184781000119102",
+        "display": "Primary adenocarcinoma of uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "184871000119108",
+        "display": "Primary adenocarcinoma of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "184881000119106",
+        "display": "Primary adenocarcinoma of rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "184891000119109",
+        "display": "Primary adenocarcinoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "208041000119100",
+        "display": "Primary adenocarcinoma of endocervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "226521000119108",
+        "display": "Primary malignant tumor of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "234941000119100",
+        "display": "Malignant glioma of eye (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "236811000119101",
+        "display": "Pagets disease of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "242951000119108",
+        "display": "Primary squamous cell carcinoma of vermilion border of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350621000119100",
+        "display": "Primary malignant neoplasm of right acoustic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350631000119102",
+        "display": "Primary malignant neoplasm of left vestibulocochlear nerve (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350681000119101",
+        "display": "Primary malignant neoplasm of adrenal medulla of right adrenal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350801000119105",
+        "display": "Primary malignant neoplasm of left adrenal cortex"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350851000119109",
+        "display": "Primary malignant neoplasm of adrenal medulla of left adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350861000119106",
+        "display": "Primary malignant neoplasm of right adrenal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350881000119102",
+        "display": "Primary malignant neoplasm of right adrenal cortex (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350921000119109",
+        "display": "Primary malignant neoplasm of left adrenal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350951000119101",
+        "display": "B-cell lymphoma of intra-abdominal lymph nodes (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "351041000119109",
+        "display": "Primary malignant neoplasm of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "351051000119106",
+        "display": "Primary malignant neoplasm of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "351211000119104",
+        "display": "B-cell lymphoma of lymph nodes of multiple sites (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "351251000119103",
+        "display": "Acute myelofibrosis in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "351461000119100",
+        "display": "Merkel cell carcinoma of right lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "351961000119109",
+        "display": "Malignant melanoma of skin of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352001000119100",
+        "display": "Malignant melanoma of skin of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352071000119105",
+        "display": "Merkel cell carcinoma of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352201000119105",
+        "display": "Malignant melanoma of skin of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352231000119103",
+        "display": "Primary malignant neoplasm of soft tissue of left upper extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352251000119109",
+        "display": "Small lymphocytic B-cell lymphoma of lymph nodes of multiple sites (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352301000119103",
+        "display": "Primary malignant neoplasm of soft tissue of right upper extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352311000119100",
+        "display": "Primary malignant neoplasm of soft tissue of right lower extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352321000119107",
+        "display": "Primary malignant neoplasm of soft tissue of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352331000119105",
+        "display": "Primary malignant neoplasm of left spermatic cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352341000119101",
+        "display": "Primary malignant neoplasm of right spermatic cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352381000119106",
+        "display": "Primary malignant neoplasm of skin of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352391000119109",
+        "display": "Primary malignant neoplasm of skin of left ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352411000119109",
+        "display": "Small lymphocytic B-cell lymphoma of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352421000119102",
+        "display": "Primary malignant neoplasm of skin of left shoulder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352431000119104",
+        "display": "Primary malignant neoplasm of skin of right ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352461000119107",
+        "display": "Primary malignant neoplasm of skin of right lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352471000119101",
+        "display": "Primary malignant neoplasm of skin of right shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352481000119103",
+        "display": "Primary malignant neoplasm of skin of left lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352551000119106",
+        "display": "Primary malignant neoplasm of left descended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352581000119104",
+        "display": "Primary malignant neoplasm of right descended testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352701000119102",
+        "display": "Primary malignant neoplasm of neck of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352731000119109",
+        "display": "Primary malignant neoplasm of peripheral nerves of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352751000119103",
+        "display": "Primary malignant neoplasm of peripheral nerves of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352771000119107",
+        "display": "Primary malignant neoplasm of peripheral nerves of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352791000119108",
+        "display": "Non-Hodgkin's lymphoma of lymph nodes of multiple sites (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352911000119101",
+        "display": "Primary malignant neoplasm of left optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352921000119108",
+        "display": "Primary malignant neoplasm of right optic nerve (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352961000119103",
+        "display": "Primary malignant neoplasm of right renal pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353061000119107",
+        "display": "Primary malignant neoplasm of right retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353081000119103",
+        "display": "Primary malignant neoplasm of retina of left eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353111000119108",
+        "display": "Primary malignant neoplasm of left renal pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353211000119103",
+        "display": "Extramedullary plasmacytoma in remission (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353421000119109",
+        "display": "Primary malignant neoplasm of axillary tail of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353431000119107",
+        "display": "Primary malignant neoplasm of female left breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353441000119103",
+        "display": "Primary malignant neoplasm of central portion of female left breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353501000119104",
+        "display": "Primary malignant neoplasm of axillary tail of right female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353511000119101",
+        "display": "Primary malignant neoplasm of female right breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353521000119108",
+        "display": "Primary malignant neoplasm of central portion of female right breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353661000119102",
+        "display": "Overlapping primary malignant neoplasm of bone and articular cartilage of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353671000119108",
+        "display": "Overlapping primary malignant neoplasm of bone and articular cartilage of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353761000119105",
+        "display": "Primary malignant neoplasm of cornea of left eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353791000119103",
+        "display": "Primary malignant neoplasm of right conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353801000119102",
+        "display": "Primary malignant neoplasm of right choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353811000119104",
+        "display": "Primary malignant neoplasm of cornea of right eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353841000119100",
+        "display": "Primary malignant neoplasm of left conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354301000119106",
+        "display": "Primary malignant neoplasm of left choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354331000119104",
+        "display": "Primary malignant neoplasm of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354351000119105",
+        "display": "Primary malignant neoplasm of left kidney (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354361000119107",
+        "display": "Primary malignant neoplasm of right kidney (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354391000119100",
+        "display": "Kaposi sarcoma of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354421000119107",
+        "display": "Primary malignant neoplasm of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354461000119102",
+        "display": "Kaposi sarcoma of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354491000119109",
+        "display": "Primary malignant neoplasm of left male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354591000119108",
+        "display": "Primary malignant neoplasm of right male breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354621000119105",
+        "display": "Overlapping primary malignant neoplasm of bone and articular cartilage of left upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354641000119104",
+        "display": "Primary malignant neoplasm of bone of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354651000119102",
+        "display": "Primary malignant neoplasm of bone of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354671000119106",
+        "display": "Primary malignant neoplasm of bone of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354681000119109",
+        "display": "Primary malignant neoplasm of bone of right lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354721000119103",
+        "display": "Primary malignant neoplasm of left main bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354731000119100",
+        "display": "Primary malignant neoplasm of right main bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354851000119101",
+        "display": "Follicular non-Hodgkin's lymphoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "355141000119106",
+        "display": "Primary malignant neoplasm of skin of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "550991000124107",
+        "display": "Cancer in complete remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "551001000124108",
+        "display": "Malignant neoplasm in partial remission"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681591000119108",
+        "display": "Primary adenocarcinoma of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681601000119101",
+        "display": "Primary adenocarcinoma of ascending colon (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681611000119103",
+        "display": "Primary adenocarcinoma of neck of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681621000119105",
+        "display": "Primary adenocarcinoma of body of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681631000119108",
+        "display": "Primary adenocarcinoma of body of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681651000119102",
+        "display": "Primary adenocarcinoma of descending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681661000119100",
+        "display": "Primary adenocarcinoma of dome of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681681000119109",
+        "display": "Primary adenocarcinoma of fundus of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681691000119107",
+        "display": "Primary adenocarcinoma of gastrointestinal tract (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681701000119107",
+        "display": "Primary adenocarcinoma of greater curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681711000119105",
+        "display": "Primary adenocarcinoma of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681721000119103",
+        "display": "Primary adenocarcinoma of head of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681751000119106",
+        "display": "Primary adenocarcinoma of intrahepatic bile duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681781000119104",
+        "display": "Primary adenocarcinoma of lesser curvature of stomach (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681821000119109",
+        "display": "Primary adenocarcinoma of neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681831000119107",
+        "display": "Primary adenocarcinoma of neck of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681911000119108",
+        "display": "Primary adenocarcinoma of pancreatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681921000119101",
+        "display": "Primary adenocarcinoma of posterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681941000119107",
+        "display": "Primary adenocarcinoma of pylorus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681971000119100",
+        "display": "Primary adenocarcinoma of tail of pancreas (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "681991000119104",
+        "display": "Primary adenocarcinoma of trigone of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682031000119109",
+        "display": "Primary adenocarcinoma of urachus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682041000119100",
+        "display": "Primary adenocarcinoma of ureteric orifice"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682221000119103",
+        "display": "Primary anaplastic astrocytoma of cerebrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682231000119100",
+        "display": "Primary anaplastic astrocytoma of frontal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682241000119109",
+        "display": "Primary anaplastic astrocytoma of occipital lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682251000119106",
+        "display": "Primary anaplastic astrocytoma of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682261000119108",
+        "display": "Primary anaplastic astrocytoma of temporal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682271000119102",
+        "display": "Primary angiosarcoma of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682291000119101",
+        "display": "Primary angiosarcoma of axillary region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682311000119102",
+        "display": "Primary angiosarcoma of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682321000119109",
+        "display": "Primary angiosarcoma of head (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682361000119104",
+        "display": "Primary angiosarcoma of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682381000119108",
+        "display": "Primary angiosarcoma of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682411000119106",
+        "display": "Primary angiosarcoma of thorax (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682421000119104",
+        "display": "Primary angiosarcoma of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682441000119105",
+        "display": "Primary astrocytoma of cerebral ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682451000119107",
+        "display": "Primary astrocytoma of frontal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682461000119109",
+        "display": "Primary astrocytoma of occipital lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682471000119103",
+        "display": "Primary astrocytoma of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682481000119100",
+        "display": "Primary astrocytoma of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "682541000119106",
+        "display": "Primary basal cell carcinoma of skin of perianal area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683031000119101",
+        "display": "Primary carcinoma ex pleomorphic adenoma of salivary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683041000119105",
+        "display": "Primary carcinoma ex pleomorphic adenoma of submandibular gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683121000119103",
+        "display": "Primary chondrosarcoma of mandible (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683131000119100",
+        "display": "Primary chondrosarcoma of vertebral column (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683761000119107",
+        "display": "Primary ependymoma of brain ventricle (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683791000119100",
+        "display": "Primary ependymoma of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683981000119101",
+        "display": "Primary Ewing sarcoma of bone of spine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "683991000119103",
+        "display": "Extensive stage primary small cell carcinoma of lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "684901000119107",
+        "display": "Primary glioblastoma multiforme of cerebrum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "684911000119105",
+        "display": "Primary glioblastoma multiforme of frontal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "684921000119103",
+        "display": "Primary glioblastoma multiforme of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "684931000119100",
+        "display": "Primary glioblastoma multiforme of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "684941000119109",
+        "display": "Primary glioblastoma multiforme of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685571000119105",
+        "display": "Primary leiomyosarcoma of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685601000119104",
+        "display": "Primary leiomyosarcoma of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685611000119101",
+        "display": "Primary leiomyosarcoma of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685621000119108",
+        "display": "Primary leiomyosarcoma of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685641000119102",
+        "display": "Primary leiomyosarcoma of inguinal region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685671000119109",
+        "display": "Primary leiomyosarcoma of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685691000119105",
+        "display": "Primary leiomyosarcoma of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685701000119105",
+        "display": "Primary leiomyosarcoma of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685721000119101",
+        "display": "Primary leiomyosarcoma of thorax (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685731000119103",
+        "display": "Primary leiomyosarcoma of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685831000119105",
+        "display": "Primary liposarcoma of soft tissue of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685851000119104",
+        "display": "Primary liposarcoma of soft tissue of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685861000119102",
+        "display": "Primary liposarcoma of soft tissue of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685901000119108",
+        "display": "Primary liposarcoma of soft tissue of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685921000119104",
+        "display": "Primary liposarcoma of soft tissue of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685941000119105",
+        "display": "Primary liposarcoma of soft tissue of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685951000119107",
+        "display": "Primary liposarcoma of soft tissue of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685971000119103",
+        "display": "Primary liposarcoma of soft tissue of thorax (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "685981000119100",
+        "display": "Primary liposarcoma of soft tissue of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686431000119100",
+        "display": "Primary malignant glioma of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686441000119109",
+        "display": "Primary malignant glioma of occipital lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686451000119106",
+        "display": "Primary malignant glioma of parietal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686461000119108",
+        "display": "Primary malignant glioma of temporal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686591000119102",
+        "display": "Primary malignant pheochromocytoma of left adrenal gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686601000119109",
+        "display": "Primary malignant pheochromocytoma of right adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686981000119108",
+        "display": "Mycosis fungoides of inguinal lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "686991000119106",
+        "display": "Mycosis fungoides of lower limb lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687331000119109",
+        "display": "Primary oligodendroglioma of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687351000119103",
+        "display": "Primary oligodendroglioma of parietal lobe (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687361000119101",
+        "display": "Primary oligodendroglioma of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687401000119105",
+        "display": "Primary osteosarcoma of mandible"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687421000119101",
+        "display": "Primary osteosarcoma of vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687771000119106",
+        "display": "Primary rhabdomyosarcoma of abdomen (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687801000119108",
+        "display": "Primary rhabdomyosarcoma of buttock (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687811000119106",
+        "display": "Primary rhabdomyosarcoma of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687821000119104",
+        "display": "Primary rhabdomyosarcoma of head (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687841000119105",
+        "display": "Primary rhabdomyosarcoma of inguinal region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687861000119109",
+        "display": "Primary rhabdomyosarcoma of neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687881000119100",
+        "display": "Primary rhabdomyosarcoma of pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687891000119102",
+        "display": "Primary rhabdomyosarcoma of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687911000119100",
+        "display": "Primary rhabdomyosarcoma of thorax (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687941000119101",
+        "display": "Primary sarcoma of soft tissues of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687961000119102",
+        "display": "Primary sarcoma of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687971000119108",
+        "display": "Primary sarcoma of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "687991000119109",
+        "display": "Primary sarcoma of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688011000119102",
+        "display": "Primary sarcoma of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688031000119107",
+        "display": "Primary sarcoma of neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688061000119104",
+        "display": "Primary sarcoma of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688081000119108",
+        "display": "Primary sarcoma of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688091000119106",
+        "display": "Primary sarcoma of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688321000119107",
+        "display": "Primary malignant neoplasm of skin of bridge of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688381000119106",
+        "display": "Primary malignant neoplasm of skin of ala nasi"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688411000119109",
+        "display": "Primary malignant neoplasm of skin of tip of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688671000119103",
+        "display": "Primary squamous cell carcinoma of anterior floor of mouth (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688681000119100",
+        "display": "Primary squamous cell carcinoma of anterior two thirds of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688691000119102",
+        "display": "Primary squamous cell carcinoma of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688711000119104",
+        "display": "Primary squamous cell carcinoma of aryepiglottic fold (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688731000119109",
+        "display": "Primary squamous cell carcinoma of neck of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688751000119103",
+        "display": "Primary squamous cell carcinoma of border of tongue (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688781000119105",
+        "display": "Primary squamous cell carcinoma of commissure of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688801000119109",
+        "display": "Primary squamous cell carcinoma of dome of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688811000119107",
+        "display": "Primary squamous cell carcinoma of dorsal surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688861000119105",
+        "display": "Primary squamous cell carcinoma of hard palate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688891000119103",
+        "display": "Primary squamous cell carcinoma of mucous membrane of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688901000119104",
+        "display": "Primary squamous cell carcinoma of mucous membrane of lower lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688911000119101",
+        "display": "Primary squamous cell carcinoma of mucous membrane of upper lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688931000119106",
+        "display": "Primary squamous cell carcinoma of lateral portion of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688941000119102",
+        "display": "Primary squamous cell carcinoma of lateral wall of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "688981000119107",
+        "display": "Primary squamous cell carcinoma of lower gum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689211000119102",
+        "display": "Primary squamous cell carcinoma of perianal skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689231000119107",
+        "display": "Primary squamous cell carcinoma of posterior wall of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689251000119101",
+        "display": "Primary squamous cell carcinoma of posterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689281000119108",
+        "display": "Primary squamous cell carcinoma of retromolar area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689311000119105",
+        "display": "Primary squamous cell carcinoma of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689361000119108",
+        "display": "Primary squamous cell carcinoma of tonsillar fossa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689371000119102",
+        "display": "Primary squamous cell carcinoma of tonsillar pillar (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689401000119104",
+        "display": "Primary squamous cell carcinoma of upper gum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689441000119102",
+        "display": "Primary squamous cell carcinoma of ureteral orifice"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689451000119100",
+        "display": "Primary squamous cell carcinoma of uvula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689471000119109",
+        "display": "Primary squamous cell carcinoma of ventral surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689481000119107",
+        "display": "Primary squamous cell carcinoma of vermilion border of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689491000119105",
+        "display": "Primary squamous cell carcinoma of vermilion border of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689501000119103",
+        "display": "Primary squamous cell carcinoma of vestibule of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689771000119103",
+        "display": "Primary transitional cell carcinoma of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689781000119100",
+        "display": "Primary transitional cell carcinoma of neck of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689791000119102",
+        "display": "Primary transitional cell carcinoma of dome of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689801000119101",
+        "display": "Primary transitional cell carcinoma of lateral wall of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689821000119105",
+        "display": "Primary transitional cell carcinoma of posterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689831000119108",
+        "display": "Primary transitional cell carcinoma of trigone of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "689851000119102",
+        "display": "Primary transitional cell carcinoma of ureteric orifice"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "690121000119109",
+        "display": "Primary basal cell carcinoma of skin of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "690141000119103",
+        "display": "Primary basal cell carcinoma of skin of male genitalia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078881000119102",
+        "display": "Primary adenocarcinoma of lower lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078891000119104",
+        "display": "Primary adenocarcinoma of left main bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078901000119100",
+        "display": "Primary adenocarcinoma of upper lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078931000119107",
+        "display": "Primary adenocarcinoma of lower lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078941000119103",
+        "display": "Primary adenocarcinoma of right main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078951000119101",
+        "display": "Primary adenocarcinoma of middle lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078961000119104",
+        "display": "Primary adenocarcinoma of upper lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078971000119105",
+        "display": "Adenoid cystic carcinoma of left lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1078981000119108",
+        "display": "Adenoid cystic carcinoma of right lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079011000119109",
+        "display": "Primary angiosarcoma of left upper extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079021000119102",
+        "display": "Primary angiosarcoma of left hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079031000119104",
+        "display": "Primary angiosarcoma of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079051000119105",
+        "display": "Primary angiosarcoma of right upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079061000119107",
+        "display": "Primary angiosarcoma of right hip region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079071000119101",
+        "display": "Primary angiosarcoma of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079091000119100",
+        "display": "Primary basal cell carcinoma of left upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079101000119105",
+        "display": "Primary basal cell carcinoma of left ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079111000119108",
+        "display": "Primary basal cell carcinoma of left eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079121000119101",
+        "display": "Primary basal cell carcinoma of skin of left hip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079131000119103",
+        "display": "Primary basal cell carcinoma of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079141000119107",
+        "display": "Primary basal cell carcinoma of skin of left shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079151000119109",
+        "display": "Primary basal cell carcinoma of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079161000119106",
+        "display": "Primary basal cell carcinoma of right ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079171000119100",
+        "display": "Primary basal cell carcinoma of right eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079181000119102",
+        "display": "Primary basal cell carcinoma of skin of right hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079191000119104",
+        "display": "Primary basal cell carcinoma of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079201000119101",
+        "display": "Primary basal cell carcinoma of skin of right shoulder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079551000119100",
+        "display": "Primary chondrosarcoma of bone of left upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079561000119103",
+        "display": "Primary chondrosarcoma of bone of left foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079571000119109",
+        "display": "Primary chondrosarcoma of bone of left hand (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079581000119107",
+        "display": "Primary chondrosarcoma of bone of left lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079591000119105",
+        "display": "Primary chondrosarcoma of left scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079601000119103",
+        "display": "Primary chondrosarcoma of bone of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079611000119100",
+        "display": "Primary chondrosarcoma of bone of right foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079621000119107",
+        "display": "Primary chondrosarcoma of bone of right hand (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079631000119105",
+        "display": "Primary chondrosarcoma of bone of right lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079641000119101",
+        "display": "Primary chondrosarcoma of right scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079991000119101",
+        "display": "Primary Ewing sarcoma of bone of left upper extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080001000119106",
+        "display": "Primary Ewing sarcoma of bone of left foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080021000119102",
+        "display": "Primary Ewing sarcoma of bone of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080041000119108",
+        "display": "Primary Ewing sarcoma of bone of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080051000119105",
+        "display": "Primary Ewing sarcoma of bone of right foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080071000119101",
+        "display": "Primary Ewing sarcoma of bone of right lower extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080091000119100",
+        "display": "Infiltrating ductal carcinoma of axillary tail of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080111000119108",
+        "display": "Infiltrating ductal carcinoma of central portion of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080121000119101",
+        "display": "Infiltrating ductal carcinoma of lower inner quadrant of left female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080131000119103",
+        "display": "Infiltrating ductal carcinoma of lower outer quadrant of left female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080151000119109",
+        "display": "Infiltrating ductal carcinoma of upper inner quadrant of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080161000119106",
+        "display": "Infiltrating ductal carcinoma of upper outer quadrant of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080171000119100",
+        "display": "Infiltrating ductal carcinoma of axillary tail of right female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080191000119104",
+        "display": "Infiltrating ductal carcinoma of central portion of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080201000119101",
+        "display": "Infiltrating ductal carcinoma of lower inner quadrant of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080211000119103",
+        "display": "Infiltrating ductal carcinoma of lower outer quadrant of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080231000119108",
+        "display": "Infiltrating ductal carcinoma of upper inner quadrant of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080241000119104",
+        "display": "Infiltrating ductal carcinoma of upper outer quadrant of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080261000119100",
+        "display": "Infiltrating lobular carcinoma of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080341000119105",
+        "display": "Infiltrating lobular carcinoma of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080451000119101",
+        "display": "Primary large cell carcinoma of lower lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080471000119105",
+        "display": "Primary large cell carcinoma of upper lobe of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080501000119104",
+        "display": "Primary large cell carcinoma of lower lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080531000119106",
+        "display": "Primary large cell carcinoma of upper lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080541000119102",
+        "display": "Primary leiomyosarcoma of left upper extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080551000119100",
+        "display": "Primary leiomyosarcoma of left hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080561000119103",
+        "display": "Primary leiomyosarcoma of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080571000119109",
+        "display": "Primary leiomyosarcoma of left lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080581000119107",
+        "display": "Primary leiomyosarcoma of left shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080591000119105",
+        "display": "Primary leiomyosarcoma of right upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080601000119103",
+        "display": "Primary leiomyosarcoma of right hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080611000119100",
+        "display": "Primary leiomyosarcoma of right kidney (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080621000119107",
+        "display": "Primary leiomyosarcoma of right lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080631000119105",
+        "display": "Primary leiomyosarcoma of right shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080681000119106",
+        "display": "Primary liposarcoma of soft tissue of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080691000119109",
+        "display": "Primary liposarcoma of soft tissue of left hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080701000119109",
+        "display": "Primary liposarcoma of soft tissue of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080711000119107",
+        "display": "Primary liposarcoma of soft tissue of left shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080721000119100",
+        "display": "Primary liposarcoma of soft tissue of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080731000119102",
+        "display": "Primary liposarcoma of soft tissue of right hip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080741000119106",
+        "display": "Primary liposarcoma of soft tissue of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080751000119108",
+        "display": "Primary liposarcoma of soft tissue of right shoulder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080941000119109",
+        "display": "Malignant melanoma of left choroid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080981000119104",
+        "display": "Malignant melanoma of right choroid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081021000119109",
+        "display": "Malignant melanoma of skin of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081271000119100",
+        "display": "Primary osteosarcoma of bone of left upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081281000119102",
+        "display": "Primary osteosarcoma of bone of left foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081291000119104",
+        "display": "Primary osteosarcoma of bone of left hand (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081301000119103",
+        "display": "Primary osteosarcoma of bone of left lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081311000119100",
+        "display": "Primary osteosarcoma of left scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081321000119107",
+        "display": "Primary osteosarcoma of bone of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081331000119105",
+        "display": "Primary osteosarcoma of bone of right foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081341000119101",
+        "display": "Primary osteosarcoma of bone of right hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081351000119104",
+        "display": "Primary osteosarcoma of bone of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081361000119102",
+        "display": "Primary osteosarcoma of right scapula (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081551000119106",
+        "display": "Recurrent primary malignant neoplasm of left female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081561000119108",
+        "display": "Recurrent primary malignant neoplasm of right female breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081591000119101",
+        "display": "Primary retinoblastoma of left retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081601000119108",
+        "display": "Primary retinoblastoma of right retina (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081611000119106",
+        "display": "Primary rhabdomyosarcoma of left upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081631000119101",
+        "display": "Primary rhabdomyosarcoma of left lower extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081651000119107",
+        "display": "Primary rhabdomyosarcoma of right upper extremity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081671000119103",
+        "display": "Primary rhabdomyosarcoma of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081691000119102",
+        "display": "Primary sarcoma of soft tissues of left upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081701000119102",
+        "display": "Primary sarcoma of soft tissues of left hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081711000119104",
+        "display": "Primary sarcoma of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081721000119106",
+        "display": "Primary sarcoma of left shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081731000119109",
+        "display": "Primary sarcoma of soft tissues of right upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081741000119100",
+        "display": "Primary sarcoma of soft tissues of right hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081751000119103",
+        "display": "Primary sarcoma of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081761000119101",
+        "display": "Primary sarcoma of right shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081781000119105",
+        "display": "Primary seminoma of left testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081811000119107",
+        "display": "Primary seminoma of right testis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081841000119106",
+        "display": "Primary small cell carcinoma of lower lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081851000119108",
+        "display": "Primary small cell carcinoma of left main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081861000119105",
+        "display": "Primary small cell carcinoma of upper lobe of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081891000119103",
+        "display": "Primary small cell carcinoma of lower lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081901000119104",
+        "display": "Primary small cell carcinoma of right main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081911000119101",
+        "display": "Primary small cell carcinoma of middle lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1081921000119108",
+        "display": "Primary small cell carcinoma of upper lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082051000119106",
+        "display": "Primary squamous cell carcinoma of skin of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082061000119108",
+        "display": "Primary squamous cell carcinoma of left conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082071000119102",
+        "display": "Primary squamous cell carcinoma of left ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082091000119101",
+        "display": "Primary squamous cell carcinoma of skin of left hip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082101000119106",
+        "display": "Primary squamous cell carcinoma of skin of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082111000119109",
+        "display": "Primary squamous cell carcinoma of lower lobe of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082121000119102",
+        "display": "Primary squamous cell carcinoma of left main bronchus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082131000119104",
+        "display": "Primary squamous cell carcinoma of skin of left shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082141000119108",
+        "display": "Primary squamous cell carcinoma of upper lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082171000119101",
+        "display": "Primary squamous cell carcinoma of skin of right upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082181000119103",
+        "display": "Primary squamous cell carcinoma of right conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082191000119100",
+        "display": "Primary squamous cell carcinoma of right ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082211000119104",
+        "display": "Primary squamous cell carcinoma of skin of right hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082221000119106",
+        "display": "Primary squamous cell carcinoma of skin of right lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082231000119109",
+        "display": "Primary squamous cell carcinoma of lower lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082241000119100",
+        "display": "Primary squamous cell carcinoma of right main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082251000119103",
+        "display": "Primary squamous cell carcinoma of middle lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082261000119101",
+        "display": "Primary squamous cell carcinoma of skin of right shoulder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082271000119107",
+        "display": "Primary squamous cell carcinoma of upper lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082281000119105",
+        "display": "Transitional cell carcinoma of left renal pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082291000119108",
+        "display": "Transitional cell carcinoma of left ureter (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082301000119109",
+        "display": "Transitional cell carcinoma of right renal pelvis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082311000119107",
+        "display": "Transitional cell carcinoma of right ureter (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082321000119100",
+        "display": "Nephroblastoma of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082331000119102",
+        "display": "Nephroblastoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082701000112100",
+        "display": "LABC - locally advanced breast cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1098981000119101",
+        "display": "Recurrent malignant neoplasm of prostate (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1099571000119100",
+        "display": "Primary malignant neoplasm of left lacrimal sac (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1099581000119102",
+        "display": "Primary malignant neoplasm of right lacrimal sac (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10708511000119108",
+        "display": "Primary malignant neoplasm of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737361000119109",
+        "display": "Primary adenocarcinoma of right fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737401000119100",
+        "display": "Primary adenocarcinoma of left fallopian tube (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737521000119108",
+        "display": "Primary mucinous cystadenocarcinoma of right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737561000119103",
+        "display": "Primary mucinous cystadenocarcinoma of left ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737601000119103",
+        "display": "Primary serous papillary cystadenocarcinoma of right ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737641000119101",
+        "display": "Primary serous papillary cystadenocarcinoma of left ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737781000119101",
+        "display": "Primary endometrioid carcinoma of right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10737821000119106",
+        "display": "Primary endometrioid carcinoma of left ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10745291000119103",
+        "display": "Cancer in childbirth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10749871000119100",
+        "display": "Malignant neoplastic disease in pregnancy"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10976631000119101",
+        "display": "Leiomyosarcoma of skin of chest"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10976711000119104",
+        "display": "Primary primitive neuroectodermal tumor of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "11010461000119101",
+        "display": "Small cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12240951000119107",
+        "display": "Squamous cell carcinoma of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12240991000119102",
+        "display": "Squamous cell carcinoma of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15635721000119108",
+        "display": "Primary malignant neoplasm of both ovaries (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15635801000119106",
+        "display": "Primary malignant neoplasm of bilateral female breasts (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15931021000119108",
+        "display": "Primary sarcoma of left ovary (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15931061000119103",
+        "display": "Primary sarcoma of right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15949941000119101",
+        "display": "Primary squamous cell carcinoma of skin of left breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15950021000119100",
+        "display": "Primary squamous cell carcinoma of skin of right breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15950061000119105",
+        "display": "Primary malignant neoplasm of skin of right breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15950101000119108",
+        "display": "Primary basal cell carcinoma of skin of right breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15950141000119105",
+        "display": "Primary basal cell carcinoma of skin of left breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15950221000119108",
+        "display": "Primary malignant neoplasm of skin of left breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15951021000119107",
+        "display": "Bilateral malignant melanoma of skin of lower limbs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15951061000119102",
+        "display": "Malignant melanoma of skin of both upper extremities"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15955101000119101",
+        "display": "Primary malignant neoplasm of right Bartholin's gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15955141000119104",
+        "display": "Primary malignant neoplasm of left greater vestibular gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15955901000119104",
+        "display": "Primary small cell carcinoma of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15955941000119102",
+        "display": "Primary small cell carcinoma of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956341000119105",
+        "display": "Adenocarcinoma of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956381000119100",
+        "display": "Adenocarcinoma of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15957261000119102",
+        "display": "Kaposi sarcoma of bilateral lungs (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958021000119103",
+        "display": "Primary sarcoma of left kidney (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958101000119106",
+        "display": "Primary sarcoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15959061000119101",
+        "display": "Transitional cell carcinoma of left kidney (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15959101000119103",
+        "display": "Transitional cell carcinoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16091131000119108",
+        "display": "Primary angiosarcoma of skin of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16091251000119109",
+        "display": "Primary angiosarcoma of skin of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16091371000119108",
+        "display": "Primary angiosarcoma of skin of temporal region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16091411000119109",
+        "display": "Primary angiosarcoma of skin of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16218761000119102",
+        "display": "Primary squamous cell carcinoma of skin of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16228971000119104",
+        "display": "Primary malignant neoplasm of soft tissue of left hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16229011000119100",
+        "display": "Primary malignant neoplasm of soft tissue of right hip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16260391000119109",
+        "display": "Primary malignant neoplasm of soft tissues of left shoulder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16260431000119104",
+        "display": "Primary malignant neoplasm of soft tissues of right shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16414611000119100",
+        "display": "Primary malignant neoplasm of peripheral nerves of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527441000119105",
+        "display": "Primary non-small cell carcinoma of lower lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527481000119100",
+        "display": "Primary non-small cell carcinoma of middle lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527521000119100",
+        "display": "Primary non-small cell carcinoma of upper lobe of left lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527561000119105",
+        "display": "Primary non-small cell carcinoma of lower lobe of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527601000119105",
+        "display": "Primary non-small cell carcinoma of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527641000119107",
+        "display": "Primary non-small cell carcinoma of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16527721000119108",
+        "display": "Primary non-small cell carcinoma of upper lobe of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16636051000119105",
+        "display": "Primary malignant gastrointestinal stromal neoplasm of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16636101000119105",
+        "display": "Primary malignant gastrointestinal stromal neoplasm of rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16637101000119107",
+        "display": "Primary sarcoma of small intestine (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16699241000119100",
+        "display": "Kaposi's sarcoma of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16774551000119100",
+        "display": "Primary basal cell carcinoma of skin of left hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16774591000119105",
+        "display": "Primary basal cell carcinoma of skin of right hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16774671000119108",
+        "display": "Primary basal cell carcinoma of skin of labium majus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16775311000119107",
+        "display": "Mycosis fungoides of facial lymph node (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16782241000119104",
+        "display": "Primary squamous cell carcinoma of skin of left hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16782321000119104",
+        "display": "Primary squamous cell carcinoma of skin of right hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16823941000119108",
+        "display": "Primary malignant gastrointestinal stromal tumor of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16845301000119108",
+        "display": "Primary glioblastoma multiforme of cerebellum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16845341000119105",
+        "display": "Primary glioblastoma multiforme of brainstem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16845381000119100",
+        "display": "Primary chondrosarcoma of sternum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16899901000119104",
+        "display": "Primary squamous cell carcinoma of skin of chest (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16899941000119102",
+        "display": "Primary squamous cell carcinoma of skin of anus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905141000119107",
+        "display": "Primary malignant neoplasm of skin of right upper eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905341000119105",
+        "display": "Primary malignant neoplasm of skin of right lower eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905381000119100",
+        "display": "Primary basal cell carcinoma of left upper eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905421000119109",
+        "display": "Primary basal cell carcinoma of right upper eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905461000119104",
+        "display": "Primary basal cell carcinoma of right lower eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905501000119104",
+        "display": "Primary basal cell carcinoma of left lower eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905541000119102",
+        "display": "Primary malignant neoplasm of skin of left lower eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16905581000119107",
+        "display": "Primary malignant neoplasm of skin of left upper eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16906481000119103",
+        "display": "Primary squamous cell carcinoma of right upper eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16906521000119103",
+        "display": "Primary squamous cell carcinoma of right lower eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16906561000119108",
+        "display": "Primary squamous cell carcinoma of left upper eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16906601000119108",
+        "display": "Primary squamous cell carcinoma of left lower eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "145194251000119106",
+        "display": "Primary basal cell carcinoma of skin of right foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "145298771000119104",
+        "display": "Malignant carcinoid tumor of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "243971001000119103",
+        "display": "Malignant melanoma of skin of right ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "249389151000119103",
+        "display": "Malignant melanoma of skin of right wrist"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400375351000119102",
+        "display": "Malignant melanoma of skin of left ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428487561000119102",
+        "display": "Primary basal cell carcinoma of skin of left foot (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "455733521000119103",
+        "display": "Primary squamous cell carcinoma of skin of head and/or neck (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763101411000119100",
+        "display": "Primary renal cell carcinoma of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "793197981000119106",
+        "display": "Malignant carcinoid tumor of right lung (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "808558991000119105",
+        "display": "Malignant melanoma of skin of left forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "894171571000119107",
+        "display": "Primary renal cell carcinoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "939595491000119108",
+        "display": "Malignant melanoma of skin of right forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "985355341000119101",
+        "display": "Malignant melanoma of skin of left wrist (disorder)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.0",
+        "display": "Malignant neoplasm of external upper lip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.1",
+        "display": "Malignant neoplasm of external lower lip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.2",
+        "display": "Malignant neoplasm of external lip, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.3",
+        "display": "Malignant neoplasm of upper lip, inner aspect"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.4",
+        "display": "Malignant neoplasm of lower lip, inner aspect"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.5",
+        "display": "Malignant neoplasm of lip, unspecified, inner aspect"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.6",
+        "display": "Malignant neoplasm of commissure of lip, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.8",
+        "display": "Malignant neoplasm of overlapping sites of lip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C00.9",
+        "display": "Malignant neoplasm of lip, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C01",
+        "display": "MALIGNANT NEOPLASM OF BASE OF TONGUE"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.0",
+        "display": "Malignant neoplasm of dorsal surface of tongue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.1",
+        "display": "Malignant neoplasm of border of tongue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.2",
+        "display": "Malignant neoplasm of ventral surface of tongue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.3",
+        "display": "Malignant neoplasm of anterior two-thirds of tongue, part unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.4",
+        "display": "Malignant neoplasm of lingual tonsil"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.8",
+        "display": "Malignant neoplasm of overlapping sites of tongue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C02.9",
+        "display": "Malignant neoplasm of tongue, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C03.0",
+        "display": "Malignant neoplasm of upper gum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C03.1",
+        "display": "Malignant neoplasm of lower gum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C03.9",
+        "display": "Malignant neoplasm of gum, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C04.0",
+        "display": "Malignant neoplasm of anterior floor of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C04.1",
+        "display": "Malignant neoplasm of lateral floor of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C04.8",
+        "display": "Malignant neoplasm of overlapping sites of floor of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C04.9",
+        "display": "Malignant neoplasm of floor of mouth, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C05.0",
+        "display": "Malignant neoplasm of hard palate"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C05.1",
+        "display": "Malignant neoplasm of soft palate"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C05.2",
+        "display": "Malignant neoplasm of uvula"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C05.8",
+        "display": "Malignant neoplasm of overlapping sites of palate"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C05.9",
+        "display": "Malignant neoplasm of palate, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C06.0",
+        "display": "Malignant neoplasm of cheek mucosa"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C06.1",
+        "display": "Malignant neoplasm of vestibule of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C06.2",
+        "display": "Malignant neoplasm of retromolar area"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C06.80",
+        "display": "Malignant neoplasm of overlapping sites of unspecified parts of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C06.89",
+        "display": "Malignant neoplasm of overlapping sites of other parts of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C06.9",
+        "display": "Malignant neoplasm of mouth, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C07",
+        "display": "MALIGNANT NEOPLASM OF PAROTID GLAND"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C08.0",
+        "display": "Malignant neoplasm of submandibular gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C08.1",
+        "display": "Malignant neoplasm of sublingual gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C08.9",
+        "display": "Malignant neoplasm of major salivary gland, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C09.0",
+        "display": "Malignant neoplasm of tonsillar fossa"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C09.1",
+        "display": "Malignant neoplasm of tonsillar pillar (anterior) (posterior)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C09.8",
+        "display": "Malignant neoplasm of overlapping sites of tonsil"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C09.9",
+        "display": "Malignant neoplasm of tonsil, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.0",
+        "display": "Malignant neoplasm of vallecula"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.1",
+        "display": "Malignant neoplasm of anterior surface of epiglottis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.2",
+        "display": "Malignant neoplasm of lateral wall of oropharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.3",
+        "display": "Malignant neoplasm of posterior wall of oropharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.4",
+        "display": "Malignant neoplasm of branchial cleft"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.8",
+        "display": "Malignant neoplasm of overlapping sites of oropharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C10.9",
+        "display": "Malignant neoplasm of oropharynx, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C11.0",
+        "display": "Malignant neoplasm of superior wall of nasopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C11.1",
+        "display": "Malignant neoplasm of posterior wall of nasopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C11.2",
+        "display": "Malignant neoplasm of lateral wall of nasopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C11.3",
+        "display": "Malignant neoplasm of anterior wall of nasopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C11.8",
+        "display": "Malignant neoplasm of overlapping sites of nasopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C11.9",
+        "display": "Malignant neoplasm of nasopharynx, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C12",
+        "display": "MALIGNANT NEOPLASM OF PYRIFORM SINUS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C13.0",
+        "display": "Malignant neoplasm of postcricoid region"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C13.1",
+        "display": "Malignant neoplasm aryepiglottic fold, hypopharyngeal aspect"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C13.2",
+        "display": "Malignant neoplasm of posterior wall of hypopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C13.8",
+        "display": "Malignant neoplasm of overlapping sites of hypopharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C13.9",
+        "display": "Malignant neoplasm of hypopharynx, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C14.0",
+        "display": "Malignant neoplasm of pharynx, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C14.2",
+        "display": "Malignant neoplasm of Waldeyer's ring"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C14.8",
+        "display": "Malignant neoplasm of overlapping sites of lip, oral cavity and pharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C15.3",
+        "display": "Malignant neoplasm of upper third of esophagus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C15.4",
+        "display": "Malignant neoplasm of middle third of esophagus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C15.5",
+        "display": "Malignant neoplasm of lower third of esophagus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C15.8",
+        "display": "Malignant neoplasm of overlapping sites esophagus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C15.9",
+        "display": "Malignant neoplasm of esophagus, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.0",
+        "display": "Malignant neoplasm of cardia"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.1",
+        "display": "Malignant neoplasm of fundus of stomach"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.2",
+        "display": "Malignant neoplasm of body of stomach"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.3",
+        "display": "Malignant neoplasm of pyloric antrum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.4",
+        "display": "Malignant neoplasm of pylorus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.5",
+        "display": "Malignant neoplasm of lesser curvature of stomach, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.6",
+        "display": "Malignant neoplasm of greater curvature of stomach, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.8",
+        "display": "Malignant neoplasm of overlapping sites of stomach"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C16.9",
+        "display": "Malignant neoplasm of stomach, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C17.0",
+        "display": "Malignant neoplasm of duodenum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C17.1",
+        "display": "Malignant neoplasm of jejunum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C17.2",
+        "display": "Malignant neoplasm of ileum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C17.3",
+        "display": "Meckel's diverticulum, malignant"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C17.8",
+        "display": "Malignant neoplasm of overlapping sites of small intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C17.9",
+        "display": "Malignant neoplasm of small intestine, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.0",
+        "display": "Malignant neoplasm of cecum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.1",
+        "display": "Malignant neoplasm of appendix"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.2",
+        "display": "Malignant neoplasm of ascending colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.3",
+        "display": "Malignant neoplasm of hepatic flexure"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.4",
+        "display": "Malignant neoplasm of transverse colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.5",
+        "display": "Malignant neoplasm of splenic flexure"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.6",
+        "display": "Malignant neoplasm of descending colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.7",
+        "display": "Malignant neoplasm of sigmoid colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.8",
+        "display": "Malignant neoplasm of overlapping sites of colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C18.9",
+        "display": "Malignant neoplasm of colon, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C19",
+        "display": "MALIGNANT NEOPLASM OF RECTOSIGMOID JUNCTION"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C20",
+        "display": "MALIGNANT NEOPLASM OF RECTUM"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C21.0",
+        "display": "Malignant neoplasm of anus, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C21.1",
+        "display": "Malignant neoplasm of anal canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C21.2",
+        "display": "Malignant neoplasm of cloacogenic zone"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C21.8",
+        "display": "Malignant neoplasm of overlapping sites of rectum, anus and anal canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.0",
+        "display": "Liver cell carcinoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.1",
+        "display": "Intrahepatic bile duct carcinoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.2",
+        "display": "Hepatoblastoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.3",
+        "display": "Angiosarcoma of liver"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.4",
+        "display": "Other sarcomas of liver"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.7",
+        "display": "Other specified carcinomas of liver"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.8",
+        "display": "Malignant neoplasm of liver, primary, unspecified as to type"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C22.9",
+        "display": "Malignant neoplasm of liver, not specified as primary or secondary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C23",
+        "display": "MALIGNANT NEOPLASM OF GALLBLADDER"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C24.0",
+        "display": "Malignant neoplasm of extrahepatic bile duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C24.1",
+        "display": "Malignant neoplasm of Ampulla of Vater"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C24.8",
+        "display": "Malignant neoplasm of overlapping sites of biliary tract"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C24.9",
+        "display": "Malignant neoplasm of biliary tract, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.0",
+        "display": "Malignant neoplasm of head of pancreas"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.1",
+        "display": "Malignant neoplasm of body of pancreas"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.2",
+        "display": "Malignant neoplasm of tail of pancreas"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.3",
+        "display": "Malignant neoplasm of pancreatic duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.4",
+        "display": "Malignant neoplasm of endocrine pancreas"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.7",
+        "display": "Malignant neoplasm of other parts of pancreas"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.8",
+        "display": "Malignant neoplasm of overlapping sites of pancreas"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C25.9",
+        "display": "Malignant neoplasm of pancreas, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C26.0",
+        "display": "Malignant neoplasm of intestinal tract, part unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C26.1",
+        "display": "Malignant neoplasm of spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C26.9",
+        "display": "Malignant neoplasm of ill-defined sites within the digestive system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C30.0",
+        "display": "Malignant neoplasm of nasal cavity"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C30.1",
+        "display": "Malignant neoplasm of middle ear"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C31.0",
+        "display": "Malignant neoplasm of maxillary sinus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C31.1",
+        "display": "Malignant neoplasm of ethmoidal sinus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C31.2",
+        "display": "Malignant neoplasm of frontal sinus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C31.3",
+        "display": "Malignant neoplasm of sphenoid sinus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C31.8",
+        "display": "Malignant neoplasm of overlapping sites of accessory sinuses"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C31.9",
+        "display": "Malignant neoplasm of accessory sinus, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C32.0",
+        "display": "Malignant neoplasm of glottis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C32.1",
+        "display": "Malignant neoplasm of supraglottis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C32.2",
+        "display": "Malignant neoplasm of subglottis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C32.3",
+        "display": "Malignant neoplasm of laryngeal cartilage"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C32.8",
+        "display": "Malignant neoplasm of overlapping sites of larynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C32.9",
+        "display": "Malignant neoplasm of larynx, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C33",
+        "display": "MALIGNANT NEOPLASM OF TRACHEA"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.00",
+        "display": "Malignant neoplasm of unspecified main bronchus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.01",
+        "display": "Malignant neoplasm of right main bronchus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.02",
+        "display": "Malignant neoplasm of left main bronchus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.10",
+        "display": "Malignant neoplasm of upper lobe, unspecified bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.11",
+        "display": "Malignant neoplasm of upper lobe, right bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.12",
+        "display": "Malignant neoplasm of upper lobe, left bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.2",
+        "display": "Malignant neoplasm of middle lobe, bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.30",
+        "display": "Malignant neoplasm of lower lobe, unspecified bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.31",
+        "display": "Malignant neoplasm of lower lobe, right bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.32",
+        "display": "Malignant neoplasm of lower lobe, left bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.80",
+        "display": "Malignant neoplasm of overlapping sites of unspecified bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.81",
+        "display": "Malignant neoplasm of overlapping sites of right bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.82",
+        "display": "Malignant neoplasm of overlapping sites of left bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.90",
+        "display": "Malignant neoplasm of unspecified part of unspecified bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.91",
+        "display": "Malignant neoplasm of unspecified part of right bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C34.92",
+        "display": "Malignant neoplasm of unspecified part of left bronchus or lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C37",
+        "display": "MALIGNANT NEOPLASM OF THYMUS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C38.0",
+        "display": "Malignant neoplasm of heart"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C38.1",
+        "display": "Malignant neoplasm of anterior mediastinum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C38.2",
+        "display": "Malignant neoplasm of posterior mediastinum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C38.3",
+        "display": "Malignant neoplasm of mediastinum, part unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C38.4",
+        "display": "Malignant neoplasm of pleura"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C38.8",
+        "display": "Malignant neoplasm of overlapping sites of heart, mediastinum and pleura"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C39.0",
+        "display": "Malignant neoplasm of upper respiratory tract, part unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C39.9",
+        "display": "Malignant neoplasm of lower respiratory tract, part unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.00",
+        "display": "Malignant neoplasm of scapula and long bones of unspecified upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.01",
+        "display": "Malignant neoplasm of scapula and long bones of right upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.02",
+        "display": "Malignant neoplasm of scapula and long bones of left upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.10",
+        "display": "Malignant neoplasm of short bones of unspecified upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.11",
+        "display": "Malignant neoplasm of short bones of right upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.12",
+        "display": "Malignant neoplasm of short bones of left upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.20",
+        "display": "Malignant neoplasm of long bones of unspecified lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.21",
+        "display": "Malignant neoplasm of long bones of right lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.22",
+        "display": "Malignant neoplasm of long bones of left lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.30",
+        "display": "Malignant neoplasm of short bones of unspecified lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.31",
+        "display": "Malignant neoplasm of short bones of right lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.32",
+        "display": "Malignant neoplasm of short bones of left lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.80",
+        "display": "Malignant neoplasm of overlapping sites of bone and articular cartilage of unspecified limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.81",
+        "display": "Malignant neoplasm of overlapping sites of bone and articular cartilage of right limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.82",
+        "display": "Malignant neoplasm of overlapping sites of bone and articular cartilage of left limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.90",
+        "display": "Malignant neoplasm of unspecified bones and articular cartilage of unspecified limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.91",
+        "display": "Malignant neoplasm of unspecified bones and articular cartilage of right limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C40.92",
+        "display": "Malignant neoplasm of unspecified bones and articular cartilage of left limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C41.0",
+        "display": "Malignant neoplasm of bones of skull and face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C41.1",
+        "display": "Malignant neoplasm of mandible"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C41.2",
+        "display": "Malignant neoplasm of vertebral column"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C41.3",
+        "display": "Malignant neoplasm of ribs, sternum and clavicle"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C41.4",
+        "display": "Malignant neoplasm of pelvic bones, sacrum and coccyx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C41.9",
+        "display": "Malignant neoplasm of unspecified bones and articular cartilage of limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.0",
+        "display": "Malignant melanoma of lip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.10",
+        "display": "Malignant melanoma of unspecified eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.111",
+        "display": "Malignant melanoma of right upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.112",
+        "display": "Malignant melanoma of right lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.121",
+        "display": "Malignant melanoma of left upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.122",
+        "display": "Malignant melanoma of left lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.20",
+        "display": "Malignant melanoma of unspecified ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.21",
+        "display": "Malignant melanoma of right ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.22",
+        "display": "Malignant melanoma of left ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.30",
+        "display": "Malignant melanoma of unspecified part of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.31",
+        "display": "Malignant melanoma of nose"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.39",
+        "display": "Malignant melanoma of other parts of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.4",
+        "display": "Malignant melanoma of scalp and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.51",
+        "display": "Malignant melanoma of anal skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.52",
+        "display": "Malignant melanoma of skin of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.59",
+        "display": "Malignant melanoma of other part of trunk"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.60",
+        "display": "Malignant melanoma of unspecified upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.61",
+        "display": "Malignant melanoma of right upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.62",
+        "display": "Malignant melanoma of left upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.70",
+        "display": "Malignant melanoma of unspecified lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.71",
+        "display": "Malignant melanoma of right lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.72",
+        "display": "Malignant melanoma of left lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.8",
+        "display": "Malignant melanoma of overlapping sites of skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C43.9",
+        "display": "Malignant melanoma of skin, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.131",
+        "display": "Sebaceous cell carcinoma of skin of unspecified eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.1321",
+        "display": "Sebaceous cell carcinoma of skin of right upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.1322",
+        "display": "Sebaceous cell carcinoma of skin of right lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.1391",
+        "display": "Sebaceous cell carcinoma of skin of left upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.1392",
+        "display": "Sebaceous cell carcinoma of skin of left lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.90",
+        "display": "Unspecified malignant neoplasm of skin, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C44.99",
+        "display": "Other specified malignant neoplasm of skin, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C45.0",
+        "display": "Mesothelioma of pleura"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C45.1",
+        "display": "Mesothelioma of peritoneum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C45.2",
+        "display": "Mesothelioma of pericardium"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C45.7",
+        "display": "Mesothelioma of other sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C45.9",
+        "display": "Mesothelioma, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.0",
+        "display": "Kaposi's sarcoma of skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.1",
+        "display": "Kaposi's sarcoma of soft tissue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.2",
+        "display": "Kaposi's sarcoma of palate"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.3",
+        "display": "Kaposi's sarcoma of lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.4",
+        "display": "Kaposiâ€™s sarcoma of gastrointestinal sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.50",
+        "display": "Kaposi's sarcoma of unspecified lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.51",
+        "display": "Kaposi's sarcoma of right lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.52",
+        "display": "Kaposi's sarcoma of left lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.7",
+        "display": "Kaposi's sarcoma of other sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C46.9",
+        "display": "Kaposi's sarcoma, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.0",
+        "display": "Malignant neoplasm of peripheral nerves of head, face and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.1",
+        "display": "Malignant neoplasm of peripheral nerves of upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.10",
+        "display": "Malignant neoplasm of peripheral nerves of unspecified upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.11",
+        "display": "Malignant neoplasm of peripheral nerves of right upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.12",
+        "display": "Malignant neoplasm of peripheral nerves of left upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.20",
+        "display": "Malignant neoplasm of peripheral nerves of unspecified lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.21",
+        "display": "Malignant neoplasm of peripheral nerves of right lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.22",
+        "display": "Malignant neoplasm of peripheral nerves of left lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.3",
+        "display": "Malignant neoplasm of peripheral nerves of thorax"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.4",
+        "display": "Malignant neoplasm of peripheral nerves of abdomen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.5",
+        "display": "Malignant neoplasm of peripheral nerves of pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.6",
+        "display": "Malignant neoplasm of peripheral nerves of trunk, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.8",
+        "display": "Malignant neoplasm of overlapping sites of peripheral nerves and autonomic nervous system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C47.9",
+        "display": "Malignant neoplasm of peripheral nerves and autonomic nervous system, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C48.0",
+        "display": "Malignant neoplasm of retroperitoneum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C48.1",
+        "display": "Malignant neoplasm of specified parts of peritoneum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C48.2",
+        "display": "Malignant neoplasm of peritoneum, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C48.8",
+        "display": "Malignant neoplasm of overlapping sites of retroperitoneum and peritoneum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.0",
+        "display": "Malignant neoplasm of connective and soft tissue of head, face and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.10",
+        "display": "Malignant neoplasm of connective and soft tissue of unspecified upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.11",
+        "display": "Malignant neoplasm of connective and soft tissue of right upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.12",
+        "display": "Malignant neoplasm of connective and soft tissue of left upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.20",
+        "display": "Malignant neoplasm of connective and soft tissue of unspecified lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.21",
+        "display": "Malignant neoplasm of connective and soft tissue of right lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.22",
+        "display": "Malignant neoplasm of connective and soft tissue of left lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.3",
+        "display": "Malignant neoplasm of connective and soft tissue of thorax"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.4",
+        "display": "Malignant neoplasm of connective and soft tissue of abdomen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.5",
+        "display": "Malignant neoplasm of connective and soft tissue of pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.6",
+        "display": "Malignant neoplasm of connective and soft tissue of trunk, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.8",
+        "display": "Malignant neoplasm of overlapping sites of connective and soft tissue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.9",
+        "display": "Malignant neoplasm of connective and soft tissue, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A0",
+        "display": "Gastrointestinal stromal tumor, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A1",
+        "display": "Gastrointestinal stromal tumor of esophagus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A2",
+        "display": "Gastrointestinal stromal tumor of stomach"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A3",
+        "display": "Gastrointestinal stromal tumor of small intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A4",
+        "display": "Gastrointestinal stromal tumor of large intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A5",
+        "display": "Gastrointestinal stromal tumor of rectum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C49.A9",
+        "display": "Gastrointestinal stromal tumor of other site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.0",
+        "display": "Merkel cell carcinoma of lip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.10",
+        "display": "Merkel cell carcinoma of unspecified eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.111",
+        "display": "Merkel cell carcinoma of right upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.112",
+        "display": "Merkel cell carcinoma of right lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.121",
+        "display": "Merkel cell carcinoma of left upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.122",
+        "display": "Merkel cell carcinoma of left lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.20",
+        "display": "Merkel cell carcinoma of unspecified ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.21",
+        "display": "Merkel cell carcinoma of right ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.22",
+        "display": "Merkel cell carcinoma of left ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.30",
+        "display": "Merkel cell carcinoma of unspecified part of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.31",
+        "display": "Merkel cell carcinoma of nose"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.39",
+        "display": "Merkel cell carcinoma of other parts of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.4",
+        "display": "Merkel cell carcinoma of scalp and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.51",
+        "display": "Merkel cell carcinoma of anal skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.52",
+        "display": "Merkel cell carcinoma of skin of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.59",
+        "display": "Merkel cell carcinoma of other part of trunk"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.60",
+        "display": "Merkel cell carcinoma of unspecified upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.61",
+        "display": "Merkel cell carcinoma of right upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.62",
+        "display": "Merkel cell carcinoma of left upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.70",
+        "display": "Merkel cell carcinoma of unspecified lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.71",
+        "display": "Merkel cell carcinoma of right lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.72",
+        "display": "Merkel cell carcinoma of left lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.8",
+        "display": "Merkel cell carcinoma of overlapping sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C4A.9",
+        "display": "Merkel cell carcinoma, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.011",
+        "display": "Malignant neoplasm of nipple and areola, right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.012",
+        "display": "Malignant neoplasm of nipple and areola, left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.019",
+        "display": "Malignant neoplasm of nipple and areola, unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.021",
+        "display": "Malignant neoplasm of nipple and areola, right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.022",
+        "display": "Malignant neoplasm of nipple and areola, left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.029",
+        "display": "Malignant neoplasm of nipple and areola, unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.111",
+        "display": "Malignant neoplasm of central portion of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.112",
+        "display": "Malignant neoplasm of central portion of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.119",
+        "display": "Malignant neoplasm of central portion of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.121",
+        "display": "Malignant neoplasm of central portion of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.122",
+        "display": "Malignant neoplasm of central portion of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.129",
+        "display": "Malignant neoplasm of central portion of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.211",
+        "display": "Malignant neoplasm of upper-inner quadrant of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.212",
+        "display": "Malignant neoplasm of upper-inner quadrant of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.219",
+        "display": "Malignant neoplasm of upper-inner quadrant of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.221",
+        "display": "Malignant neoplasm of upper-inner quadrant of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.222",
+        "display": "Malignant neoplasm of upper-inner quadrant of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.229",
+        "display": "Malignant neoplasm of upper-inner quadrant of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.311",
+        "display": "Malignant neoplasm of lower-inner quadrant of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.312",
+        "display": "Malignant neoplasm of lower-inner quadrant of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.319",
+        "display": "Malignant neoplasm of lower-inner quadrant of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.321",
+        "display": "Malignant neoplasm of lower-inner quadrant of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.322",
+        "display": "Malignant neoplasm of lower-inner quadrant of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.329",
+        "display": "Malignant neoplasm of lower-inner quadrant of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.411",
+        "display": "Malignant neoplasm of upper-outer quadrant of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.412",
+        "display": "Malignant neoplasm of upper-outer quadrant of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.419",
+        "display": "Malignant neoplasm of upper-outer quadrant of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.421",
+        "display": "Malignant neoplasm of upper-outer quadrant of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.422",
+        "display": "Malignant neoplasm of upper-outer quadrant of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.429",
+        "display": "Malignant neoplasm of upper-outer quadrant of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.511",
+        "display": "Malignant neoplasm of lower-outer quadrant of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.512",
+        "display": "Malignant neoplasm of lower-outer quadrant of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.519",
+        "display": "Malignant neoplasm of lower-outer quadrant of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.521",
+        "display": "Malignant neoplasm of lower-outer quadrant of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.522",
+        "display": "Malignant neoplasm of lower-outer quadrant of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.529",
+        "display": "Malignant neoplasm of lower-outer quadrant of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.611",
+        "display": "Malignant neoplasm of axillary tail of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.612",
+        "display": "Malignant neoplasm of axillary tail of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.619",
+        "display": "Malignant neoplasm of axillary tail of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.621",
+        "display": "Malignant neoplasm of axillary tail of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.622",
+        "display": "Malignant neoplasm of axillary tail of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.629",
+        "display": "Malignant neoplasm of axillary tail of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.811",
+        "display": "Malignant neoplasm of overlapping sites of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.812",
+        "display": "Malignant neoplasm of overlapping sites of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.819",
+        "display": "Malignant neoplasm of overlapping sites of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.821",
+        "display": "Malignant neoplasm of overlapping sites of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.822",
+        "display": "Malignant neoplasm of overlapping sites of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.829",
+        "display": "Malignant neoplasm of overlapping sites of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.911",
+        "display": "Malignant neoplasm of unspecified site of right female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.912",
+        "display": "Malignant neoplasm of unspecified site of left female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.919",
+        "display": "Malignant neoplasm of unspecified site of unspecified female breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.921",
+        "display": "Malignant neoplasm of unspecified site of right male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.922",
+        "display": "Malignant neoplasm of unspecified site of left male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C50.929",
+        "display": "Malignant neoplasm of unspecified site of unspecified male breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C51.0",
+        "display": "Malignant neoplasm of labium majus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C51.1",
+        "display": "Malignant neoplasm of labium minus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C51.2",
+        "display": "Malignant neoplasm of clitoris"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C51.8",
+        "display": "Malignant neoplasm of other specified female genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C51.9",
+        "display": "Malignant neoplasm of vulva, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C52",
+        "display": "MALIGNANT NEOPLASM OF VAGINA"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C53.0",
+        "display": "Malignant neoplasm of endocervix"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C53.1",
+        "display": "Malignant neoplasm of exocervix"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C53.8",
+        "display": "Malignant neoplasm of overlapping sites of cervix uteri"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C53.9",
+        "display": "Malignant neoplasm of cervix uteri, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C54.0",
+        "display": "Malignant neoplasm of isthmus uteri"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C54.1",
+        "display": "Malignant neoplasm of endometrium"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C54.2",
+        "display": "Malignant neoplasm of myometrium"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C54.3",
+        "display": "Malignant neoplasm of fundus uteri"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C54.8",
+        "display": "Malignant neoplasm of overlapping sites of corpus uteri"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C54.9",
+        "display": "Malignant neoplasm of corpus uteri, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C55",
+        "display": "MALIGNANT NEOPLASM OF UTERUS, PART UNSPECIFIED"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C56.1",
+        "display": "Malignant neoplasm of right ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C56.2",
+        "display": "Malignant neoplasm of left ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C56.9",
+        "display": "Malignant neoplasm of unspecified ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.00",
+        "display": "Malignant neoplasm of unspecified fallopian tube"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.01",
+        "display": "Malignant neoplasm of right fallopian tube"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.02",
+        "display": "Malignant neoplasm of left fallopian tube"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.10",
+        "display": "Malignant neoplasm of unspecified broad ligament"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.11",
+        "display": "Malignant neoplasm of right broad ligament"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.12",
+        "display": "Malignant neoplasm of left broad ligament"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.20",
+        "display": "Malignant neoplasm of unspecified round ligament"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.21",
+        "display": "Malignant neoplasm of right round ligament"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.22",
+        "display": "Malignant neoplasm of left round ligament"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.3",
+        "display": "Malignant neoplasm of parametrium"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.4",
+        "display": "Malignant neoplasm of uterine adnexa, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.7",
+        "display": "Malignant neoplasm of overlapping sites of vulva"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.8",
+        "display": "Malignant neoplasm of overlapping sites of female genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C57.9",
+        "display": "Malignant neoplasm of female genital organ, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C58",
+        "display": "MALIGNANT NEOPLASM OF PLACENTA"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C60.0",
+        "display": "Malignant neoplasm of prepuce"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C60.1",
+        "display": "Malignant neoplasm of glans penis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C60.2",
+        "display": "Malignant neoplasm of body of penis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C60.8",
+        "display": "Malignant neoplasm of overlapping sites of penis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C60.9",
+        "display": "Malignant neoplasm of penis, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C61",
+        "display": "MALIGNANT NEOPLASM OF PROSTATE"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.00",
+        "display": "Malignant neoplasm of unspecified undescended testis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.01",
+        "display": "Malignant neoplasm of undescended right testis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.02",
+        "display": "Malignant neoplasm of undescended left testis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.10",
+        "display": "Malignant neoplasm of unspecified descended testis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.11",
+        "display": "Malignant neoplasm of descended right testis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.12",
+        "display": "Malignant neoplasm of descended left testis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.90",
+        "display": "Malignant neoplasm of unspecified testis, unspecified whether descended or undescended"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.91",
+        "display": "Malignant neoplasm of right testis, unspecified whether descended or undescended"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C62.92",
+        "display": "Malignant neoplasm of left testis, unspecified whether descended or undescended"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.00",
+        "display": "Malignant neoplasm of unspecified epididymis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.01",
+        "display": "Malignant neoplasm of right epididymis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.02",
+        "display": "Malignant neoplasm of left epididymis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.10",
+        "display": "Malignant neoplasm of unspecified spermatic cord"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.11",
+        "display": "Malignant neoplasm of right spermatic cord"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.12",
+        "display": "Malignant neoplasm of left spermatic cord"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.2",
+        "display": "Malignant neoplasm of scrotum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.7",
+        "display": "Malignant neoplasm of other specified male genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.8",
+        "display": "Malignant neoplasm of overlapping sites of male genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C63.9",
+        "display": "Malignant neoplasm of male genital organ, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C64.1",
+        "display": "Malignant neoplasm of right kidney, except renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C64.2",
+        "display": "Malignant neoplasm of left kidney, except renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C64.9",
+        "display": "Malignant neoplasm of unspecified kidney, except renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C65.1",
+        "display": "Malignant neoplasm of right renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C65.2",
+        "display": "Malignant neoplasm of left renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C65.9",
+        "display": "Malignant neoplasm of unspecified renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C66.1",
+        "display": "Malignant neoplasm of right ureter"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C66.2",
+        "display": "Malignant neoplasm of left ureter"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C66.9",
+        "display": "Malignant neoplasm of unspecified ureter"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.0",
+        "display": "Malignant neoplasm of trigone of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.1",
+        "display": "Malignant neoplasm of dome of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.2",
+        "display": "Malignant neoplasm of lateral wall of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.3",
+        "display": "Malignant neoplasm of anterior wall of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.4",
+        "display": "Malignant neoplasm of posterior wall of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.5",
+        "display": "Malignant neoplasm of bladder neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.6",
+        "display": "Malignant neoplasm of ureteric orifice"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.7",
+        "display": "Malignant neoplasm of urachus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.8",
+        "display": "Malignant neoplasm of overlapping sites of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C67.9",
+        "display": "Malignant neoplasm of bladder, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C68.0",
+        "display": "Malignant neoplasm of urethra"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C68.1",
+        "display": "Malignant neoplasm of paraurethral glands"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C68.8",
+        "display": "Malignant neoplasm of overlapping sites of urinary organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C68.9",
+        "display": "Malignant neoplasm of urinary organ, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.00",
+        "display": "Malignant neoplasm of unspecified conjunctiva"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.01",
+        "display": "Malignant neoplasm of right conjunctiva"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.02",
+        "display": "Malignant neoplasm of left conjunctiva"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.10",
+        "display": "Malignant neoplasm of unspecified cornea"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.11",
+        "display": "Malignant neoplasm of right cornea"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.12",
+        "display": "Malignant neoplasm of left cornea"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.20",
+        "display": "Malignant neoplasm of unspecified retina"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.21",
+        "display": "Malignant neoplasm of right retina"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.22",
+        "display": "Malignant neoplasm of left retina"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.30",
+        "display": "Malignant neoplasm of unspecified choroid"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.31",
+        "display": "Malignant neoplasm of right choroid"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.32",
+        "display": "Malignant neoplasm of left choroid"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.40",
+        "display": "Malignant neoplasm of unspecified ciliary body"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.41",
+        "display": "Malignant neoplasm of right ciliary body"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.42",
+        "display": "Malignant neoplasm of left ciliary body"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.50",
+        "display": "Malignant neoplasm of unspecified lacrimal gland and duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.51",
+        "display": "Malignant neoplasm of right lacrimal gland and duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.52",
+        "display": "Malignant neoplasm of left lacrimal gland and duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.60",
+        "display": "Malignant neoplasm of unspecified orbit"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.61",
+        "display": "Malignant neoplasm of right orbit"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.62",
+        "display": "Malignant neoplasm of left orbit"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.80",
+        "display": "Malignant neoplasm of overlapping sites of unspecified eye and adnexa"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.81",
+        "display": "Malignant neoplasm of overlapping sites of right eye and adnexa"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.82",
+        "display": "Malignant neoplasm of overlapping sites of left eye and adnexa"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.90",
+        "display": "Malignant neoplasm of unspecified site of unspecified eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.91",
+        "display": "Malignant neoplasm of unspecified site of right eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C69.92",
+        "display": "Malignant neoplasm of unspecified site of left eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C70.0",
+        "display": "Malignant neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C70.1",
+        "display": "Malignant neoplasm of spinal meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C70.9",
+        "display": "Malignant neoplasm of meninges, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.0",
+        "display": "Malignant neoplasm of cerebrum, except lobes and ventricles"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.1",
+        "display": "Malignant neoplasm of frontal lobe"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.2",
+        "display": "Malignant neoplasm of temporal lobe"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.3",
+        "display": "Malignant neoplasm of parietal lobe"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.4",
+        "display": "Malignant neoplasm of occipital lobe"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.5",
+        "display": "Malignant neoplasm of cerebral ventricle"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.6",
+        "display": "Malignant neoplasm of cerebellum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.7",
+        "display": "Malignant neoplasm of brain stem"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.8",
+        "display": "Malignant neoplasm of overlapping sites of brain"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C71.9",
+        "display": "Malignant neoplasm of brain, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.0",
+        "display": "Malignant neoplasm of spinal cord"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.1",
+        "display": "Malignant neoplasm of cauda equina"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.20",
+        "display": "Malignant neoplasm of unspecified olfactory nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.21",
+        "display": "Malignant neoplasm of right olfactory nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.22",
+        "display": "Malignant neoplasm of left olfactory nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.30",
+        "display": "Malignant neoplasm of unspecified optic nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.31",
+        "display": "Malignant neoplasm of right optic nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.32",
+        "display": "Malignant neoplasm of left optic nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.40",
+        "display": "Malignant neoplasm of unspecified acoustic nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.41",
+        "display": "Malignant neoplasm of right acoustic nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.42",
+        "display": "Malignant neoplasm of left acoustic nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.50",
+        "display": "Malignant neoplasm of unspecified cranial nerve"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.59",
+        "display": "Malignant neoplasm of other cranial nerves"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C72.9",
+        "display": "Malignant neoplasm of central nervous system, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C73",
+        "display": "MALIGNANT NEOPLASM OF THYROID GLAND"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.00",
+        "display": "Malignant neoplasm of cortex of unspecified adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.01",
+        "display": "Malignant neoplasm of cortex of right adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.02",
+        "display": "Malignant neoplasm of cortex of left adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.10",
+        "display": "Malignant neoplasm of medulla of unspecified adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.11",
+        "display": "Malignant neoplasm of medulla of right adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.12",
+        "display": "Malignant neoplasm of medulla of left adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.90",
+        "display": "Malignant neoplasm of unspecified part of unspecified adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.91",
+        "display": "Malignant neoplasm of unspecified part of right adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C74.92",
+        "display": "Malignant neoplasm of unspecified part of left adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.0",
+        "display": "Malignant neoplasm of parathyroid gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.1",
+        "display": "Malignant neoplasm of pituitary gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.2",
+        "display": "Malignant neoplasm of craniopharyngeal duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.3",
+        "display": "Malignant neoplasm of pineal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.4",
+        "display": "Malignant neoplasm of carotid body"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.5",
+        "display": "Malignant neoplasm of aortic body and other paraganglia"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.8",
+        "display": "Malignant neoplasm with pluriglanduar involvement, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C75.9",
+        "display": "Malignant neoplasm of endocrine gland, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.0",
+        "display": "Malignant neoplasm of head, face and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.1",
+        "display": "Malignant neoplasm of thorax"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.2",
+        "display": "Malignant neoplasm of abdomen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.3",
+        "display": "Malignant neoplasm pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.40",
+        "display": "Malignant neoplasm of unspecified upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.41",
+        "display": "Malignant neoplasm of right upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.42",
+        "display": "Malignant neoplasm of left upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.50",
+        "display": "Malignant neoplasm of unspecified lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.51",
+        "display": "Malignant neoplasm of right lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.52",
+        "display": "Malignant neoplasm of left lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C76.8",
+        "display": "Malignant neoplasm of overlapping sites of other and ill-defined sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.00",
+        "display": "Malignant carcinoid tumor of unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.010",
+        "display": "Malignant carcinoid tumor of the duodenum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.011",
+        "display": "Malignant carcinoid tumor of the jejunum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.012",
+        "display": "Malignant carcinoid tumor of the ileum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.019",
+        "display": "Malignant carcinoid tumor of the small intestine, unspecified portion"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.020",
+        "display": "Malignant carcinoid tumor of the appendix"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.021",
+        "display": "Malignant carcinoid tumor of the cecum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.022",
+        "display": "Malignant carcinoid tumor of the ascending colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.023",
+        "display": "Malignant carcinoid tumor of the transverse colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.024",
+        "display": "Malignant carcinoid tumor of the descending colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.025",
+        "display": "Malignant carcinoid tumor of the sigmoid colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.026",
+        "display": "Malignant carcinoid tumor of the rectum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.029",
+        "display": "Malignant carcinoid tumor of the large intestine, unspecified portion"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.090",
+        "display": "Malignant carcinoid tumor of the bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.091",
+        "display": "Malignant carcinoid tumor of thymus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.092",
+        "display": "Malignant carcinoid tumor of the stomach"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.093",
+        "display": "Malignant carcinoid tumor of the kidney"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.094",
+        "display": "Malignant carcinoid tumors of the foregut NOS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.095",
+        "display": "Malignant carcinoid tumors of the midgut NOS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.096",
+        "display": "Malignant carcinoid tumors of the hindgut NOS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.098",
+        "display": "Malignant carcinoid tumors of other sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.1",
+        "display": "Malignant poorly differentiated neuroendocrine tumors"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7A.8",
+        "display": "Other malignant neuroendocrine tumors"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C80.0",
+        "display": "Disseminated malignant neoplasm, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C80.1",
+        "display": "Malignant (primary) neoplasm, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C80.2",
+        "display": "Malignant neoplasm associated with transplanted organ"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.00",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.01",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.02",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.03",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.04",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.05",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.06",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.07",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.08",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.09",
+        "display": "Nodular lymphocyte predominant Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.10",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.11",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.12",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.13",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.14",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.15",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.16",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.17",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.18",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.19",
+        "display": "Nodular sclerosis classical Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.20",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.21",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.22",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.23",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.24",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.25",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.26",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.27",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.28",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.29",
+        "display": "Mixed cellularity classical Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.30",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.31",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.32",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.33",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.34",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.35",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.36",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.37",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.38",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.39",
+        "display": "Lymphocyte depleted classical Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.40",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.41",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.42",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.43",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.44",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.45",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.46",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.47",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.48",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.49",
+        "display": "Lymphocyte-rich classical Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.70",
+        "display": "Other classical Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.71",
+        "display": "Other classical Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.72",
+        "display": "Other classical Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.73",
+        "display": "Other classical Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.74",
+        "display": "Other classical Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.75",
+        "display": "Other classical Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.76",
+        "display": "Other classical Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.77",
+        "display": "Other classical Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.78",
+        "display": "Other classical Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.79",
+        "display": "Other classical Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.90",
+        "display": "Hodgkin lymphoma, unspecified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.91",
+        "display": "Hodgkin lymphoma, unspecified, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.92",
+        "display": "Hodgkin lymphoma, unspecified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.93",
+        "display": "Hodgkin lymphoma, unspecified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.94",
+        "display": "Hodgkin lymphoma, unspecified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.95",
+        "display": "Hodgkin lymphoma, unspecified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.96",
+        "display": "Hodgkin lymphoma, unspecified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.97",
+        "display": "Hodgkin lymphoma, unspecified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.98",
+        "display": "Hodgkin lymphoma, unspecified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C81.99",
+        "display": "Hodgkin lymphoma, unspecified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.00",
+        "display": "Follicular lymphoma grade I, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.01",
+        "display": "Follicular lymphoma grade I, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.02",
+        "display": "Follicular lymphoma grade I, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.03",
+        "display": "Follicular lymphoma grade I, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.04",
+        "display": "Follicular lymphoma grade I, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.05",
+        "display": "Follicular lymphoma grade I, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.06",
+        "display": "Follicular lymphoma grade I, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.07",
+        "display": "Follicular lymphoma grade I, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.08",
+        "display": "Follicular lymphoma grade I, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.09",
+        "display": "Follicular lymphoma grade I, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.10",
+        "display": "Follicular lymphoma grade II, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.11",
+        "display": "Follicular lymphoma grade II, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.12",
+        "display": "Follicular lymphoma grade II, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.13",
+        "display": "Follicular lymphoma grade II, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.14",
+        "display": "Follicular lymphoma grade II, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.15",
+        "display": "Follicular lymphoma grade II, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.16",
+        "display": "Follicular lymphoma grade II, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.17",
+        "display": "Follicular lymphoma grade II, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.18",
+        "display": "Follicular lymphoma grade II, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.19",
+        "display": "Follicular lymphoma grade II, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.20",
+        "display": "Follicular lymphoma grade III, unspecified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.21",
+        "display": "Follicular lymphoma grade III, unspecified, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.22",
+        "display": "Follicular lymphoma grade III, unspecified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.23",
+        "display": "Follicular lymphoma grade III, unspecified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.24",
+        "display": "Follicular lymphoma grade III, unspecified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.25",
+        "display": "Follicular lymphoma grade III, unspecified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.26",
+        "display": "Follicular lymphoma grade III, unspecified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.27",
+        "display": "Follicular lymphoma grade III, unspecified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.28",
+        "display": "Follicular lymphoma grade III, unspecified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.29",
+        "display": "Follicular lymphoma grade III, unspecified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.30",
+        "display": "Follicular lymphoma grade IIIa, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.31",
+        "display": "Follicular lymphoma grade IIIa, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.32",
+        "display": "Follicular lymphoma grade IIIa, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.33",
+        "display": "Follicular lymphoma grade IIIa, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.34",
+        "display": "Follicular lymphoma grade IIIa, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.35",
+        "display": "Follicular lymphoma grade IIIa, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.36",
+        "display": "Follicular lymphoma grade IIIa, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.37",
+        "display": "Follicular lymphoma grade IIIa, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.38",
+        "display": "Follicular lymphoma grade IIIa, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.39",
+        "display": "Follicular lymphoma grade IIIa, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.40",
+        "display": "Follicular lymphoma grade IIIb, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.41",
+        "display": "Follicular lymphoma grade IIIb, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.42",
+        "display": "Follicular lymphoma grade IIIb, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.43",
+        "display": "Follicular lymphoma grade IIIb, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.44",
+        "display": "Follicular lymphoma grade IIIb, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.45",
+        "display": "Follicular lymphoma grade IIIb, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.46",
+        "display": "Follicular lymphoma grade IIIb, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.47",
+        "display": "Follicular lymphoma grade IIIb, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.48",
+        "display": "Follicular lymphoma grade IIIb, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.49",
+        "display": "Follicular lymphoma grade IIIb, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.50",
+        "display": "Diffuse follicle center lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.51",
+        "display": "Diffuse follicle center lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.52",
+        "display": "Diffuse follicle center lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.53",
+        "display": "Diffuse follicle center lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.54",
+        "display": "Diffuse follicle center lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.55",
+        "display": "Diffuse follicle center lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.56",
+        "display": "Diffuse follicle center lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.57",
+        "display": "Diffuse follicle center lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.58",
+        "display": "Diffuse follicle center lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.59",
+        "display": "Diffuse follicle center lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.60",
+        "display": "Cutaneous follicle center lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.61",
+        "display": "Cutaneous follicle center lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.62",
+        "display": "Cutaneous follicle center lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.63",
+        "display": "Cutaneous follicle center lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.64",
+        "display": "Cutaneous follicle center lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.65",
+        "display": "Cutaneous follicle center lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.66",
+        "display": "Cutaneous follicle center lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.67",
+        "display": "Cutaneous follicle center lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.68",
+        "display": "Cutaneous follicle center lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.69",
+        "display": "Cutaneous follicle center lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.80",
+        "display": "Other types of follicular lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.81",
+        "display": "Other types of follicular lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.82",
+        "display": "Other types of follicular lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.83",
+        "display": "Other types of follicular lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.84",
+        "display": "Other types of follicular lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.85",
+        "display": "Other types of follicular lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.86",
+        "display": "Other types of follicular lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.87",
+        "display": "Other types of follicular lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.88",
+        "display": "Other types of follicular lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.89",
+        "display": "Other types of follicular lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.90",
+        "display": "Follicular lymphoma, unspecified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.91",
+        "display": "Follicular lymphoma, unspecified, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.92",
+        "display": "Follicular lymphoma, unspecified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.93",
+        "display": "Follicular lymphoma, unspecified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.94",
+        "display": "Follicular lymphoma, unspecified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.95",
+        "display": "Follicular lymphoma, unspecified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.96",
+        "display": "Follicular lymphoma, unspecified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.97",
+        "display": "Follicular lymphoma, unspecified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.98",
+        "display": "Follicular lymphoma, unspecified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C82.99",
+        "display": "Follicular lymphoma, unspecified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.00",
+        "display": "Small cell B-cell lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.01",
+        "display": "Small cell B-cell lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.02",
+        "display": "Small cell B-cell lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.03",
+        "display": "Small cell B-cell lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.04",
+        "display": "Small cell B-cell lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.05",
+        "display": "Small cell B-cell lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.06",
+        "display": "Small cell B-cell lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.07",
+        "display": "Small cell B-cell lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.08",
+        "display": "Small cell B-cell lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.09",
+        "display": "Small cell B-cell lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.10",
+        "display": "Mantle cell lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.11",
+        "display": "Mantle cell lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.12",
+        "display": "Mantle cell lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.13",
+        "display": "Mantle cell lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.14",
+        "display": "Mantle cell lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.15",
+        "display": "Mantle cell lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.16",
+        "display": "Mantle cell lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.17",
+        "display": "Mantle cell lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.18",
+        "display": "Mantle cell lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.19",
+        "display": "Mantle cell lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.30",
+        "display": "Diffuse large B-cell lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.31",
+        "display": "Diffuse large B-cell lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.32",
+        "display": "Diffuse large B-cell lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.33",
+        "display": "Diffuse large B-cell lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.34",
+        "display": "Diffuse large B-cell lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.35",
+        "display": "Diffuse large B-cell lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.36",
+        "display": "Diffuse large B-cell lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.37",
+        "display": "Diffuse large B-cell lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.38",
+        "display": "Diffuse large B-cell lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.39",
+        "display": "Diffuse large B-cell lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.50",
+        "display": "Lymphoblastic (diffuse) lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.51",
+        "display": "Lymphoblastic (diffuse) lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.52",
+        "display": "Lymphoblastic (diffuse) lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.53",
+        "display": "Lymphoblastic (diffuse) lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.54",
+        "display": "Lymphoblastic (diffuse) lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.55",
+        "display": "Lymphoblastic (diffuse) lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.56",
+        "display": "Lymphoblastic (diffuse) lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.57",
+        "display": "Lymphoblastic (diffuse) lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.58",
+        "display": "Lymphoblastic (diffuse) lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.59",
+        "display": "Lymphoblastic (diffuse) lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.70",
+        "display": "Burkitt lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.71",
+        "display": "Burkitt lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.72",
+        "display": "Burkitt lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.73",
+        "display": "Burkitt lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.74",
+        "display": "Burkitt lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.75",
+        "display": "Burkitt lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.76",
+        "display": "Burkitt lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.77",
+        "display": "Burkitt lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.78",
+        "display": "Burkitt lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.79",
+        "display": "Burkitt lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.80",
+        "display": "Other non-follicular lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.81",
+        "display": "Other non-follicular lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.82",
+        "display": "Other non-follicular lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.83",
+        "display": "Other non-follicular lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.84",
+        "display": "Other non-follicular lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.85",
+        "display": "Other non-follicular lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.86",
+        "display": "Other non-follicular lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.87",
+        "display": "Other non-follicular lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.88",
+        "display": "Other non-follicular lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.89",
+        "display": "Other non-follicular lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.90",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.91",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.92",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.93",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.94",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.95",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.96",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.97",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.98",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C83.99",
+        "display": "Non-follicular (diffuse) lymphoma, unspecified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.00",
+        "display": "Mycosis fungoides, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.01",
+        "display": "Mycosis fungoides, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.02",
+        "display": "Mycosis fungoides, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.03",
+        "display": "Mycosis fungoides, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.04",
+        "display": "Mycosis fungoides, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.05",
+        "display": "Mycosis fungoides, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.06",
+        "display": "Mycosis fungoides, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.07",
+        "display": "Mycosis fungoides, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.08",
+        "display": "Mycosis fungoides, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.09",
+        "display": "Mycosis fungoides, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.10",
+        "display": "Sezary disease, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.11",
+        "display": "Sezary disease, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.12",
+        "display": "Sezary disease, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.13",
+        "display": "Sezary disease, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.14",
+        "display": "Sezary disease, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.15",
+        "display": "Sezary disease, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.16",
+        "display": "Sezary disease, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.17",
+        "display": "Sezary disease, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.18",
+        "display": "Sezary disease, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.19",
+        "display": "Sezary disease, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.40",
+        "display": "Peripheral T-cell lymphoma, not classified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.41",
+        "display": "Peripheral T-cell lymphoma, not classified, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.42",
+        "display": "Peripheral T-cell lymphoma, not classified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.43",
+        "display": "Peripheral T-cell lymphoma, not classified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.44",
+        "display": "Peripheral T-cell lymphoma, not classified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.45",
+        "display": "Peripheral T-cell lymphoma, not classified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.46",
+        "display": "Peripheral T-cell lymphoma, not classified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.47",
+        "display": "Peripheral T-cell lymphoma, not classified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.48",
+        "display": "Peripheral T-cell lymphoma, not classified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.49",
+        "display": "Peripheral T-cell lymphoma, not classified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.60",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.61",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.62",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.63",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.64",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.65",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.66",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.67",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.68",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.69",
+        "display": "Anaplastic large cell lymphoma, ALK-positive, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.70",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.71",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.72",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.73",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.74",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.75",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.76",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.77",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.78",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.79",
+        "display": "Anaplastic large cell lymphoma, ALK-negative, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.90",
+        "display": "Mature T/NK-cell lymphomas, unspecified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.91",
+        "display": "Mature T/NK-cell lymphomas, unspecified, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.92",
+        "display": "Mature T/NK-cell lymphomas, unspecified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.93",
+        "display": "Mature T/NK-cell lymphomas, unspecified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.94",
+        "display": "Mature T/NK-cell lymphomas, unspecified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.95",
+        "display": "Mature T/NK-cell lymphomas, unspecified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.96",
+        "display": "Mature T/NK-cell lymphomas, unspecified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.97",
+        "display": "Mature T/NK-cell lymphomas, unspecified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.98",
+        "display": "Mature T/NK-cell lymphomas, unspecified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.99",
+        "display": "Mature T/NK-cell lymphomas, unspecified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A0",
+        "display": "Cutaneous T-cell lymphoma, unspecified, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A1",
+        "display": "Cutaneous T-cell lymphoma, unspecified lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A2",
+        "display": "Cutaneous T-cell lymphoma, unspecified, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A3",
+        "display": "Cutaneous T-cell lymphoma, unspecified, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A4",
+        "display": "Cutaneous T-cell lymphoma, unspecified, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A5",
+        "display": "Cutaneous T-cell lymphoma, unspecified, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A6",
+        "display": "Cutaneous T-cell lymphoma, unspecified, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A7",
+        "display": "Cutaneous T-cell lymphoma, unspecified, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A8",
+        "display": "Cutaneous T-cell lymphoma, unspecified, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.A9",
+        "display": "Cutaneous T-cell lymphoma, unspecified, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z0",
+        "display": "Other mature T/NK-cell lymphomas, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z1",
+        "display": "Other mature T/NK-cell lymphomas, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z2",
+        "display": "Other mature T/NK-cell lymphomas, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z3",
+        "display": "Other mature T/NK-cell lymphomas, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z4",
+        "display": "Other mature T/NK-cell lymphomas, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z5",
+        "display": "Other mature T/NK-cell lymphomas, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z6",
+        "display": "Other mature T/NK-cell lymphomas, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z7",
+        "display": "Other mature T/NK-cell lymphomas, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z8",
+        "display": "Other mature T/NK-cell lymphomas, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C84.Z9",
+        "display": "Other mature T/NK-cell lymphomas, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.10",
+        "display": "Unspecified B-cell lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.11",
+        "display": "Unspecified B-cell lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.12",
+        "display": "Unspecified B-cell lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.13",
+        "display": "Unspecified B-cell lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.14",
+        "display": "Unspecified B-cell lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.15",
+        "display": "Unspecified B-cell lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.16",
+        "display": "Unspecified B-cell lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.17",
+        "display": "Unspecified B-cell lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.18",
+        "display": "Unspecified B-cell lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.19",
+        "display": "Unspecified B-cell lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.20",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.21",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.22",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.23",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.24",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.25",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.26",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.27",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.28",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.29",
+        "display": "Mediastinal (thymic) large B-cell lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.80",
+        "display": "Other specified types of non-Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.81",
+        "display": "Other specified types of non-Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.82",
+        "display": "Other specified types of non-Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.83",
+        "display": "Other specified types of non-Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.84",
+        "display": "Other specified types of non-Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.85",
+        "display": "Other specified types of non-Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.86",
+        "display": "Other specified types of non-Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.87",
+        "display": "Other specified types of non-Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.88",
+        "display": "Other specified types of non-Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.89",
+        "display": "Other specified types of non-Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.90",
+        "display": "Non-Hodgkin lymphoma, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.91",
+        "display": "Non-Hodgkin lymphoma, lymph nodes of head, face, and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.92",
+        "display": "Non-Hodgkin lymphoma, intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.93",
+        "display": "Non-Hodgkin lymphoma, intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.94",
+        "display": "Non-Hodgkin lymphoma, lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.95",
+        "display": "Non-Hodgkin lymphoma, lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.96",
+        "display": "Non-Hodgkin lymphoma, intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.97",
+        "display": "Non-Hodgkin lymphoma, spleen"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.98",
+        "display": "Non-Hodgkin lymphoma, lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C85.99",
+        "display": "Non-Hodgkin lymphoma, extranodal and solid organ sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.0",
+        "display": "Extranodal NK/T-cell lymphoma, nasal type"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.1",
+        "display": "Hepatosplenic T-cell lymphoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.2",
+        "display": "Enteropathy-type (intestinal) T-cell lymphoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.3",
+        "display": "Subcutaneous panniculitis-like T-cell lymphoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.4",
+        "display": "Blastic NK-cell lymphoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.5",
+        "display": "Angioimmunoblastic T-cell lymphoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C86.6",
+        "display": "Primary cutaneous CD30-positive T-cell proliferation"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C88.0",
+        "display": "Waldenstrom's macroglobulinemia"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C88.2",
+        "display": "Heavy chain disease"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C88.3",
+        "display": "Immunoproliferative small intestinal diseases"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C88.4",
+        "display": "Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue [MALT-lymphoma]"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C88.8",
+        "display": "Other malignant immunoproliferative diseases"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C88.9",
+        "display": "Malignant immunoproliferative disease, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.00",
+        "display": "Multiple myeloma not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.01",
+        "display": "Multiple myeloma in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.02",
+        "display": "Multiple myeloma in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.10",
+        "display": "Plasma cell leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.11",
+        "display": "Plasma cell leukemia in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.12",
+        "display": "Plasma cell leukemia in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.20",
+        "display": "Extramedullary plasmacytoma not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.21",
+        "display": "Extramedullary plasmacytoma in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.22",
+        "display": "Extramedullary plasmacytoma in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.30",
+        "display": "Solitary plasmacytoma not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.31",
+        "display": "Solitary plasmacytoma in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C90.32",
+        "display": "Solitary plasmacytoma in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.00",
+        "display": "Acute lymphoblastic leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.01",
+        "display": "Acute lymphoblastic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.02",
+        "display": "Acute lymphoblastic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.10",
+        "display": "Chronic lymphocytic leukemia of B-cell type not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.11",
+        "display": "Chronic lymphocytic leukemia of B-cell type in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.12",
+        "display": "Chronic lymphocytic leukemia of B-cell type in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.30",
+        "display": "Prolymphocytic leukemia of B-cell type not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.31",
+        "display": "Prolymphocytic leukemia of B-cell type, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.32",
+        "display": "Prolymphocytic leukemia of B â€“cell type, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.40",
+        "display": "Hairy cell leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.41",
+        "display": "Hairy cell leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.42",
+        "display": "Hairy cell leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.50",
+        "display": "Adult T-cell lymphoma/leukemia (HTLV-1-associated) not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.51",
+        "display": "Adult T-cell lymphoma/leukemia (HTLV-1-associated) in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.52",
+        "display": "Adult T-cell lymphoma/leukemia (HTLV-1-associated) in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.60",
+        "display": "Prolymphocytic leukemia of T-cell type not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.61",
+        "display": "Prolymphocytic leukemia of T-cell type, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.62",
+        "display": "Prolymphocytic leukemia of T â€“cell type, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.90",
+        "display": "Lymphoid leukemia, unspecified not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.91",
+        "display": "Lymphoid leukemia, unspecified, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.92",
+        "display": "Lymphoid leukemia, unspecified, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.A0",
+        "display": "Mature B-cell leukemia Burkitt-type not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.A1",
+        "display": "Mature B-cell leukemia Burkitt-type, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.A2",
+        "display": "Mature B-cell leukemia Burkitt-type, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.Z0",
+        "display": "Other lymphoid leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.Z1",
+        "display": "Other lymphoid leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C91.Z2",
+        "display": "Other lymphoid leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.00",
+        "display": "Acute myeloblastic leukemia, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.01",
+        "display": "Acute myeloblastic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.02",
+        "display": "Acute myeloblastic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.10",
+        "display": "Chronic myeloid leukemia, BCR/ABL-positive, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.11",
+        "display": "Chronic myeloid leukemia, BCR/ABL-positive, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.12",
+        "display": "Chronic myeloid leukemia, BCR/ABL-positive, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.20",
+        "display": "Atypical chronic myeloid leukemia, BCR/ABL-negative not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.21",
+        "display": "Atypical chronic myeloid leukemia, BCR/ABL-negative, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.22",
+        "display": "Atypical chronic myeloid leukemia, BCR/ABL-negative, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.30",
+        "display": "Myeloid sarcoma, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.31",
+        "display": "Myeloid sarcoma, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.32",
+        "display": "Myeloid sarcoma, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.40",
+        "display": "Acute promyelocytic leukemia, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.41",
+        "display": "Acute promyelocytic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.42",
+        "display": "Acute promyelocytic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.50",
+        "display": "Acute myelomonocytic leukemia, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.51",
+        "display": "Acute myelomonocytic in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.52",
+        "display": "Acute myelomonocytic in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.60",
+        "display": "Acute myeloid leukemia with 11q23 abnormality not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.61",
+        "display": "Acute myeloid leukemia with 11q23 abnormality in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.62",
+        "display": "Acute myeloid leukemia with 11q23 abnormality in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.90",
+        "display": "Myeloid leukemia, unspecified, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.91",
+        "display": "Myeloid leukemia, unspecified in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.92",
+        "display": "Myeloid leukemia, unspecified in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.A0",
+        "display": "Acute myeloid leukemia with multilineage dysplasia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.A1",
+        "display": "Acute myeloid leukemia with multilineage dysplasia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.A2",
+        "display": "Acute myeloid leukemia with multilineage dysplasia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.Z0",
+        "display": "Other myeloid leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.Z1",
+        "display": "Other myeloid leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C92.Z2",
+        "display": "Other myeloid leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.00",
+        "display": "Acute monoblastic/monocytic leukemia, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.01",
+        "display": "Acute monoblastic/monocytic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.02",
+        "display": "Acute monoblastic/monocytic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.10",
+        "display": "Chronic myelomonocytic leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.11",
+        "display": "Chronic myelomonocytic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.12",
+        "display": "Chronic myelomonocytic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.30",
+        "display": "Juvenile myelomonocytic leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.31",
+        "display": "Juvenile myelomonocytic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.32",
+        "display": "Juvenile myelomonocytic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.90",
+        "display": "Monocytic leukemia, unspecified, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.91",
+        "display": "Monocytic leukemia, unspecified in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.92",
+        "display": "Monocytic leukemia, unspecified in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.Z0",
+        "display": "Other monocytic leukemia, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.Z1",
+        "display": "Other monocytic leukemia in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C93.Z2",
+        "display": "Other monocytic leukemia in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.00",
+        "display": "Acute erythroid leukemia, not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.01",
+        "display": "Acute erythroid leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.02",
+        "display": "Acute erythroid leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.20",
+        "display": "Acute megakaryoblastic leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.21",
+        "display": "Acute megakaryoblastic leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.22",
+        "display": "Acute megakaryoblastic leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.30",
+        "display": "Mast cell leukemia not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.31",
+        "display": "Mast cell leukemia, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.32",
+        "display": "Mast cell leukemia, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.40",
+        "display": "Acute panmyelosis with myelofibrosis not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.41",
+        "display": "Acute panmyelosis with myelofibrosis, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.42",
+        "display": "Acute panmyelosis with myelofibrosis, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.6",
+        "display": "Myelodysplastic disease, not classified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.80",
+        "display": "Other specified leukemias not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.81",
+        "display": "Other specified leukemias, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C94.82",
+        "display": "Other specified leukemias, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.00",
+        "display": "Acute leukemia of unspecified cell type not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.01",
+        "display": "Acute leukemia of unspecified cell type, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.02",
+        "display": "Acute leukemia of unspecified cell type, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.10",
+        "display": "Chronic leukemia of unspecified cell type not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.11",
+        "display": "Chronic leukemia of unspecified cell type, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.12",
+        "display": "Chronic leukemia of unspecified cell type, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.90",
+        "display": "Leukemia, unspecified not having achieved remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.91",
+        "display": "Leukemia, unspecified, in remission"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C95.92",
+        "display": "Leukemia, unspecified, in relapse"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.0",
+        "display": "Multifocal and multisystemic (disseminated) Langerhans-cell histiocytosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.20",
+        "display": "Malignant mast cell neoplasm, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.21",
+        "display": "Aggressive systemic mastocytosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.22",
+        "display": "Mast cell sarcoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.29",
+        "display": "Other malignant cell neoplasm"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.4",
+        "display": "Sarcoma of dendritic cells (accessory cells) Malignant neoplasm of lymphoid, hematopoietic and related tissue, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.5",
+        "display": "Multifocal and unisystemic Langerhans-cell histiocytosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.6",
+        "display": "Unifocal Langerhans-cell histiocytosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.9",
+        "display": "Malignant neoplasm of lymphoid, hematopoietic and related tissue, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.A",
+        "display": "Histiocytic sarcoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C96.Z",
+        "display": "Other specified malignant neoplasms of lymphoid, hematopoietic and related tissue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D45",
+        "display": "POLYCYTHEMIA VERA"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.0",
+        "display": "Refractory anemia without ring sideroblasts, so stated"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.1",
+        "display": "Refractory anemia with ring sideroblasts"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.20",
+        "display": "Refractory anemia with excess of blasts, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.21",
+        "display": "Refractory anemia with excess of blasts 1"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.22",
+        "display": "Refractory anemia with excess of blasts 2"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.4",
+        "display": "Refractory anemia, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.9",
+        "display": "Myelodysplastic syndrome, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.B",
+        "display": "Refractory cytopenia with multilineage dysplasia and ring sideroblasts"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.C",
+        "display": "Myelodysplastic syndrome with isolated del (5q) chromosomal abnormality"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D46.Z",
+        "display": "Other myelodysplastic syndromes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.02",
+        "display": "Systemic mastocytosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.1",
+        "display": "Chronic myeloproliferative disease"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.3",
+        "display": "Essential (hemorrhagic) thrombocythemia"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.4",
+        "display": "Osteomyelofibrosis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.9",
+        "display": "Neoplasm of uncertain behavior of lymphoid, hematopoietic and related tissue, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.Z1",
+        "display": "Post-transplant lymphoproliferative disorder (PTLD)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D47.Z9",
+        "display": "Other specified neoplasms of uncertain behavior of lymphoid, hematopoietic and related tissue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D49.6",
+        "display": "Neoplasm of unspecified behavior of brain"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D49.7",
+        "display": "Neoplasm of unspecified behavior of endocrine glands and other parts of nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "393573009",
+        "display": "Hypereosinophilic syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423294001",
+        "display": "Idiopathic hypereosinophilic syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866109006",
+        "display": "Lymphocytic hypereosinophilic syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1153341001",
+        "display": "Myeloproliferative hypereosinophilic syndrome (disorder)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D72.110",
+        "display": "Idiopathic hypereosinophilic syndrome [HES]"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D72.111",
+        "display": "Lymphocytic Variant Hypereosinophilic Syndrome [LHES]"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D72.118",
+        "display": "Other hypereosinophilic syndrome"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D72.119",
+        "display": "Hypereosinophilic syndrome [HES], unspecified"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109355002",
+        "display": "Carcinoma in situ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92523001",
+        "display": "Carcinoma in situ of accessory sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92524007",
+        "display": "Carcinoma in situ of adenoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92525008",
+        "display": "Carcinoma in situ of adnexa of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92526009",
+        "display": "Carcinoma in situ of adrenal cortex"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92527000",
+        "display": "Carcinoma in situ of adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92528005",
+        "display": "Carcinoma in situ of adrenal medulla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92529002",
+        "display": "Carcinoma in situ of alveolar ridge mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92530007",
+        "display": "Carcinoma in situ of ampulla of Vater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92531006",
+        "display": "Carcinoma in situ of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92532004",
+        "display": "Carcinoma in situ of anterior aspect of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92534003",
+        "display": "Carcinoma in situ of anterior two-thirds of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92535002",
+        "display": "Carcinoma in situ of anterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92536001",
+        "display": "Carcinoma in situ of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92537005",
+        "display": "Carcinoma in situ of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92538000",
+        "display": "Carcinoma in situ of apex of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92539008",
+        "display": "Carcinoma in situ of appendix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92540005",
+        "display": "Carcinoma in situ of areola of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92541009",
+        "display": "Carcinoma in situ of areola of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92542002",
+        "display": "Carcinoma in situ of ascending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92543007",
+        "display": "Carcinoma in situ of axillary tail of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92544001",
+        "display": "Carcinoma in situ of base of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92545000",
+        "display": "Carcinoma in situ of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92546004",
+        "display": "Carcinoma in situ of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92547008",
+        "display": "Carcinoma in situ of body of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92548003",
+        "display": "Carcinoma in situ of body of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92549006",
+        "display": "Carcinoma in situ of body of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92550006",
+        "display": "Carcinoma in situ of body of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92551005",
+        "display": "Carcinoma in situ of broad ligament"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92552003",
+        "display": "Carcinoma in situ of bronchus of left lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92553008",
+        "display": "Carcinoma in situ of bronchus of left upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92554002",
+        "display": "Carcinoma in situ of bronchus of right lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92555001",
+        "display": "Carcinoma in situ of bronchus of right middle lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92556000",
+        "display": "Carcinoma in situ of bronchus of right upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92557009",
+        "display": "Carcinoma in situ of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92558004",
+        "display": "Carcinoma in situ of buccal mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92559007",
+        "display": "Carcinoma in situ of cecum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92560002",
+        "display": "Carcinoma in situ of cardia of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92562005",
+        "display": "Carcinoma in situ of central portion of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92563000",
+        "display": "Carcinoma in situ of cervical esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92564006",
+        "display": "Carcinoma in situ of uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92565007",
+        "display": "Carcinoma in situ of choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92566008",
+        "display": "Carcinoma in situ of ciliary body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92567004",
+        "display": "Carcinoma in situ of clitoris"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92568009",
+        "display": "Carcinoma in situ of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92569001",
+        "display": "Carcinoma in situ of commissure of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92570000",
+        "display": "Carcinoma in situ of common bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92571001",
+        "display": "Carcinoma in situ of conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92572008",
+        "display": "Carcinoma in situ of cornea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92573003",
+        "display": "Carcinoma in situ of craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92574009",
+        "display": "Carcinoma in situ of cystic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92575005",
+        "display": "Carcinoma in situ of descending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92576006",
+        "display": "Carcinoma in situ of dorsal surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92577002",
+        "display": "Carcinoma in situ of duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92578007",
+        "display": "Carcinoma in situ of ectopic female breast tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92579004",
+        "display": "Carcinoma in situ of ectopic male breast tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92580001",
+        "display": "Carcinoma in situ of endocervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92581002",
+        "display": "Carcinoma in situ of endocrine gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92582009",
+        "display": "Carcinoma in situ of endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92583004",
+        "display": "Carcinoma in situ of epididymis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92584005",
+        "display": "Carcinoma in situ of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92585006",
+        "display": "Carcinoma in situ of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92586007",
+        "display": "Carcinoma in situ of ethmoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92587003",
+        "display": "Carcinoma in situ of eustachian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92588008",
+        "display": "Carcinoma in situ of exocervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92589000",
+        "display": "Carcinoma in situ of extrahepatic bile ducts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92590009",
+        "display": "Carcinoma in situ of eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92591008",
+        "display": "Carcinoma in situ of fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92593006",
+        "display": "Carcinoma in situ of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92594000",
+        "display": "Carcinoma in situ of female genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92595004",
+        "display": "Carcinoma in situ of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92596003",
+        "display": "Carcinoma in situ of prepuce"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92597007",
+        "display": "Carcinoma in situ of frontal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92598002",
+        "display": "Carcinoma in situ of fundus of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92599005",
+        "display": "Carcinoma in situ of gallbladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92600008",
+        "display": "Carcinoma in situ of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92601007",
+        "display": "Carcinoma in situ of gingival mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92602000",
+        "display": "Carcinoma in situ of glans penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92603005",
+        "display": "Carcinoma in situ of glottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92604004",
+        "display": "Carcinoma in situ of greater curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92605003",
+        "display": "Carcinoma in situ of gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92606002",
+        "display": "Carcinoma in situ of hard palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92607006",
+        "display": "Carcinoma in situ of head of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92608001",
+        "display": "Carcinoma in situ of hepatic flexure of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92609009",
+        "display": "Carcinoma in situ of hilus of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92610004",
+        "display": "Carcinoma in situ of hypopharyngeal aspect of aryepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92611000",
+        "display": "Carcinoma in situ of hypopharyngeal aspect of interarytenoid fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92612007",
+        "display": "Carcinoma in situ of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92613002",
+        "display": "Carcinoma in situ of ileum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92614008",
+        "display": "Carcinoma in situ of inner aspect of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92617001",
+        "display": "Carcinoma in situ of intestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92618006",
+        "display": "Carcinoma in situ of intrahepatic bile ducts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92619003",
+        "display": "Carcinoma in situ of islets of Langerhans"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92620009",
+        "display": "Carcinoma in situ of isthmus of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92621008",
+        "display": "Carcinoma in situ of jejunum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92622001",
+        "display": "Carcinoma in situ of junctional region of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92623006",
+        "display": "Carcinoma in situ of junctional zone of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92624000",
+        "display": "Carcinoma in situ of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92625004",
+        "display": "Carcinoma in situ of labia majora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92626003",
+        "display": "Carcinoma in situ of labia minora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92628002",
+        "display": "Carcinoma in situ of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92629005",
+        "display": "Carcinoma in situ of large intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92630000",
+        "display": "Carcinoma in situ of laryngeal aspect of aryepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92631001",
+        "display": "Carcinoma in situ of laryngeal aspect of interarytenoid fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92632008",
+        "display": "Carcinoma in situ of laryngeal commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92633003",
+        "display": "Carcinoma in situ of laryngeal surface of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92634009",
+        "display": "Carcinoma in situ of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92636006",
+        "display": "Carcinoma in situ of lateral wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92637002",
+        "display": "Carcinoma in situ of lateral wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92638007",
+        "display": "Carcinoma in situ of lateral wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92639004",
+        "display": "Carcinoma in situ of left lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92640002",
+        "display": "Carcinoma in situ of left upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92642005",
+        "display": "Carcinoma in situ of lingual tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92643000",
+        "display": "Carcinoma in situ of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92644006",
+        "display": "Carcinoma in situ of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92645007",
+        "display": "Carcinoma in situ of lower gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92646008",
+        "display": "Carcinoma in situ of lower inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92647004",
+        "display": "Carcinoma in situ of lower outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92648009",
+        "display": "Carcinoma in situ of lower third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92649001",
+        "display": "Carcinoma in situ of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92650001",
+        "display": "Carcinoma in situ of main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92651002",
+        "display": "Carcinoma in situ of major salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92652009",
+        "display": "Carcinoma in situ of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92653004",
+        "display": "Carcinoma in situ of male genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92654005",
+        "display": "Carcinoma in situ of mastoid air cells"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92655006",
+        "display": "Carcinoma in situ of maxillary sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92656007",
+        "display": "Carcinoma in situ of Meckel's diverticulum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92657003",
+        "display": "Carcinoma in situ of middle ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92658008",
+        "display": "Carcinoma in situ of middle third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92659000",
+        "display": "Carcinoma in situ of minor salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92660005",
+        "display": "Carcinoma in situ of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92661009",
+        "display": "Carcinoma in situ of multiple endocrine glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92662002",
+        "display": "Carcinoma in situ of myometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92663007",
+        "display": "Carcinoma in situ of nasal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92664001",
+        "display": "Carcinoma in situ of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92665000",
+        "display": "Carcinoma in situ of nipple of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92666004",
+        "display": "Carcinoma in situ of nipple of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92668003",
+        "display": "Carcinoma in situ of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92669006",
+        "display": "Carcinoma in situ of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92670007",
+        "display": "Carcinoma in situ of palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92671006",
+        "display": "Carcinoma in situ of tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92672004",
+        "display": "Carcinoma in situ of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92673009",
+        "display": "Carcinoma in situ of pancreatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92674003",
+        "display": "Carcinoma in situ of parametrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92675002",
+        "display": "Carcinoma in situ of parathyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92676001",
+        "display": "Carcinoma in situ of paraurethral glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92677005",
+        "display": "Carcinoma in situ of parietal pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92678000",
+        "display": "Carcinoma in situ of parotid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92679008",
+        "display": "Carcinoma in situ of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92680006",
+        "display": "Carcinoma in situ of perianal skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92681005",
+        "display": "Carcinoma in situ of pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92682003",
+        "display": "Carcinoma in situ of pineal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92683008",
+        "display": "Carcinoma in situ of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92684002",
+        "display": "Carcinoma in situ of placenta"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92685001",
+        "display": "Carcinoma in situ of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92686000",
+        "display": "Carcinoma in situ of postcricoid region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92687009",
+        "display": "Carcinoma in situ of posterior hypopharyngeal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92688004",
+        "display": "Carcinoma in situ of posterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92689007",
+        "display": "Carcinoma in situ of posterior wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92690003",
+        "display": "Carcinoma in situ of posterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92691004",
+        "display": "Carcinoma in situ of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92692006",
+        "display": "Carcinoma in situ of pyloric antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92693001",
+        "display": "Carcinoma in situ of pylorus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92694007",
+        "display": "Carcinoma in situ of pyriform sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92695008",
+        "display": "Carcinoma in situ of rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92696009",
+        "display": "Carcinoma in situ of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92697000",
+        "display": "Carcinoma in situ of renal pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92698005",
+        "display": "Carcinoma in situ of respiratory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92699002",
+        "display": "Carcinoma in situ of retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92700001",
+        "display": "Carcinoma in situ of retromolar area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92701002",
+        "display": "Carcinoma in situ of right lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92702009",
+        "display": "Carcinoma in situ of right middle lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92703004",
+        "display": "Carcinoma in situ of right upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92704005",
+        "display": "Carcinoma in situ of round ligament of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92705006",
+        "display": "Carcinoma in situ of sclera"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92706007",
+        "display": "Carcinoma in situ of scrotum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92707003",
+        "display": "Carcinoma in situ of sebaceous gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92708008",
+        "display": "Carcinoma in situ of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92709000",
+        "display": "Carcinoma in situ of skin of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92710005",
+        "display": "Carcinoma in situ of skin of ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92712002",
+        "display": "Carcinoma in situ of skin of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92713007",
+        "display": "Carcinoma in situ of skin of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92714001",
+        "display": "Carcinoma in situ of skin of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92715000",
+        "display": "Carcinoma in situ of skin of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92716004",
+        "display": "Carcinoma in situ of skin of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92717008",
+        "display": "Carcinoma in situ of skin of chest"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92718003",
+        "display": "Carcinoma in situ of skin of chin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92719006",
+        "display": "Carcinoma in situ of skin of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92720000",
+        "display": "Carcinoma in situ of skin of elbow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92722008",
+        "display": "Carcinoma in situ of skin of eyebrow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92723003",
+        "display": "Carcinoma in situ of skin of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92724009",
+        "display": "Carcinoma in situ of skin of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92725005",
+        "display": "Carcinoma in situ of skin of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92726006",
+        "display": "Carcinoma in situ of skin of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92727002",
+        "display": "Carcinoma in situ of skin of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92728007",
+        "display": "Carcinoma in situ of skin of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92729004",
+        "display": "Carcinoma in situ of skin of groin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92730009",
+        "display": "Carcinoma in situ of skin of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92731008",
+        "display": "Carcinoma in situ of skin of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92732001",
+        "display": "Carcinoma in situ of skin of knee"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92734000",
+        "display": "Carcinoma in situ of skin of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92735004",
+        "display": "Carcinoma in situ of skin of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92736003",
+        "display": "Carcinoma in situ of skin of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92737007",
+        "display": "Carcinoma in situ of skin of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92738002",
+        "display": "Carcinoma in situ of skin of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92739005",
+        "display": "Carcinoma in situ of skin of popliteal area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92740007",
+        "display": "Carcinoma in situ of skin of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92741006",
+        "display": "Carcinoma in situ of skin of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92742004",
+        "display": "Carcinoma in situ of skin of temporal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92743009",
+        "display": "Carcinoma in situ of skin of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92744003",
+        "display": "Carcinoma in situ of skin of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92745002",
+        "display": "Carcinoma in situ of skin of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92746001",
+        "display": "Carcinoma in situ of skin of umbilicus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92747005",
+        "display": "Carcinoma in situ of skin of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92748000",
+        "display": "Carcinoma in situ of skin of wrist"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92749008",
+        "display": "Carcinoma in situ of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92750008",
+        "display": "Carcinoma in situ of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92751007",
+        "display": "Carcinoma in situ of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92752000",
+        "display": "Carcinoma in situ of spermatic cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92753005",
+        "display": "Carcinoma in situ of sphenoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92754004",
+        "display": "Carcinoma in situ of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92756002",
+        "display": "Carcinoma in situ of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92757006",
+        "display": "Carcinoma in situ of subglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92758001",
+        "display": "Carcinoma in situ of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92759009",
+        "display": "Carcinoma in situ of submaxillary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92760004",
+        "display": "Carcinoma in situ of superior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92761000",
+        "display": "Carcinoma in situ of supraglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92762007",
+        "display": "Carcinoma in situ of sweat gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92763002",
+        "display": "Carcinoma in situ of tail of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92764008",
+        "display": "Carcinoma in situ of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92766005",
+        "display": "Carcinoma in situ of thyroglossal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92767001",
+        "display": "Carcinoma in situ of thyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92768006",
+        "display": "Carcinoma in situ of tip AND/OR lateral border of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92769003",
+        "display": "Carcinoma in situ of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92770002",
+        "display": "Carcinoma in situ of tonsillar fossa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92771003",
+        "display": "Carcinoma in situ of tonsillar pillar"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92772005",
+        "display": "Carcinoma in situ of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92773000",
+        "display": "Carcinoma in situ of transverse colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92774006",
+        "display": "Carcinoma in situ of trigone of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92775007",
+        "display": "Carcinoma in situ of undescended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92776008",
+        "display": "Carcinoma in situ of upper gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92777004",
+        "display": "Carcinoma in situ of upper inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92778009",
+        "display": "Carcinoma in situ of upper outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92779001",
+        "display": "Carcinoma in situ of upper respiratory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92780003",
+        "display": "Carcinoma in situ of upper third esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92781004",
+        "display": "Carcinoma in situ of urachus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92782006",
+        "display": "Carcinoma in situ of ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92783001",
+        "display": "Carcinoma in situ of ureteric orifice of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92784007",
+        "display": "Carcinoma in situ of urethra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92785008",
+        "display": "Carcinoma in situ of urinary bladder neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92786009",
+        "display": "Carcinoma in situ of urinary system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92787000",
+        "display": "Carcinoma in situ of uterine adnexa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92788005",
+        "display": "Carcinoma in situ of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92789002",
+        "display": "Carcinoma in situ of uveal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92790006",
+        "display": "Carcinoma in situ of uvula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92791005",
+        "display": "Carcinoma in situ of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92792003",
+        "display": "Carcinoma in situ of vallecula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92793008",
+        "display": "Carcinoma in situ of vas deferens"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92794002",
+        "display": "Carcinoma in situ of ventral surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92795001",
+        "display": "Carcinoma in situ of vermilion border of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92796000",
+        "display": "Carcinoma in situ of vermilion border of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92797009",
+        "display": "Carcinoma in situ of vermilion border of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92798004",
+        "display": "Carcinoma in situ of vestibule of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92799007",
+        "display": "Carcinoma in situ of vestibule of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92800006",
+        "display": "Carcinoma in situ of visceral pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92801005",
+        "display": "Carcinoma in situ of vocal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92802003",
+        "display": "Carcinoma in situ of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92803008",
+        "display": "Carcinoma in situ of Waldeyer's ring"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109827007",
+        "display": "Carcinoma in situ of salivary gland duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109850001",
+        "display": "Carcinoma in situ of digestive organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109888004",
+        "display": "Lobular carcinoma in situ of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109889007",
+        "display": "Intraductal carcinoma in situ of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189212001",
+        "display": "Carcinoma in situ of salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189229003",
+        "display": "Carcinoma in situ of splenic flexure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189231007",
+        "display": "Carcinoma in situ of rectum and rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189243008",
+        "display": "Carcinoma in situ of hepatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189246000",
+        "display": "Carcinoma in situ of sphincter of Oddi"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189251006",
+        "display": "Carcinoma in situ of respiratory system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189252004",
+        "display": "Carcinoma in situ of thyroid cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189253009",
+        "display": "Carcinoma in situ of cricoid cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189255002",
+        "display": "Carcinoma in situ of arytenoid cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189256001",
+        "display": "Carcinoma in situ of corniculate cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189257005",
+        "display": "Carcinoma in situ of cuneiform cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189258000",
+        "display": "Carcinoma in situ of aryepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189259008",
+        "display": "Carcinoma in situ of vestibular fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189262006",
+        "display": "Carcinoma in situ of bronchus and lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189263001",
+        "display": "Carcinoma in situ of carina of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189265008",
+        "display": "Carcinoma in situ of upper lobe bronchus and lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189266009",
+        "display": "Carcinoma in situ of middle lobe bronchus and lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189267000",
+        "display": "Carcinoma in situ of lower lobe bronchus and lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189271002",
+        "display": "Carcinoma in situ of tympanic cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189272009",
+        "display": "Carcinoma in situ of tympanic antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189277003",
+        "display": "Carcinoma in situ of skin of eyelid including canthus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189279000",
+        "display": "Carcinoma in situ of skin of auricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189280002",
+        "display": "Carcinoma in situ of skin of external auricular canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189289001",
+        "display": "Carcinoma in situ of skin of jaw"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189291009",
+        "display": "Carcinoma in situ of scalp and skin of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189292002",
+        "display": "Carcinoma in situ of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189308005",
+        "display": "Carcinoma in situ of skin of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189317005",
+        "display": "Carcinoma in situ of skin of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189336000",
+        "display": "Carcinoma in situ of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189565007",
+        "display": "Squamous cell carcinoma in situ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "231830001",
+        "display": "Bowen's disease of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "240545008",
+        "display": "Anogenital papillomaviral intraepithelial neoplasia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254394005",
+        "display": "Carcinoma in situ of frenum of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254399000",
+        "display": "Carcinoma in situ of frenum of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254403009",
+        "display": "Carcinoma in situ of frenum of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254406001",
+        "display": "Carcinoma in situ of anterior two-thirds of tongue - dorsal surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254409008",
+        "display": "Carcinoma in situ of anterior two-thirds of tongue - border"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254413001",
+        "display": "Carcinoma in situ of tip of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254418005",
+        "display": "Carcinoma in situ of frenum linguae"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254428001",
+        "display": "Carcinoma in situ anterior floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254432007",
+        "display": "Carcinoma in situ lateral floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254442009",
+        "display": "Carcinoma in situ of upper buccal sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254446007",
+        "display": "Carcinoma in situ of lower buccal sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254451001",
+        "display": "Carcinoma in situ upper labial sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254455005",
+        "display": "Carcinoma in situ of lower labial sulcus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254460009",
+        "display": "Carcinoma in situ of anterior pillar of fauces"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254510001",
+        "display": "Carcinoma in situ of anterior commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254514005",
+        "display": "Carcinoma in situ of posterior commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254540004",
+        "display": "Carcinoma in situ of thoracic part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254544008",
+        "display": "Carcinoma in situ of abdominal part of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254564003",
+        "display": "Carcinoma in situ of lesser curve of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254639005",
+        "display": "Carcinoma in situ of lung parenchyma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254656002",
+        "display": "Bowen's disease of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255007008",
+        "display": "Bowen's disease of cornea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255131000",
+        "display": "Carcinoma in situ of oral cavity, lips, salivary glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255132007",
+        "display": "Carcinoma in situ of anterior two-thirds of tongue - ventral surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255136005",
+        "display": "Carcinoma in situ of upper labial mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255137001",
+        "display": "Carcinoma in situ of buccal aspect of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255138006",
+        "display": "Carcinoma in situ of ear, nose and throat"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255139003",
+        "display": "Carcinoma in situ of middle ear and mastoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255140001",
+        "display": "Carcinoma in situ of nasal cavity and nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255142009",
+        "display": "Carcinoma in situ of respiratory and intrathoracic organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255144005",
+        "display": "Carcinoma in situ of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255145006",
+        "display": "Carcinoma in situ of surface epithelium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255149000",
+        "display": "Carcinoma in situ of prostatic ducts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255150000",
+        "display": "Carcinoma in situ of urinary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271525004",
+        "display": "Carcinoma in situ of liver and/or biliary system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275492001",
+        "display": "Carcinoma in situ tongue base - dorsal surface"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "276875006",
+        "display": "Vulval intraepithelial neoplasia grade III"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "313351009",
+        "display": "Bowen's disease of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "398768004",
+        "display": "Queyrat's erythroplasia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "398831006",
+        "display": "Bowen's disease of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399911003",
+        "display": "Bowenoid papulosis of vulva with vulval intraepithelial neoplasia grade III (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399929008",
+        "display": "Bowenoid papulosis of anus with anal intraepithelial neoplasia grade III (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400066006",
+        "display": "Intraepithelial squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400092004",
+        "display": "Penile intraepithelial neoplasia grade III (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400118002",
+        "display": "Bowenoid papulosis of penis with penile intraepithelial neoplasia grade III (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402813000",
+        "display": "Carcinoma-in-situ of oral mucosa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403485001",
+        "display": "Anal intraepithelial neoplasia (AIN III) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403873003",
+        "display": "Intraepidermal squamous carcinoma of scalp (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403874009",
+        "display": "Intraepidermal squamous carcinoma of face (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403875005",
+        "display": "Intraepidermal squamous carcinoma of forehead (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403876006",
+        "display": "Intraepidermal squamous carcinoma of ear (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403877002",
+        "display": "Intraepidermal squamous carcinoma of hand (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403878007",
+        "display": "Intraepidermal squamous carcinoma of upper extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403879004",
+        "display": "Intraepidermal squamous carcinoma of lower extremity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403880001",
+        "display": "Intraepidermal squamous carcinoma of trunk (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403881002",
+        "display": "Bowen's disease, atrophic (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403882009",
+        "display": "Bowen's disease, verrucous (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403883004",
+        "display": "Bowen's disease, psoriasiform (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403884005",
+        "display": "Bowen's disease, pigmented (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403885006",
+        "display": "Bowen's disease, pagetoid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403886007",
+        "display": "Bowen's disease, clonal (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403887003",
+        "display": "Bowen's disease, clear cell (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403888008",
+        "display": "Multiple intraepidermal squamous carcinomata (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "406103009",
+        "display": "Squamous cell carcinoma in situ of uterine cervix (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "416921001",
+        "display": "Carcinoma in situ of nasolacrimal duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422607004",
+        "display": "Carcinoma in situ of lacrimal drainage system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422893006",
+        "display": "Carcinoma in situ of lacrimal gland duct (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423278008",
+        "display": "Lentigo maligna of skin of eyelid (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "446711009",
+        "display": "High grade prostatic intraepithelial neoplasia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "447953007",
+        "display": "Bowen's disease of skin of chest (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449064001",
+        "display": "Bowen's disease of skin of buttock (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449802004",
+        "display": "Carcinoma in situ of dome of urinary bladder (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "473419009",
+        "display": "Intraductal papillary mucinous carcinoma in situ of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702712006",
+        "display": "Carcinoma in situ of common hepatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721594000",
+        "display": "Papillary carcinoma in situ of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721595004",
+        "display": "Primary intracystic papillary carcinoma of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721596003",
+        "display": "Solid papillary carcinoma in situ of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722523004",
+        "display": "Mixed ductal and lobular carcinoma in situ of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722664004",
+        "display": "Carcinoma in situ of ocular adnexa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722713005",
+        "display": "Carcinoma in situ of anal margin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "723164006",
+        "display": "Carcinoma in situ of skin of penis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "737169005",
+        "display": "Ductal comedocarcinoma in situ of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "762260000",
+        "display": "Pleomorphic lobular carcinoma in situ of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "767544007",
+        "display": "Intraepithelial squamous cell carcinoma of anogenital region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "785798002",
+        "display": "Carcinoma in situ of oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "789051005",
+        "display": "Squamous cell carcinoma in situ of skin caused by sunlight (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "816979008",
+        "display": "Differentiated vulvar intraepithelial neoplasia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "816980006",
+        "display": "Differentiated PeIN (penile intraepithelial neoplasia)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "826978004",
+        "display": "Solid ductal carcinoma in situ of breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "871635009",
+        "display": "Squamous cell carcinoma in situ of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196834001",
+        "display": "Intraductal papillary neoplasia with high grade intraepithelial neoplasia of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197288009",
+        "display": "High grade squamous intraepithelial neoplasia of esophagus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "80071000119103",
+        "display": "Basal cell carcinoma of skin in situ (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353591000119105",
+        "display": "Carcinoma in situ of left breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353631000119105",
+        "display": "Carcinoma in situ of right breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354341000119108",
+        "display": "Lobular carcinoma in situ of left breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354471000119108",
+        "display": "Lobular carcinoma in situ of right breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16908281000119101",
+        "display": "Squamous cell carcinoma in situ of skin of right lower eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16908321000119106",
+        "display": "Squamous cell carcinoma in situ of skin of left lower eyelid (disorder)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00",
+        "display": "CARCINOMA IN SITU OF ORAL CAVITY, ESOPHAGUS AND STOMACH"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.0",
+        "display": "Carcinoma in situ of lip, oral cavity and pharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.00",
+        "display": "Carcinoma in situ of oral cavity, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.01",
+        "display": "Carcinoma in situ of labial mucosa and vermilion border"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.02",
+        "display": "Carcinoma in situ of buccal mucosa"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.03",
+        "display": "Carcinoma in situ of gingiva and edentulous alveolar ridge"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.04",
+        "display": "Carcinoma in situ of soft palate"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.05",
+        "display": "Carcinoma in situ of hard palate"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.06",
+        "display": "Carcinoma in situ of floor of mouth"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.07",
+        "display": "Carcinoma in situ of tongue"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.08",
+        "display": "Carcinoma in situ of pharynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.1",
+        "display": "Carcinoma in situ of esophagus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D00.2",
+        "display": "Carcinoma in situ of stomach"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01",
+        "display": "CARCINOMA IN SITU OF OTHER AND UNSPECIFIED DIGESTIVE ORGANS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.0",
+        "display": "Carcinoma in situ of colon"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.1",
+        "display": "Carcinoma in situ of rectosigmoid junction"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.2",
+        "display": "Carcinoma in situ of rectum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.3",
+        "display": "Carcinoma in situ of anus and anal canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.4",
+        "display": "Carcinoma in situ of other and unspecified parts of intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.40",
+        "display": "Carcinoma in situ of unspecified part of intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.49",
+        "display": "Carcinoma in situ of other parts of intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.5",
+        "display": "Carcinoma in situ of liver, gallbladder and bile ducts"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.7",
+        "display": "Carcinoma in situ of other specified digestive organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D01.9",
+        "display": "Carcinoma in situ of digestive organ, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02",
+        "display": "CARCINOMA IN SITU OF MIDDLE EAR AND RESPIRATORY SYSTEM"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.0",
+        "display": "Carcinoma in situ of larynx"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.1",
+        "display": "Carcinoma in situ of trachea"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.2",
+        "display": "Carcinoma in situ of bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.20",
+        "display": "Carcinoma in situ of unspecified bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.21",
+        "display": "Carcinoma in situ of right bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.22",
+        "display": "Carcinoma in situ of left bronchus and lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.3",
+        "display": "Carcinoma in situ of other parts of respiratory system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D02.4",
+        "display": "Carcinoma in situ of respiratory system, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05",
+        "display": "CARCINOMA IN SITU OF BREAST"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.0",
+        "display": "Lobular carcinoma in situ of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.00",
+        "display": "Lobular carcinoma in situ of unspecified breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.01",
+        "display": "Lobular carcinoma in situ of right breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.02",
+        "display": "Lobular carcinoma in situ of left breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.1",
+        "display": "Intraductal carcinoma in situ of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.10",
+        "display": "Intraductal carcinoma in situ of unspecified breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.11",
+        "display": "Intraductal carcinoma in situ of right breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.12",
+        "display": "Intraductal carcinoma in situ of left breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.8",
+        "display": "Other specified type of carcinoma in situ of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.80",
+        "display": "Other specified type of carcinoma in situ of unspecified breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.81",
+        "display": "Other specified type of carcinoma in situ of right breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.82",
+        "display": "Other specified type of carcinoma in situ of left breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.9",
+        "display": "Unspecified type of carcinoma in situ of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.90",
+        "display": "Unspecified type of carcinoma in situ of unspecified breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.91",
+        "display": "Unspecified type of carcinoma in situ of right breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D05.92",
+        "display": "Unspecified type of carcinoma in situ of left breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07",
+        "display": "CARCINOMA IN SITU OF OTHER AND UNSPECIFIED GENITAL ORGANS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.0",
+        "display": "Carcinoma in situ of endometrium"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.1",
+        "display": "Carcinoma in situ of vulva"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.2",
+        "display": "Carcinoma in situ of vagina"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.3",
+        "display": "Carcinoma in situ of other and unspecified female genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.30",
+        "display": "Carcinoma in situ of unspecified female genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.39",
+        "display": "Carcinoma in situ of other female genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.4",
+        "display": "Carcinoma in situ of penis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.6",
+        "display": "Carcinoma in situ of other and unspecified male genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.60",
+        "display": "Carcinoma in situ of unspecified male genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.61",
+        "display": "Carcinoma in situ of scrotum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D07.69",
+        "display": "Carcinoma in situ of other male genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09",
+        "display": "CARCINOMA IN SITU OF OTHER AND UNSPECIFIED SITES"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.0",
+        "display": "Carcinoma in situ of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.1",
+        "display": "Carcinoma in situ of other and unspecified urinary organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.10",
+        "display": "Carcinoma in situ of unspecified urinary organ"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.19",
+        "display": "Carcinoma in situ of other urinary organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.2",
+        "display": "Carcinoma in situ of eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.20",
+        "display": "Carcinoma in situ of unspecified eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.21",
+        "display": "Carcinoma in situ of right eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.22",
+        "display": "Carcinoma in situ of left eye"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.3",
+        "display": "Carcinoma in situ of thyroid and other endocrine glands"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.8",
+        "display": "Carcinoma in situ of other specified sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D09.9",
+        "display": "Carcinoma in situ, unspecified"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189758001",
+        "display": "Melanoma in situ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109266006",
+        "display": "Melanoma in situ of skin (clinical)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109268007",
+        "display": "Melanoma in situ of non-skin site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109270003",
+        "display": "Melanoma in situ of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109272006",
+        "display": "Melanoma in situ of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109274007",
+        "display": "Melanoma in situ of eyelid, including canthus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109276009",
+        "display": "Melanoma in situ of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109278005",
+        "display": "Melanoma in situ of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109280004",
+        "display": "Melanoma in situ of external auditory canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109282007",
+        "display": "Melanoma in situ of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109284008",
+        "display": "Melanoma in situ of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109286005",
+        "display": "Melanoma in situ of skin of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109288006",
+        "display": "Melanoma in situ of perianal skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109290007",
+        "display": "Melanoma in situ of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109292004",
+        "display": "Melanoma in situ of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109294003",
+        "display": "Melanoma in situ of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109296001",
+        "display": "Melanoma in situ of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189324006",
+        "display": "Melanoma in situ of skin structure of scalp and/or neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315036008",
+        "display": "Melanoma in situ of back of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315230006",
+        "display": "Melanoma in situ of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402556000",
+        "display": "Malignant melanoma (radial growth phase) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402557009",
+        "display": "In situ acral lentiginous malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722689005",
+        "display": "Melanoma in situ of conjunctiva (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878798006",
+        "display": "Melanoma in situ of skin of scrotum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "878799003",
+        "display": "Melanoma in situ of vermilion border of lip (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352161000119100",
+        "display": "Melanoma in situ of right upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "352191000119107",
+        "display": "Melanoma in situ of right lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080901000119107",
+        "display": "Melanoma in situ of left upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1080931000119100",
+        "display": "Melanoma in situ of left lower limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15951341000119104",
+        "display": "Melanoma in situ of skin of left breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15951381000119109",
+        "display": "Bilateral melanoma in situ of skin of breasts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15951421000119100",
+        "display": "Melanoma in situ of skin of right breast (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15951461000119105",
+        "display": "Melanoma in situ of bilateral upper limbs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16764101000119100",
+        "display": "Melanoma in situ of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16782651000119104",
+        "display": "Melanoma in situ of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16782691000119109",
+        "display": "Melanoma in situ of chin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16782731000119102",
+        "display": "Melanoma in situ of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16782771000119104",
+        "display": "Melanoma in situ of temple"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16907161000119103",
+        "display": "Melanoma in situ of left lower eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16907241000119105",
+        "display": "Melanoma in situ of right lower eyelid"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03",
+        "display": "Melanoma in situ of skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.0",
+        "display": "Melanoma in situ of lip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.1",
+        "display": "Melanoma in situ of eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.10",
+        "display": "Melanoma in situ of unspecified eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.11",
+        "display": "Melanoma in situ of right eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.111",
+        "display": "Melanoma in situ of right upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.112",
+        "display": "Melanoma in situ of right lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.12",
+        "display": "Melanoma in situ of left eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.121",
+        "display": "Melanoma in situ of left upper eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.122",
+        "display": "Melanoma in situ of left lower eyelid, including canthus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.2",
+        "display": "Melanoma in situ of ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.20",
+        "display": "Melanoma in situ of unspecified ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.21",
+        "display": "Melanoma in situ of right ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.22",
+        "display": "Melanoma in situ of left ear and external auricular canal"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.3",
+        "display": "Melanoma in situ of other and unspecified parts of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.30",
+        "display": "Melanoma in situ of unspecified part of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.39",
+        "display": "Melanoma in situ of other parts of face"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.4",
+        "display": "Melanoma in situ of scalp and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.5",
+        "display": "Melanoma in situ of trunk"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.51",
+        "display": "Melanoma in situ of anal skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.52",
+        "display": "Melanoma in situ of breast (skin) (soft tissue)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.59",
+        "display": "Melanoma in situ of other part of trunk"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.6",
+        "display": "Melanoma in situ of upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.60",
+        "display": "Melanoma in situ of unspecified upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.61",
+        "display": "Melanoma in situ of right upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.62",
+        "display": "Melanoma in situ of left upper limb, including shoulder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.7",
+        "display": "Melanoma in situ of lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.70",
+        "display": "Melanoma in situ of unspecified lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.71",
+        "display": "Melanoma in situ of right lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.72",
+        "display": "Melanoma in situ of left lower limb, including hip"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.8",
+        "display": "Melanoma in situ of other sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D03.9",
+        "display": "Melanoma in situ, unspecified"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "126361000119107",
+        "display": "Cytological evidence of malignancy on anal Papanicolaou smear (finding)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "126371000119101",
+        "display": "Cytological evidence of malignancy on vaginal Papanicolaou smear (finding)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "R85.614",
+        "display": "Cytologic evidence of malignancy on smear of anus"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "R87.624",
+        "display": "Cytologic evidence of malignancy on smear of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93468003",
+        "display": "Hemangioma of intracranial structure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403775003",
+        "display": "Hereditary neurocutaneous angiomata (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "428089008",
+        "display": "Venous hemangioma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "444869007",
+        "display": "Cavernous hemangioma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "717003001",
+        "display": "Hereditary cavernous hemangioma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109913001",
+        "display": "Benign neoplasm of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92051001",
+        "display": "Benign neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92406008",
+        "display": "Benign neoplasm of spinal meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189016009",
+        "display": "Lipoma of spinal canal - intradural"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253192007",
+        "display": "Fibrolipoma of filum terminale"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277527003",
+        "display": "Melanocytoma of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "429306002",
+        "display": "Benign neoplasm of spinal intradural intramedullary space (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "429691007",
+        "display": "Benign neoplasm of spinal intradural space"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "724171006",
+        "display": "Benign meningioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "765202001",
+        "display": "Familial multiple benign meningioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770628008",
+        "display": "Diffuse leptomeningeal melanocytosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "8551000119100",
+        "display": "Benign neoplasm of spinal intradural extramedullary space"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "104431000119107",
+        "display": "Lipomyelomeningocele"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92030004",
+        "display": "Benign neoplasm of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92029009",
+        "display": "Benign neoplasm of brain stem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92050000",
+        "display": "Benign neoplasm of cerebellum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92052008",
+        "display": "Benign neoplasm of cerebral ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92072003",
+        "display": "Benign neoplasm of craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92114009",
+        "display": "Benign neoplasm of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92253009",
+        "display": "Benign neoplasm of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92276007",
+        "display": "Benign neoplasm of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92294001",
+        "display": "Benign neoplasm of pineal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92296004",
+        "display": "Benign neoplasm of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92427003",
+        "display": "Benign neoplasm of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "126948004",
+        "display": "Cerebellopontine angle meningioma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "134209002",
+        "display": "Prolactinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "135884009",
+        "display": "Benign neoplasm of pons"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189162003",
+        "display": "Benign neoplasm of brain, supratentorial"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "237719001",
+        "display": "Pituitary adenoma with extrasellar extension"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253010003",
+        "display": "Microprolactinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "253011004",
+        "display": "Macroprolactinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254943007",
+        "display": "Benign tumor of choroid plexus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254956000",
+        "display": "Pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254957009",
+        "display": "Somatotroph adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254958004",
+        "display": "ACTH-secreting pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254959007",
+        "display": "Thyrotroph adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254960002",
+        "display": "Gonadotrophin-secreting pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254961003",
+        "display": "Mixed-functioning pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254962005",
+        "display": "Functionless pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254963000",
+        "display": "Pituitary microadenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254964006",
+        "display": "Pituitary mesoadenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254965007",
+        "display": "Pituitary macroadenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254966008",
+        "display": "Suprasellar extension of pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254970000",
+        "display": "Benign tumor of olfactory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255200003",
+        "display": "Benign tumor of hypothalamus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "264906008",
+        "display": "Pituitary macroadenoma with extrasellar extension"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "271479005",
+        "display": "Benign neoplasm of pituitary gland and craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275269004",
+        "display": "Benign cerebral tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425868004",
+        "display": "Benign papilloma of choroid plexus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "429765002",
+        "display": "Benign neoplasm of medulla oblongata (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "448135004",
+        "display": "Benign teratoma of pineal region (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "699331002",
+        "display": "Granular cell tumor of neurohypophysis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702375004",
+        "display": "Familial isolated pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722201004",
+        "display": "Median cleft of upper lip, corpus callosum lipoma, cutaneous polyp syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "778046002",
+        "display": "Somatomammotropinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "783008000",
+        "display": "Pituitary dermoid and epidermoid cysts (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788756004",
+        "display": "Spindle cell oncocytoma of posterior pituitary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830032008",
+        "display": "Dermoid cyst of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830033003",
+        "display": "Dermoid cyst of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157249003",
+        "display": "Invasive benign pituitary adenoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196837008",
+        "display": "Dysembryoplastic neuroepithelial neoplasm of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "87161000119107",
+        "display": "Benign ependymoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "350841000119107",
+        "display": "Benign neoplasm of infratentorial brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15863451000119107",
+        "display": "Lipoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92048008",
+        "display": "Benign neoplasm of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92257005",
+        "display": "Benign neoplasm of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92405007",
+        "display": "Benign neoplasm of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189015008",
+        "display": "Lipoma of spinal canal - extradural"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189017000",
+        "display": "Lipoma of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254977002",
+        "display": "Benign neoplasm of optic nerve and nerve sheath (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254979004",
+        "display": "Melanocytoma of optic nerve head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423361002",
+        "display": "Lipoma of dorsal spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426470009",
+        "display": "Lipoma of terminal spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "426510004",
+        "display": "Schwannoma of spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "427939000",
+        "display": "Benign neoplasm of spinal extradural space (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "782680004",
+        "display": "Gangliocytoma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "830015009",
+        "display": "Dermoid cyst of spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838304009",
+        "display": "Benign ependymoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "838350007",
+        "display": "Adenoma of neuroepithelium of iris"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1003434002",
+        "display": "Lipoma due to neurospinal dysraphism"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "33441000119100",
+        "display": "Transitional lipoma of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "34041000119108",
+        "display": "Benign neoplasm of extramedullary spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16207161000119102",
+        "display": "Cavernous hemangioma of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94963005",
+        "display": "Neoplasm of uncertain behavior of nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "19133005",
+        "display": "Neurofibromatosis syndrome"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92503002",
+        "display": "Bilateral acoustic neurofibromatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "92824003",
+        "display": "Neurofibromatosis type 1"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94722009",
+        "display": "Neoplasm of uncertain behavior of abducens nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94723004",
+        "display": "Neoplasm of uncertain behavior of accessory nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94725006",
+        "display": "Neoplasm of uncertain behavior of acoustic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94766006",
+        "display": "Neoplasm of uncertain behavior of brain stem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94767002",
+        "display": "Neoplasm of uncertain behavior of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94782007",
+        "display": "Neoplasm of uncertain behavior of cauda equina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94784008",
+        "display": "Neoplasm of uncertain behavior of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94786005",
+        "display": "Neoplasm of uncertain behavior of cerebellum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94787001",
+        "display": "Neoplasm of uncertain behavior of cerebral meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94788006",
+        "display": "Neoplasm of uncertain behavior of cerebral ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94789003",
+        "display": "Neoplasm of uncertain behavior of cerebrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94807005",
+        "display": "Neoplasm of uncertain behavior of cranial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94808000",
+        "display": "Neoplasm of uncertain behavior of craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94833002",
+        "display": "Neoplasm of uncertain behavior of facial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94847003",
+        "display": "Neoplasm of uncertain behavior of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94855005",
+        "display": "Neoplasm of uncertain behavior of glossopharyngeal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94868002",
+        "display": "Neoplasm of uncertain behavior of hypoglossal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94968001",
+        "display": "Neoplasm of uncertain behavior of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94969009",
+        "display": "Neoplasm of uncertain behavior of oculomotor nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94970005",
+        "display": "Neoplasm of uncertain behavior of olfactory nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94971009",
+        "display": "Neoplasm of uncertain behavior of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94986003",
+        "display": "Neoplasm of uncertain behavior of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95002008",
+        "display": "Neoplasm of uncertain behavior of pineal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95004009",
+        "display": "Neoplasm of uncertain behavior of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95108005",
+        "display": "Neoplasm of uncertain behavior of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95109002",
+        "display": "Neoplasm of uncertain behavior of spinal meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95126008",
+        "display": "Neoplasm of uncertain behavior of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95148002",
+        "display": "Neoplasm of uncertain behavior of trigeminal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95150005",
+        "display": "Neoplasm of uncertain behavior of trochlear nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "95171000",
+        "display": "Neoplasm of uncertain behavior of vagus nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109914007",
+        "display": "Neoplasm of uncertain behavior of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "109917000",
+        "display": "Neoplasm of uncertain behavior of peripheral nerves and peripheral autonomic nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189179009",
+        "display": "Craniopharyngioma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189484008",
+        "display": "Neoplasm of uncertain behavior of brain and spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189487001",
+        "display": "Neoplasm of uncertain or unknown behavior of brain, supratentorial"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "189488006",
+        "display": "Neoplasm of uncertain or unknown behavior of brain, infratentorial"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254241004",
+        "display": "Segmental neurofibromatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254945000",
+        "display": "Embryonal tumor of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254954002",
+        "display": "Embryonal tumor of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "254976006",
+        "display": "Optic nerve glioma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269496008",
+        "display": "Neoplasm of uncertain behavior of endocrine glands and nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277507004",
+        "display": "Pilocytic astrocytoma of cerebellum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "277522009",
+        "display": "Hemangiopericytoma of meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359619007",
+        "display": "Pinealoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403815003",
+        "display": "Axillary freckling due to neurofibromatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403816002",
+        "display": "Multiple café-au-lait macules due to neurofibromatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403817006",
+        "display": "Multiple neurofibromas in neurofibromatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403819009",
+        "display": "Elephantiasis neurofibromatosa (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403820003",
+        "display": "Café-au-lait macules with pulmonary stenosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403821004",
+        "display": "Café-au-lait macules with temporal dysrhythmia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "416351002",
+        "display": "Intraocular optic nerve glioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "417619001",
+        "display": "Intracranial optic nerve glioma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449799008",
+        "display": "SEGA - Subependymal giant cell astrocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "608817003",
+        "display": "Pituicytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715344006",
+        "display": "Neurofibromatosis Noonan syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716592003",
+        "display": "Cerebellar liponeurocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "716787002",
+        "display": "Extraventricular neurocytoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721535002",
+        "display": "Central neurocytoma of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722377004",
+        "display": "Paraganglioma and gastric stromal sarcoma syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "763865009",
+        "display": "Pilocytic astrocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "770682007",
+        "display": "Rosette-forming glioneuronal neoplasm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "780822000",
+        "display": "Desmoplastic infantile astrocytoma and ganglioglioma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "781641005",
+        "display": "Schwannomatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788757008",
+        "display": "Pituicytoma of posterior pituitary gland (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "788758003",
+        "display": "Sellar ependymoma of posterior pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "880093002",
+        "display": "17q11 deletion syndrome (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1003465006",
+        "display": "Familial spinal neurofibromatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1010653007",
+        "display": "Segmental neurofibromatosis type 1 (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156407001",
+        "display": "Myxopapillary ependymoma of spinal cord (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156412000",
+        "display": "Angiocentric glioma of central nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156457009",
+        "display": "Papillary glioneuronal tumor of brain (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156470000",
+        "display": "Atypical choroid plexus papilloma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1156473003",
+        "display": "Pineocytoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1157161000",
+        "display": "Meningioma of uncertain behavior (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1196902006",
+        "display": "Angiocentric glioma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197306009",
+        "display": "Myxopapillary ependymoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "19191000119106",
+        "display": "Neoplasm of uncertain behavior of peripheral nerve (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "25521000119106",
+        "display": "Neoplasm of uncertain behavior of hypothalamus (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15629411000119106",
+        "display": "Subependymoma of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16903531000119107",
+        "display": "Atypical meningioma of brain"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D18.02",
+        "display": "Hemangioma of intracranial structures"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D32",
+        "display": "BENIGN NEOPLASM OF MENINGES"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D32.0",
+        "display": "Benign neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D32.1",
+        "display": "Benign neoplasm of spinal meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D32.9",
+        "display": "Benign neoplasm of meninges, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33",
+        "display": "BENIGN NEOPLASM OF BRAIN AND OTHER PARTS OF CENTRAL NERVOUS SYSTEM"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.0",
+        "display": "Benign neoplasm of brain, supratentorial"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.1",
+        "display": "Benign neoplasm of brain, infratentorial"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.2",
+        "display": "Benign neoplasm of brain, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.3",
+        "display": "Benign neoplasm of cranial nerves"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.4",
+        "display": "Benign neoplasm of spinal cord"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.7",
+        "display": "Benign neoplasm of other specified parts of central nervous system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D33.9",
+        "display": "Benign neoplasm of central nervous system, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D35.2",
+        "display": "Benign neoplasm of pituitary gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D35.3",
+        "display": "Benign neoplasm of craniopharyngeal duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D35.4",
+        "display": "Benign neoplasm of pineal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D42.0",
+        "display": "Neoplasm of uncertain behavior of cerebral meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D42.1",
+        "display": "Neoplasm of uncertain behavior of spinal meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D42.9",
+        "display": "Neoplasm of uncertain behavior of meninges, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.0",
+        "display": "Neoplasm of uncertain behavior of brain, supratentorial"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.1",
+        "display": "Neoplasm of uncertain behavior of brain, infratentorial"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.2",
+        "display": "Neoplasm of uncertain behavior of brain, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.3",
+        "display": "Neoplasm of uncertain behavior of cranial nerves"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.4",
+        "display": "Neoplasm of uncertain behavior of spinal cord"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.8",
+        "display": "Neoplasm of uncertain behavior of other specified parts of central nervous system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D43.9",
+        "display": "Neoplasm of uncertain behavior of central nervous system, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D44.3",
+        "display": "Neoplasm of uncertain behavior of pituitary gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D44.4",
+        "display": "Neoplasm of uncertain behavior of craniopharyngeal duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "D44.5",
+        "display": "Neoplasm of uncertain behavior of pineal gland"
+      }
+    ]
+  }
+}

--- a/src/lib/valueSets/ValueSet-mcode-radiotherapy-volume-type-vs.json
+++ b/src/lib/valueSets/ValueSet-mcode-radiotherapy-volume-type-vs.json
@@ -1,0 +1,57 @@
+{
+  "resourceType": "ValueSet",
+  "id": "mcode-radiotherapy-volume-type-vs",
+  "language": "en",
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-radiotherapy-volume-type-vs",
+  "version": "2.1.0",
+  "name": "RadiotherapyVolumeTypeVS",
+  "title": "Radiotherapy Volume Type Value Set",
+  "status": "active",
+  "experimental": false,
+  "expansion": {
+    "identifier": "urn:uuid:493f7c93-3d92-4254-8c64-c0a68c80d1d5",
+    "timestamp": "2022-10-05T22:14:54.004Z",
+    "parameter": [
+      {
+        "name": "expansion-source",
+        "valueUri": "ValueSet/mcode-radiotherapy-volume-type-vs"
+      },
+      {
+        "name": "version",
+        "valueUri": "http://snomed.info/sct|http://snomed.info/sct/900000000000207008/version/20220731"
+      }
+    ],
+    "contains": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "228793007",
+        "display": "Planning target volume (observable entity)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "228791009",
+        "display": "Gross tumor volume (observable entity)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "228792002",
+        "display": "Clinical target volume (observable entity)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1162586008",
+        "display": "Irradiated volume of organ at risk (observable entity)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1201745009",
+        "display": "Internal target volume (observable entity)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1201746005",
+        "display": "Internal gross tumor volume (observable entity)"
+      }
+    ]
+  }
+}

--- a/src/lib/valueSets/ValueSet-mcode-secondary-cancer-disorder-vs.json
+++ b/src/lib/valueSets/ValueSet-mcode-secondary-cancer-disorder-vs.json
@@ -1,0 +1,4557 @@
+{
+  "resourceType": "ValueSet",
+  "id": "mcode-secondary-cancer-disorder-vs",
+  "language": "en",
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-secondary-cancer-disorder-vs",
+  "version": "2.1.0",
+  "name": "SecondaryCancerDisorderVS",
+  "title": "Secondary Cancer Disorder Value Set",
+  "status": "active",
+  "experimental": false,
+  "expansion": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/valueset-unclosed",
+        "valueBoolean": true
+      }
+    ],
+    "identifier": "urn:uuid:d65914e1-8ad4-46d0-8cab-a931a06ab271",
+    "timestamp": "2022-10-05T22:14:54.254Z",
+    "parameter": [
+      {
+        "name": "expansion-source",
+        "valueUri": "ValueSet/mcode-secondary-cancer-disorder-vs"
+      },
+      {
+        "name": "version",
+        "valueUri": "http://snomed.info/sct|http://snomed.info/sct/900000000000207008/version/20220731"
+      },
+      {
+        "name": "version",
+        "valueUri": "http://hl7.org/fhir/sid/icd-10-cm|2021"
+      }
+    ],
+    "contains": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "128462008",
+        "display": "Metastatic neoplasm (disease)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "40312006",
+        "display": "Pericarditis secondary to tumor metastatic to pericardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93144003",
+        "display": "Leukemic reticuloendotheliosis of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93145002",
+        "display": "Leukemic reticuloendotheliosis of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93146001",
+        "display": "Leukemic reticuloendotheliosis of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "93150008",
+        "display": "Leukemic reticuloendotheliosis of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94152006",
+        "display": "Secondary malignant neoplasm of abdominal esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94153001",
+        "display": "Secondary malignant neoplasm of abducens nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94154007",
+        "display": "Secondary malignant neoplasm of accessory nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94155008",
+        "display": "Secondary malignant neoplasm of accessory sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94156009",
+        "display": "Secondary malignant neoplasm of acoustic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94157000",
+        "display": "Secondary malignant neoplasm of acromion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94158005",
+        "display": "Secondary malignant neoplasm of adenoid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94159002",
+        "display": "Secondary malignant neoplasm of adnexa of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94160007",
+        "display": "Secondary malignant neoplasm of adrenal cortex"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94161006",
+        "display": "Secondary malignant neoplasm of adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94162004",
+        "display": "Secondary malignant neoplasm of adrenal medulla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94163009",
+        "display": "Secondary malignant neoplasm of alveolar ridge mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94164003",
+        "display": "Secondary malignant neoplasm of ampulla of Vater"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94165002",
+        "display": "Secondary malignant neoplasm of anal canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94166001",
+        "display": "Secondary malignant neoplasm of anterior aspect of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94167005",
+        "display": "Secondary malignant neoplasm of anterior mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94168000",
+        "display": "Secondary malignant neoplasm of anterior portion of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94169008",
+        "display": "Secondary malignant neoplasm of anterior two-thirds of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94170009",
+        "display": "Secondary malignant neoplasm of anterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94171008",
+        "display": "Secondary malignant neoplasm of anterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94172001",
+        "display": "Secondary malignant neoplasm of anus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94173006",
+        "display": "Secondary malignant neoplasm of aortic body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94175004",
+        "display": "Secondary malignant neoplasm of appendix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94176003",
+        "display": "Secondary malignant neoplasm of areola of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94177007",
+        "display": "Secondary malignant neoplasm of areola of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94179005",
+        "display": "Secondary malignant neoplasm of ascending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94180008",
+        "display": "Secondary malignant neoplasm of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94181007",
+        "display": "Secondary malignant neoplasm of axillary lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94182000",
+        "display": "Secondary malignant neoplasm of axillary tail of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94183005",
+        "display": "Secondary malignant neoplasm of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94184004",
+        "display": "Secondary malignant neoplasm of base of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94185003",
+        "display": "Secondary malignant neoplasm of biliary tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94186002",
+        "display": "Secondary malignant neoplasm of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94187006",
+        "display": "Secondary malignant neoplasm of blood vessel of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94189009",
+        "display": "Secondary malignant neoplasm of blood vessel of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94190000",
+        "display": "Secondary malignant neoplasm of blood vessel of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94191001",
+        "display": "Secondary malignant neoplasm of blood vessel of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94192008",
+        "display": "Secondary malignant neoplasm of blood vessel of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94193003",
+        "display": "Secondary malignant neoplasm of blood vessel of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94194009",
+        "display": "Secondary malignant neoplasm of blood vessel of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94195005",
+        "display": "Secondary malignant neoplasm of blood vessel of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94196006",
+        "display": "Secondary malignant neoplasm of blood vessel of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94197002",
+        "display": "Secondary malignant neoplasm of blood vessel of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94198007",
+        "display": "Secondary malignant neoplasm of blood vessel of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94200001",
+        "display": "Secondary malignant neoplasm of blood vessel of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94201002",
+        "display": "Secondary malignant neoplasm of blood vessel of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94202009",
+        "display": "Secondary malignant neoplasm of blood vessel of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94203004",
+        "display": "Secondary malignant neoplasm of blood vessel of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94204005",
+        "display": "Secondary malignant neoplasm of blood vessel of popliteal space"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94205006",
+        "display": "Secondary malignant neoplasm of blood vessel of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94206007",
+        "display": "Secondary malignant neoplasm of blood vessel of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94207003",
+        "display": "Secondary malignant neoplasm of blood vessel of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94208008",
+        "display": "Secondary malignant neoplasm of blood vessel of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94209000",
+        "display": "Secondary malignant neoplasm of blood vessel of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94210005",
+        "display": "Secondary malignant neoplasm of blood vessel of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94211009",
+        "display": "Secondary malignant neoplasm of blood vessel"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94212002",
+        "display": "Secondary malignant neoplasm of body of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94213007",
+        "display": "Secondary malignant neoplasm of body of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94214001",
+        "display": "Secondary malignant neoplasm of body of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94215000",
+        "display": "Secondary malignant neoplasm of body of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94217008",
+        "display": "Secondary malignant neoplasm of bone marrow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94218003",
+        "display": "Secondary malignant neoplasm of bone of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94219006",
+        "display": "Secondary malignant neoplasm of bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94220000",
+        "display": "Secondary malignant neoplasm of bone of skull"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94221001",
+        "display": "Secondary malignant neoplasm of bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94222008",
+        "display": "Secondary malignant neoplasm of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94224009",
+        "display": "Secondary malignant neoplasm of brain stem"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94225005",
+        "display": "Secondary malignant neoplasm of brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94226006",
+        "display": "Secondary malignant neoplasm of broad ligament"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94227002",
+        "display": "Secondary malignant neoplasm of bronchopulmonary lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94228007",
+        "display": "Secondary malignant neoplasm of bronchus of left lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94229004",
+        "display": "Secondary malignant neoplasm of bronchus of left upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94230009",
+        "display": "Secondary malignant neoplasm of bronchus of right lower lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94231008",
+        "display": "Secondary malignant neoplasm of bronchus of right middle lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94232001",
+        "display": "Secondary malignant neoplasm of bronchus of right upper lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94233006",
+        "display": "Secondary malignant neoplasm of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94234000",
+        "display": "Secondary malignant neoplasm of buccal mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94235004",
+        "display": "Secondary malignant neoplasm of cecum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94236003",
+        "display": "Secondary malignant neoplasm of calcaneus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94237007",
+        "display": "Secondary malignant neoplasm of cardia of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94238002",
+        "display": "Secondary malignant neoplasm of carina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94239005",
+        "display": "Secondary malignant neoplasm of carotid body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94240007",
+        "display": "Secondary malignant neoplasm of carpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94241006",
+        "display": "Secondary malignant neoplasm of cartilage of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94242004",
+        "display": "Secondary malignant neoplasm of cauda equina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94243009",
+        "display": "Secondary malignant neoplasm of central nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94244003",
+        "display": "Secondary malignant neoplasm of central portion of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94245002",
+        "display": "Secondary malignant neoplasm of cerebellum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94246001",
+        "display": "Secondary malignant neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94247005",
+        "display": "Secondary malignant neoplasm of cerebral ventricle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94248000",
+        "display": "Secondary malignant neoplasm of cerebrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94249008",
+        "display": "Secondary malignant neoplasm of cervical esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94250008",
+        "display": "Secondary malignant neoplasm of cervical vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94252000",
+        "display": "Secondary malignant neoplasm of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94253005",
+        "display": "Secondary malignant neoplasm of chest wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94254004",
+        "display": "Secondary malignant neoplasm of choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94255003",
+        "display": "Secondary malignant neoplasm of ciliary body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94256002",
+        "display": "Secondary malignant neoplasm of clavicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94257006",
+        "display": "Secondary malignant neoplasm of clitoris"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94258001",
+        "display": "Secondary malignant neoplasm of coccygeal body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94259009",
+        "display": "Secondary malignant neoplasm of coccyx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94260004",
+        "display": "Secondary malignant neoplasm of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94261000",
+        "display": "Secondary malignant neoplasm of commissure of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94262007",
+        "display": "Secondary malignant neoplasm of common bile duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94263002",
+        "display": "Secondary malignant neoplasm of conjunctiva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94264008",
+        "display": "Secondary malignant neoplasm of connective and other soft tissues"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94265009",
+        "display": "Secondary malignant neoplasm of cornea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94266005",
+        "display": "Secondary malignant neoplasm of cranial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94267001",
+        "display": "Secondary malignant neoplasm of craniopharyngeal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94268006",
+        "display": "Secondary malignant neoplasm of cubital lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94269003",
+        "display": "Secondary malignant neoplasm of cuboid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94270002",
+        "display": "Secondary malignant neoplasm of cystic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94271003",
+        "display": "Secondary malignant neoplasm of descending colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94272005",
+        "display": "Secondary malignant neoplasm of diaphragm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94273000",
+        "display": "Secondary malignant neoplasm of dorsal surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94274006",
+        "display": "Secondary malignant neoplasm of thoracic vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94275007",
+        "display": "Secondary malignant neoplasm of duodenum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94276008",
+        "display": "Secondary malignant neoplasm of ectopic female breast tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94277004",
+        "display": "Secondary malignant neoplasm of ectopic male breast tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94278009",
+        "display": "Secondary malignant neoplasm of endocardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94279001",
+        "display": "Secondary malignant neoplasm of endocervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94280003",
+        "display": "Secondary malignant neoplasm of endocrine gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94281004",
+        "display": "Secondary malignant neoplasm of endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94282006",
+        "display": "Secondary malignant neoplasm of epicardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94283001",
+        "display": "Secondary malignant neoplasm of epididymis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94284007",
+        "display": "Secondary malignant neoplasm of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94285008",
+        "display": "Secondary malignant neoplasm of epitrochlear lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94286009",
+        "display": "Secondary malignant neoplasm of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94287000",
+        "display": "Secondary malignant neoplasm of ethmoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94288005",
+        "display": "Secondary malignant neoplasm of ethmoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94289002",
+        "display": "Secondary malignant neoplasm of eustachian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94290006",
+        "display": "Secondary malignant neoplasm of exocervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94291005",
+        "display": "Secondary malignant neoplasm of extrahepatic bile ducts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94292003",
+        "display": "Secondary malignant neoplasm of eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94293008",
+        "display": "Secondary malignant neoplasm of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94294002",
+        "display": "Secondary malignant neoplasm of facial nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94295001",
+        "display": "Secondary malignant neoplasm of fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94296000",
+        "display": "Secondary malignant neoplasm of false vocal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94297009",
+        "display": "Secondary malignant neoplasm of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94298004",
+        "display": "Secondary malignant neoplasm of female genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94299007",
+        "display": "Secondary malignant neoplasm of femoral lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94300004",
+        "display": "Secondary malignant neoplasm of femur"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94301000",
+        "display": "Secondary malignant neoplasm of fibula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94302007",
+        "display": "Secondary malignant neoplasm of first cuneiform bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94303002",
+        "display": "Secondary malignant neoplasm of flank"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94304008",
+        "display": "Secondary malignant neoplasm of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94305009",
+        "display": "Secondary malignant neoplasm of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94306005",
+        "display": "Secondary malignant neoplasm of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94307001",
+        "display": "Secondary malignant neoplasm of prepuce"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94308006",
+        "display": "Secondary malignant neoplasm of frontal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94309003",
+        "display": "Secondary malignant neoplasm of frontal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94310008",
+        "display": "Secondary malignant neoplasm of frontal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94311007",
+        "display": "Secondary malignant neoplasm of fundus of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94312000",
+        "display": "Secondary malignant neoplasm of gallbladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94313005",
+        "display": "Secondary malignant neoplasm of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94314004",
+        "display": "Secondary malignant neoplasm of gingival mucosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94315003",
+        "display": "Secondary malignant neoplasm of glans penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94316002",
+        "display": "Secondary malignant neoplasm of glomus jugulare"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94317006",
+        "display": "Secondary malignant neoplasm of glossopharyngeal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94318001",
+        "display": "Secondary malignant neoplasm of glottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94319009",
+        "display": "Secondary malignant neoplasm of great vessels"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94320003",
+        "display": "Secondary malignant neoplasm of greater curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94321004",
+        "display": "Secondary malignant neoplasm of gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94322006",
+        "display": "Secondary malignant neoplasm of hamate bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94323001",
+        "display": "Secondary malignant neoplasm of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94324007",
+        "display": "Secondary malignant neoplasm of hard palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94325008",
+        "display": "Secondary malignant neoplasm of head of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94326009",
+        "display": "Secondary malignant neoplasm of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94327000",
+        "display": "Secondary malignant neoplasm of heart"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94328005",
+        "display": "Secondary malignant neoplasm of hepatic flexure of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94329002",
+        "display": "Secondary malignant neoplasm of hilus of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94330007",
+        "display": "Secondary malignant neoplasm of hypogastric lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94331006",
+        "display": "Secondary malignant neoplasm of hypoglossal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94332004",
+        "display": "Secondary malignant neoplasm of hypopharyngeal aspect of aryepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94333009",
+        "display": "Secondary malignant neoplasm of hypopharyngeal aspect of interarytenoid fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94334003",
+        "display": "Secondary malignant neoplasm of hypopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94335002",
+        "display": "Secondary malignant neoplasm of ileum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94336001",
+        "display": "Secondary malignant neoplasm of iliac lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94337005",
+        "display": "Secondary malignant neoplasm of ilium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94338000",
+        "display": "Secondary malignant neoplasm of infraclavicular lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94339008",
+        "display": "Secondary malignant neoplasm of inguinal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94340005",
+        "display": "Secondary malignant neoplasm of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94341009",
+        "display": "Secondary malignant neoplasm of inner aspect of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94342002",
+        "display": "Secondary malignant neoplasm of inner aspect of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94343007",
+        "display": "Secondary malignant neoplasm of inner aspect of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94344001",
+        "display": "Secondary malignant neoplasm of intercostal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94345000",
+        "display": "Secondary malignant neoplasm of intestinal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94346004",
+        "display": "Secondary malignant neoplasm of intestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94347008",
+        "display": "Secondary malignant neoplasm of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94348003",
+        "display": "Secondary malignant neoplasm of intra-abdominal organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94349006",
+        "display": "Secondary malignant neoplasm of intrahepatic bile ducts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94350006",
+        "display": "Secondary malignant neoplasm of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94351005",
+        "display": "Secondary malignant neoplasm of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94352003",
+        "display": "Secondary malignant neoplasm of intrathoracic organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94353008",
+        "display": "Secondary malignant neoplasm of ischium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94354002",
+        "display": "Secondary malignant neoplasm of islets of Langerhans"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94355001",
+        "display": "Secondary malignant neoplasm of isthmus of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94356000",
+        "display": "Secondary malignant neoplasm of jaw"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94357009",
+        "display": "Secondary malignant neoplasm of jejunum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94358004",
+        "display": "Secondary malignant neoplasm of junctional region of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94359007",
+        "display": "Secondary malignant neoplasm of junctional zone of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94360002",
+        "display": "Secondary malignant neoplasm of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94361003",
+        "display": "Secondary malignant neoplasm of labia majora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94362005",
+        "display": "Secondary malignant neoplasm of labia minora"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94364006",
+        "display": "Secondary malignant neoplasm of lacrimal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94365007",
+        "display": "Secondary malignant neoplasm of large intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94366008",
+        "display": "Secondary malignant neoplasm of laryngeal aspect of aryepiglottic fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94367004",
+        "display": "Secondary malignant neoplasm of laryngeal aspect of interarytenoid fold"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94368009",
+        "display": "Secondary malignant neoplasm of laryngeal commissure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94369001",
+        "display": "Secondary malignant neoplasm of laryngeal surface of epiglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94370000",
+        "display": "Secondary malignant neoplasm of larynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94371001",
+        "display": "Secondary malignant neoplasm of lateral portion of floor of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94372008",
+        "display": "Secondary malignant neoplasm of lateral wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94373003",
+        "display": "Secondary malignant neoplasm of lateral wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94374009",
+        "display": "Secondary malignant neoplasm of lateral wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94375005",
+        "display": "Secondary malignant neoplasm of left lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94376006",
+        "display": "Secondary malignant neoplasm of left upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94378007",
+        "display": "Secondary malignant neoplasm of lesser curvature of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94379004",
+        "display": "Secondary malignant neoplasm of lingual tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94380001",
+        "display": "Secondary malignant neoplasm of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94381002",
+        "display": "Secondary malignant neoplasm of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94382009",
+        "display": "Secondary malignant neoplasm of long bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94383004",
+        "display": "Secondary malignant neoplasm of long bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94384005",
+        "display": "Secondary malignant neoplasm of lower gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94385006",
+        "display": "Secondary malignant neoplasm of lower inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94386007",
+        "display": "Secondary malignant neoplasm of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94387003",
+        "display": "Secondary malignant neoplasm of lower outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94388008",
+        "display": "Secondary malignant neoplasm of lower third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94389000",
+        "display": "Secondary malignant neoplasm of lumbar vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94390009",
+        "display": "Secondary malignant neoplasm of lunate bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94391008",
+        "display": "Secondary malignant neoplasm of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94392001",
+        "display": "Secondary malignant neoplasm of lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94393006",
+        "display": "Secondary malignant neoplasm of lymph nodes of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94394000",
+        "display": "Secondary malignant neoplasm of lymph nodes of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94395004",
+        "display": "Secondary malignant neoplasm of lymph nodes of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94396003",
+        "display": "Secondary malignant neoplasm of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94397007",
+        "display": "Secondary malignant neoplasm of lymph nodes of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94398002",
+        "display": "Secondary malignant neoplasm of lymph nodes of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94399005",
+        "display": "Secondary malignant neoplasm of main bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94400003",
+        "display": "Secondary malignant neoplasm of major salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94401004",
+        "display": "Secondary malignant neoplasm of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94402006",
+        "display": "Secondary malignant neoplasm of male genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94403001",
+        "display": "Secondary malignant neoplasm of mandible"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94404007",
+        "display": "Secondary malignant neoplasm of mastoid air cells"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94405008",
+        "display": "Secondary malignant neoplasm of maxilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94406009",
+        "display": "Secondary malignant neoplasm of maxillary sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94407000",
+        "display": "Secondary malignant neoplasm of Meckel's diverticulum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94408005",
+        "display": "Secondary malignant neoplasm of mediastinal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94409002",
+        "display": "Secondary malignant neoplasm of mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94410007",
+        "display": "Secondary malignant neoplasm of mesenteric lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94411006",
+        "display": "Secondary malignant neoplasm of metacarpal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94412004",
+        "display": "Secondary malignant neoplasm of metatarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94413009",
+        "display": "Secondary malignant neoplasm of middle ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94414003",
+        "display": "Secondary malignant neoplasm of middle third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94415002",
+        "display": "Secondary malignant neoplasm of minor salivary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94416001",
+        "display": "Secondary malignant neoplasm of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94417005",
+        "display": "Secondary malignant neoplasm of multiple endocrine glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94418000",
+        "display": "Secondary malignant neoplasm of muscle of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94419008",
+        "display": "Secondary malignant neoplasm of muscle of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94420002",
+        "display": "Secondary malignant neoplasm of muscle of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94421003",
+        "display": "Secondary malignant neoplasm of muscle of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94422005",
+        "display": "Secondary malignant neoplasm of muscle of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94423000",
+        "display": "Secondary malignant neoplasm of muscle of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94424006",
+        "display": "Secondary malignant neoplasm of muscle of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94425007",
+        "display": "Secondary malignant neoplasm of muscle of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94426008",
+        "display": "Secondary malignant neoplasm of muscle of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94427004",
+        "display": "Secondary malignant neoplasm of muscle of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94428009",
+        "display": "Secondary malignant neoplasm of muscle of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94429001",
+        "display": "Secondary malignant neoplasm of muscle of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94430006",
+        "display": "Secondary malignant neoplasm of muscle of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94431005",
+        "display": "Secondary malignant neoplasm of muscle of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94432003",
+        "display": "Secondary malignant neoplasm of muscle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94433008",
+        "display": "Secondary malignant neoplasm of myocardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94434002",
+        "display": "Secondary malignant neoplasm of myometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94435001",
+        "display": "Secondary malignant neoplasm of nasal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94436000",
+        "display": "Secondary malignant neoplasm of nasal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94437009",
+        "display": "Secondary malignant neoplasm of nasal concha"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94439007",
+        "display": "Secondary malignant neoplasm of navicular bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94440009",
+        "display": "Secondary malignant neoplasm of scaphoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94441008",
+        "display": "Secondary malignant neoplasm of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94442001",
+        "display": "Secondary malignant neoplasm of nervous system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94443006",
+        "display": "Secondary malignant neoplasm of nipple of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94444000",
+        "display": "Secondary malignant neoplasm of nipple of male breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94445004",
+        "display": "Secondary malignant neoplasm of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94446003",
+        "display": "Secondary malignant neoplasm of obturator lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94447007",
+        "display": "Secondary malignant neoplasm of occipital bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94448002",
+        "display": "Secondary malignant neoplasm of occipital lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94449005",
+        "display": "Secondary malignant neoplasm of occipital lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94450005",
+        "display": "Secondary malignant neoplasm of oculomotor nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94451009",
+        "display": "Secondary malignant neoplasm of olfactory nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94452002",
+        "display": "Secondary malignant neoplasm of optic nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94453007",
+        "display": "Secondary malignant neoplasm of orbit"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94454001",
+        "display": "Secondary malignant neoplasm of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94455000",
+        "display": "Secondary malignant neoplasm of ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94456004",
+        "display": "Secondary malignant neoplasm of palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94457008",
+        "display": "Secondary malignant neoplasm of palatine bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94458003",
+        "display": "Secondary malignant neoplasm of tonsil"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94459006",
+        "display": "Secondary malignant neoplasm of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94460001",
+        "display": "Secondary malignant neoplasm of pancreatic duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94461002",
+        "display": "Secondary malignant neoplasm of para-aortic body"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94462009",
+        "display": "Secondary malignant neoplasm of paraganglion"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94463004",
+        "display": "Secondary malignant neoplasm of paramammary lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94464005",
+        "display": "Secondary malignant neoplasm of parametrial lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94465006",
+        "display": "Secondary malignant neoplasm of parametrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94466007",
+        "display": "Secondary malignant neoplasm of pararectal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94467003",
+        "display": "Secondary malignant neoplasm of parathyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94468008",
+        "display": "Secondary malignant neoplasm of paraurethral glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94469000",
+        "display": "Secondary malignant neoplasm of paravaginal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94470004",
+        "display": "Secondary malignant neoplasm of parietal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94471000",
+        "display": "Secondary malignant neoplasm of parietal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94472007",
+        "display": "Secondary malignant neoplasm of parietal peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94473002",
+        "display": "Secondary malignant neoplasm of parietal pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94474008",
+        "display": "Secondary malignant neoplasm of parotid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94475009",
+        "display": "Secondary malignant neoplasm of parotid lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94476005",
+        "display": "Secondary malignant neoplasm of patella"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94477001",
+        "display": "Secondary malignant neoplasm of pectoral axillary lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94478006",
+        "display": "Secondary malignant neoplasm of pelvic bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94479003",
+        "display": "Secondary malignant neoplasm of pelvic peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94480000",
+        "display": "Secondary malignant neoplasm of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94481001",
+        "display": "Secondary malignant neoplasm of penis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94482008",
+        "display": "Secondary malignant neoplasm of periadrenal tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94483003",
+        "display": "Secondary malignant neoplasm of perianal skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94484009",
+        "display": "Secondary malignant neoplasm of pericardium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94485005",
+        "display": "Secondary malignant neoplasm of perirenal tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94486006",
+        "display": "Secondary malignant neoplasm of phalanx of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94487002",
+        "display": "Secondary malignant neoplasm of phalanx of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94488007",
+        "display": "Secondary malignant neoplasm of pharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94489004",
+        "display": "Secondary malignant neoplasm of pineal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94490008",
+        "display": "Secondary malignant neoplasm of pisiform bone of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94491007",
+        "display": "Secondary malignant neoplasm of pituitary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94492000",
+        "display": "Secondary malignant neoplasm of placenta"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94493005",
+        "display": "Secondary malignant neoplasm of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94494004",
+        "display": "Secondary malignant neoplasm of popliteal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94495003",
+        "display": "Secondary malignant neoplasm of postcricoid region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94496002",
+        "display": "Secondary malignant neoplasm of posterior hypopharyngeal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94497006",
+        "display": "Secondary malignant neoplasm of posterior mediastinum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94498001",
+        "display": "Secondary malignant neoplasm of posterior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94499009",
+        "display": "Secondary malignant neoplasm of posterior wall of oropharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94500000",
+        "display": "Secondary malignant neoplasm of posterior wall of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94501001",
+        "display": "Secondary malignant neoplasm of preauricular lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94502008",
+        "display": "Secondary malignant neoplasm of presacral region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94503003",
+        "display": "Secondary malignant neoplasm of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94504009",
+        "display": "Secondary malignant neoplasm of pubis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94505005",
+        "display": "Secondary malignant neoplasm of pyloric antrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94506006",
+        "display": "Secondary malignant neoplasm of pylorus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94507002",
+        "display": "Secondary malignant neoplasm of pyriform sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94508007",
+        "display": "Secondary malignant neoplasm of radius"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94509004",
+        "display": "Secondary malignant neoplasm of rectosigmoid junction"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94510009",
+        "display": "Secondary malignant neoplasm of rectouterine pouch"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94511008",
+        "display": "Secondary malignant neoplasm of rectovaginal septum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94512001",
+        "display": "Secondary malignant neoplasm of rectovesical septum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94513006",
+        "display": "Secondary malignant neoplasm of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94514000",
+        "display": "Secondary malignant neoplasm of renal pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94515004",
+        "display": "Secondary malignant neoplasm of respiratory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94516003",
+        "display": "Secondary malignant neoplasm of retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94517007",
+        "display": "Secondary malignant neoplasm of retrocecal tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94518002",
+        "display": "Secondary malignant neoplasm of retromolar area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94519005",
+        "display": "Secondary malignant neoplasm of retroperitoneal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94520004",
+        "display": "Secondary malignant neoplasm of retropharyngeal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94521000",
+        "display": "Secondary malignant neoplasm of rib"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94522007",
+        "display": "Secondary malignant neoplasm of right lower lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94523002",
+        "display": "Secondary malignant neoplasm of right middle lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94524008",
+        "display": "Secondary malignant neoplasm of right upper lobe of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94525009",
+        "display": "Secondary malignant neoplasm of round ligament of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94526005",
+        "display": "Secondary malignant neoplasm of sacrococcygeal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94527001",
+        "display": "Secondary malignant neoplasm of sacrum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94528006",
+        "display": "Secondary malignant neoplasm of scalene lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94529003",
+        "display": "Secondary malignant neoplasm of scapula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94530008",
+        "display": "Secondary malignant neoplasm of sclera"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94531007",
+        "display": "Secondary malignant neoplasm of scrotum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94532000",
+        "display": "Secondary malignant neoplasm of sebaceous gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94533005",
+        "display": "Secondary malignant neoplasm of second cuneiform bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94534004",
+        "display": "Secondary malignant neoplasm of septum of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94535003",
+        "display": "Secondary malignant neoplasm of short bone of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94536002",
+        "display": "Secondary malignant neoplasm of short bone of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94537006",
+        "display": "Secondary malignant neoplasm of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94538001",
+        "display": "Secondary malignant neoplasm of sigmoid colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94539009",
+        "display": "Secondary malignant neoplasm of skin of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94540006",
+        "display": "Secondary malignant neoplasm of skin of ankle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94542003",
+        "display": "Secondary malignant neoplasm of skin of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94543008",
+        "display": "Secondary malignant neoplasm of skin of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94544002",
+        "display": "Secondary malignant neoplasm of skin of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94545001",
+        "display": "Secondary malignant neoplasm of skin of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94546000",
+        "display": "Secondary malignant neoplasm of skin of cheek"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94547009",
+        "display": "Secondary malignant neoplasm of skin of chest"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94548004",
+        "display": "Secondary malignant neoplasm of skin of chin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94549007",
+        "display": "Secondary malignant neoplasm of skin of ear"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94550007",
+        "display": "Secondary malignant neoplasm of skin of elbow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94551006",
+        "display": "Secondary malignant neoplasm of skin of external auditory canal"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94552004",
+        "display": "Secondary malignant neoplasm of skin of eyebrow"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94553009",
+        "display": "Secondary malignant neoplasm of skin of eyelid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94554003",
+        "display": "Secondary malignant neoplasm of skin of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94555002",
+        "display": "Secondary malignant neoplasm of skin of finger"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94556001",
+        "display": "Secondary malignant neoplasm of skin of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94557005",
+        "display": "Secondary malignant neoplasm of skin of forearm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94558000",
+        "display": "Secondary malignant neoplasm of skin of forehead"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94559008",
+        "display": "Secondary malignant neoplasm of skin of groin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94560003",
+        "display": "Secondary malignant neoplasm of skin of hand"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94561004",
+        "display": "Secondary malignant neoplasm of skin of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94562006",
+        "display": "Secondary malignant neoplasm of skin of knee"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94564007",
+        "display": "Secondary malignant neoplasm of skin of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94565008",
+        "display": "Secondary malignant neoplasm of skin of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94566009",
+        "display": "Secondary malignant neoplasm of skin of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94567000",
+        "display": "Secondary malignant neoplasm of skin of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94568005",
+        "display": "Secondary malignant neoplasm of skin of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94569002",
+        "display": "Secondary malignant neoplasm of skin of popliteal area"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94570001",
+        "display": "Secondary malignant neoplasm of skin of scalp"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94571002",
+        "display": "Secondary malignant neoplasm of skin of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94572009",
+        "display": "Secondary malignant neoplasm of skin of temporal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94573004",
+        "display": "Secondary malignant neoplasm of skin of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94574005",
+        "display": "Secondary malignant neoplasm of skin of toe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94575006",
+        "display": "Secondary malignant neoplasm of skin of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94576007",
+        "display": "Secondary malignant neoplasm of skin of umbilicus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94577003",
+        "display": "Secondary malignant neoplasm of skin of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94578008",
+        "display": "Secondary malignant neoplasm of skin of wrist"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94579000",
+        "display": "Secondary malignant neoplasm of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94580002",
+        "display": "Secondary malignant neoplasm of small intestine"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94581003",
+        "display": "Secondary malignant neoplasm of soft palate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94582005",
+        "display": "Secondary malignant neoplasm of soft tissues of abdomen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94583000",
+        "display": "Secondary malignant neoplasm of soft tissues of axilla"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94584006",
+        "display": "Secondary malignant neoplasm of soft tissues of buttock"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94585007",
+        "display": "Secondary malignant neoplasm of soft tissues of face"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94586008",
+        "display": "Secondary malignant neoplasm of soft tissues of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94587004",
+        "display": "Secondary malignant neoplasm of soft tissues of hip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94588009",
+        "display": "Secondary malignant neoplasm of soft tissues of inguinal region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94589001",
+        "display": "Secondary malignant neoplasm of soft tissues of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94590005",
+        "display": "Secondary malignant neoplasm of soft tissues of neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94591009",
+        "display": "Secondary malignant neoplasm of soft tissues of pelvis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94592002",
+        "display": "Secondary malignant neoplasm of soft tissues of perineum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94593007",
+        "display": "Secondary malignant neoplasm of soft tissues of shoulder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94594001",
+        "display": "Secondary malignant neoplasm of soft tissues of thorax"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94595000",
+        "display": "Secondary malignant neoplasm of soft tissues of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94596004",
+        "display": "Secondary malignant neoplasm of soft tissues of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94597008",
+        "display": "Secondary malignant neoplasm of spermatic cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94598003",
+        "display": "Secondary malignant neoplasm of sphenoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94599006",
+        "display": "Secondary malignant neoplasm of sphenoidal sinus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94600009",
+        "display": "Secondary malignant neoplasm of spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94601008",
+        "display": "Secondary malignant neoplasm of spinal meninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94602001",
+        "display": "Secondary malignant neoplasm of vertebral column"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94603006",
+        "display": "Secondary malignant neoplasm of spleen"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94604000",
+        "display": "Secondary malignant neoplasm of splenic flexure of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94605004",
+        "display": "Secondary malignant neoplasm of sternum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94606003",
+        "display": "Secondary malignant neoplasm of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94607007",
+        "display": "Secondary malignant neoplasm of subglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94608002",
+        "display": "Secondary malignant neoplasm of sublingual gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94609005",
+        "display": "Secondary malignant neoplasm of submandibular lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94610000",
+        "display": "Secondary malignant neoplasm of submaxillary gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94611001",
+        "display": "Secondary malignant neoplasm of submental lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94612008",
+        "display": "Secondary malignant neoplasm of superficial inguinal lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94613003",
+        "display": "Secondary malignant neoplasm of superior wall of nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94614009",
+        "display": "Secondary malignant neoplasm of supraclavicular lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94615005",
+        "display": "Secondary malignant neoplasm of supraclavicular region"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94616006",
+        "display": "Secondary malignant neoplasm of supraglottis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94617002",
+        "display": "Secondary malignant neoplasm of sweat gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94618007",
+        "display": "Secondary malignant neoplasm of tail of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94619004",
+        "display": "Secondary malignant neoplasm of talus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94620005",
+        "display": "Secondary malignant neoplasm of tarsal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94621009",
+        "display": "Secondary malignant neoplasm of temporal bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94622002",
+        "display": "Secondary malignant neoplasm of temporal lobe"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94623007",
+        "display": "Secondary malignant neoplasm of testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94624001",
+        "display": "Secondary malignant neoplasm of the mesentery"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94625000",
+        "display": "Secondary malignant neoplasm of the mesocolon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94626004",
+        "display": "Omental metastasis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94627008",
+        "display": "Metastasis to peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94628003",
+        "display": "Secondary malignant neoplasm of the retroperitoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94629006",
+        "display": "Secondary malignant neoplasm of thigh"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94630001",
+        "display": "Secondary malignant neoplasm of third cuneiform bone of foot"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94631002",
+        "display": "Secondary malignant neoplasm of thoracic esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94632009",
+        "display": "Secondary malignant neoplasm of thymus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94633004",
+        "display": "Secondary malignant neoplasm of thyroglossal duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94634005",
+        "display": "Secondary malignant neoplasm of thyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94635006",
+        "display": "Secondary malignant neoplasm of tibia"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94636007",
+        "display": "Secondary malignant neoplasm of tibial lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94637003",
+        "display": "Secondary malignant neoplasm of tip and lateral border of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94638008",
+        "display": "Secondary malignant neoplasm of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94639000",
+        "display": "Secondary malignant neoplasm of tonsillar fossa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94640003",
+        "display": "Secondary malignant neoplasm of tonsillar pillar"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94641004",
+        "display": "Secondary malignant neoplasm of trachea"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94642006",
+        "display": "Secondary malignant neoplasm of tracheobronchial lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94643001",
+        "display": "Secondary malignant neoplasm of transverse colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94644007",
+        "display": "Secondary malignant neoplasm of trapezium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94645008",
+        "display": "Secondary malignant neoplasm of trapezoid bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94646009",
+        "display": "Secondary malignant neoplasm of trigeminal nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94647000",
+        "display": "Secondary malignant neoplasm of trigone of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94648005",
+        "display": "Secondary malignant neoplasm of trochlear nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94649002",
+        "display": "Secondary malignant neoplasm of trunk"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94650002",
+        "display": "Secondary malignant neoplasm of ulna"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94651003",
+        "display": "Secondary malignant neoplasm of undescended testis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94652005",
+        "display": "Secondary malignant neoplasm of upper gum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94653000",
+        "display": "Secondary malignant neoplasm of upper inner quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94654006",
+        "display": "Secondary malignant neoplasm of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94655007",
+        "display": "Secondary malignant neoplasm of upper outer quadrant of female breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94656008",
+        "display": "Secondary malignant neoplasm of upper respiratory tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94657004",
+        "display": "Metastatic malignant neoplasm to upper third of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94658009",
+        "display": "Secondary malignant neoplasm of urachus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94659001",
+        "display": "Secondary malignant neoplasm of ureter"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94660006",
+        "display": "Secondary malignant neoplasm of ureteric orifice of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94661005",
+        "display": "Secondary malignant neoplasm of urethra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94662003",
+        "display": "Secondary malignant neoplasm of urinary bladder neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94663008",
+        "display": "Secondary malignant neoplasm of urinary system"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94664002",
+        "display": "Secondary malignant neoplasm of uterine adnexa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94665001",
+        "display": "Secondary malignant neoplasm of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94666000",
+        "display": "Secondary malignant neoplasm of uveal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94667009",
+        "display": "Secondary malignant neoplasm of uvula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94668004",
+        "display": "Secondary malignant neoplasm of vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94669007",
+        "display": "Secondary malignant neoplasm of vagus nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94670008",
+        "display": "Secondary malignant neoplasm of vallecula"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94671007",
+        "display": "Secondary malignant neoplasm of vas deferens"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94672000",
+        "display": "Secondary malignant neoplasm of ventral surface of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94673005",
+        "display": "Secondary malignant neoplasm of vermilion border of lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94674004",
+        "display": "Secondary malignant neoplasm of vermilion border of lower lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94675003",
+        "display": "Secondary malignant neoplasm of vermilion border of upper lip"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94676002",
+        "display": "Secondary malignant neoplasm of vestibule of mouth"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94677006",
+        "display": "Secondary malignant neoplasm of vestibule of nose"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94678001",
+        "display": "Secondary malignant neoplasm of visceral pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94679009",
+        "display": "Secondary malignant neoplasm of vocal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94680007",
+        "display": "Secondary malignant neoplasm of vomer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94681006",
+        "display": "Secondary malignant neoplasm of vulva"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94682004",
+        "display": "Secondary malignant neoplasm of Waldeyer's ring"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "94683009",
+        "display": "Secondary malignant neoplasm of zygomatic bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "128465005",
+        "display": "Secondary malignant neoplasm of articular cartilage"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "134421000",
+        "display": "Pathologic fracture of bone at site of metastatic neoplasm (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188445006",
+        "display": "Secondary malignant neoplasm of retroperitoneum and peritoneum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188454009",
+        "display": "Secondary malignant neoplasm of skin of head"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188458007",
+        "display": "Secondary malignant neoplasm of skin of shoulder and arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188462001",
+        "display": "Secondary malignant neoplasm of brain and spinal cord"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188469005",
+        "display": "Secondary malignant neoplasm of cervix uteri"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188471005",
+        "display": "Secondary malignant neoplasm of epididymis and vas deferens"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188645002",
+        "display": "Leukemic reticuloendotheliosis of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188648000",
+        "display": "Leukemic reticuloendotheliosis of lymph nodes of axilla and upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "188649008",
+        "display": "Leukemic reticuloendotheliosis of lymph nodes of inguinal region and lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "230156002",
+        "display": "Malignant meningitis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "233940007",
+        "display": "Pulmonary tumor embolism"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "236512004",
+        "display": "Leukemic infiltrate of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "241861008",
+        "display": "Metastatic malignant neoplasm to nasopharynx"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "242862004",
+        "display": "Secondary malignant neoplasm of nasopharyngeal wall"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255118005",
+        "display": "Secondary lymphangitic carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255119002",
+        "display": "Lymphangitis carcinomatosa"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255121007",
+        "display": "Carcinomatosis of peritoneal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255123005",
+        "display": "Metastasis to nervous system and eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255124004",
+        "display": "Metastasis to peripheral nerve"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "269473008",
+        "display": "Secondary malignant neoplasm of respiratory and digestive systems"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "274088005",
+        "display": "Secondary malignant neoplasm of unknown site"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "275266006",
+        "display": "Metastasis to digestive organs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278051002",
+        "display": "Malignant lymphoma of thyroid gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "278433008",
+        "display": "Malignant infiltration of soft tissue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285598005",
+        "display": "UKP - Metastasis to trachea of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285603002",
+        "display": "UKP - Metastasis to bronchus of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285604008",
+        "display": "Metastasis to lung of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285605009",
+        "display": "UKP - Metastasis to pleura of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285606005",
+        "display": "Metastasis to heart of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285607001",
+        "display": "UKP - Metastasis to mediastinum of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285608006",
+        "display": "Metastasis to thymus of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285609003",
+        "display": "UKP - Metastasis to small intestine of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285610008",
+        "display": "UKP - Metastasis to large intestine of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285611007",
+        "display": "Metastasis to colon of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285612000",
+        "display": "UKP - Metastasis to rectum of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285613005",
+        "display": "Metastasis to liver of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285614004",
+        "display": "UKP - Metastasis to pancreas of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285615003",
+        "display": "Metastasis to spleen of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285616002",
+        "display": "UKP - Metastasis to peritoneum of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285617006",
+        "display": "Metastasis to retroperitoneum of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285618001",
+        "display": "UKP - Metastasis to bone of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285619009",
+        "display": "Metastasis to vertebral column of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285631006",
+        "display": "Metastasis to skin of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285633009",
+        "display": "UKP - Metastasis to soft tissue of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285634003",
+        "display": "UKP - Metastasis to breast of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285635002",
+        "display": "Metastasis to uterus of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285637005",
+        "display": "Metastasis to ovary of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285638000",
+        "display": "UKP - Metastasis to vagina of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285639008",
+        "display": "Metastasis to kidney of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285640005",
+        "display": "UKP - Metastasis to bladder of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285641009",
+        "display": "UKP - Metastasis to brain of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285642002",
+        "display": "Metastasis to eye of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285643007",
+        "display": "UKP - Metastasis to adrenal gland of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285644001",
+        "display": "Metastasis to lymph node of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "285645000",
+        "display": "UKP - Disseminated malignancy of unknown primary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "286902000",
+        "display": "Secondary carcinoma of gastrointestinal tract"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303194003",
+        "display": "Metastasis to head and neck lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "303201005",
+        "display": "Metastasis to multiple lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307226002",
+        "display": "Metastatic adenocarcinoma of unknown origin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307593001",
+        "display": "Disseminated carcinomatosis"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "307601000",
+        "display": "Pseudomyxoma peritonei"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314408000",
+        "display": "Leukemic infiltrate of choroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314418005",
+        "display": "Leukemic infiltrate of retina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314987003",
+        "display": "Metastasis from malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314988008",
+        "display": "Metastasis from malignant tumor of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314989000",
+        "display": "Metastasis from malignant tumor of soft tissues"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314990009",
+        "display": "Metastasis from malignant tumor of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314991008",
+        "display": "Metastasis from malignant tumor of adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314992001",
+        "display": "Metastasis from malignant tumor of cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314993006",
+        "display": "Metastasis from malignant tumor of uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314994000",
+        "display": "Metastasis from malignant tumor of prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314995004",
+        "display": "Metastasis from malignant tumor of bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314996003",
+        "display": "Metastasis from malignant tumor of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314997007",
+        "display": "Metastasis from malignant tumor of rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314998002",
+        "display": "Metastasis from malignant tumor of colon"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "314999005",
+        "display": "Metastasis from malignant tumor of pancreas"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315000005",
+        "display": "Metastasis from malignant tumor of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315001009",
+        "display": "Metastasis from malignant tumor of gallbladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315002002",
+        "display": "Metastasis from malignant tumor of stomach"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315003007",
+        "display": "Metastasis from malignant tumor of esophagus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315004001",
+        "display": "Metastasis from malignant tumor of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315005000",
+        "display": "Metastasis from malignant tumor of bronchus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315006004",
+        "display": "Metastasis from malignant tumor of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315007008",
+        "display": "Metastasis from malignant tumor of thyroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315008003",
+        "display": "Metastasis from malignant tumor of buccal cavity"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "315009006",
+        "display": "Metastasis from malignant tumor of tongue"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359780007",
+        "display": "Metastatic malignant neoplasm to lateral axillary lymph nodes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359782004",
+        "display": "Metastatic malignant neoplasm to apex of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359785002",
+        "display": "Metastatic malignant neoplasm to dome of urinary bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "359987004",
+        "display": "Krukenberg tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369455009",
+        "display": "Malignant tumor involving rectum by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369456005",
+        "display": "Malignant tumor involving rectum by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369457001",
+        "display": "Malignant tumor involving rectum by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369458006",
+        "display": "Malignant tumor involving rectum by separate metastasis from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369459003",
+        "display": "Malignant tumor involving rectum by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369460008",
+        "display": "Malignant tumor involving rectum by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369461007",
+        "display": "Malignant tumor involving rectum by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369464004",
+        "display": "Malignant tumor involving ureter by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369467006",
+        "display": "Malignant tumor involving urethra by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369468001",
+        "display": "Malignant tumor involving urethra by separate metastasis from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369476004",
+        "display": "Malignant tumor involving bladder by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369477008",
+        "display": "Malignant tumor involving bladder by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369478003",
+        "display": "Malignant tumor involving bladder by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369479006",
+        "display": "Malignant tumor involving bladder by separate metastasis from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369480009",
+        "display": "Malignant tumor involving bladder by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369481008",
+        "display": "Malignant tumor involving bladder by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369482001",
+        "display": "Malignant tumor involving bladder by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369484000",
+        "display": "Malignant tumor involving vasa deferentia by separate metastasis from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369486003",
+        "display": "Malignant tumor involving prostate by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369488002",
+        "display": "Secondary malignant neoplasm of seminal vesicle"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369491002",
+        "display": "Malignant tumor involving seminal vesicle by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369492009",
+        "display": "Malignant tumor involving seminal vesicle by separate metastasis from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369500009",
+        "display": "Malignant tumor involving uterine cervix by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369501008",
+        "display": "Malignant tumor involving uterine cervix by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369502001",
+        "display": "Malignant tumor involving uterine corpus by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369514009",
+        "display": "Secondary malignant neoplasm of left fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369521009",
+        "display": "Secondary malignant neoplasm of right fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369523007",
+        "display": "Secondary malignant neoplasm of left ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369530001",
+        "display": "Secondary malignant neoplasm of right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369535006",
+        "display": "Secondary neoplasm of left broad ligament"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369536007",
+        "display": "Secondary neoplasm of right broad ligament"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369538008",
+        "display": "Malignant tumor involving left broad ligament by metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369540003",
+        "display": "Malignant tumor involving right broad ligament by metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369542006",
+        "display": "Malignant tumor involving left fallopian tube by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369543001",
+        "display": "Malignant tumor involving left fallopian tube by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369544007",
+        "display": "Malignant tumor involving left fallopian tube by separate metastasis from right fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369545008",
+        "display": "Malignant tumor involving left fallopian tube by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369546009",
+        "display": "Malignant tumor involving left fallopian tube by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369553000",
+        "display": "Malignant tumor involving right fallopian tube by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369554006",
+        "display": "Malignant tumor involving right fallopian tube by separate metastasis from left fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369555007",
+        "display": "Malignant tumor involving right fallopian tube by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369556008",
+        "display": "Malignant tumor involving right fallopian tube by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369557004",
+        "display": "Malignant tumor involving right fallopian tube by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369558009",
+        "display": "Malignant tumor involving right fallopian tube by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369560006",
+        "display": "Malignant tumor involving left ovary by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369561005",
+        "display": "Malignant tumor involving left ovary by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369562003",
+        "display": "Malignant tumor involving left ovary by separate metastasis from right ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369563008",
+        "display": "Malignant tumor involving left ovary by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369564002",
+        "display": "Malignant tumor involving left ovary by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369565001",
+        "display": "Malignant tumor involving left ovary by separate metastasis uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369568004",
+        "display": "Malignant tumor involving right ovary by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369569007",
+        "display": "Malignant tumor involving right ovary by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369570008",
+        "display": "Malignant tumor involving right ovary by separate metastasis from left ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369571007",
+        "display": "Malignant tumor involving right ovary by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369572000",
+        "display": "Malignant tumor involving right ovary by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369573005",
+        "display": "Malignant tumor involving right ovary by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369574004",
+        "display": "Malignant tumor involving uterine cervix by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369575003",
+        "display": "Malignant tumor involving uterine corpus by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369576002",
+        "display": "Malignant tumor involving uterine corpus by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369577006",
+        "display": "Malignant tumor involving uterine corpus by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369578001",
+        "display": "Malignant tumor involving uterine corpus by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369581006",
+        "display": "Malignant tumor involving vagina by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369582004",
+        "display": "Malignant tumor involving vagina by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369583009",
+        "display": "Malignant tumor involving vagina by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369584003",
+        "display": "Malignant tumor involving vagina by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369585002",
+        "display": "Malignant tumor involving vagina by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369586001",
+        "display": "Malignant tumor involving vagina by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369588000",
+        "display": "Malignant tumor involving vulva by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369589008",
+        "display": "Malignant tumor involving vulva by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369590004",
+        "display": "Malignant tumor involving vulva by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369591000",
+        "display": "Malignant tumor involving vulva by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369592007",
+        "display": "Malignant tumor involving vulva by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369593002",
+        "display": "Malignant tumor involving vulva by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369602008",
+        "display": "Malignant tumor involving an organ by separate metastasis from bladder"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369603003",
+        "display": "Malignant tumor involving an organ by separate metastasis from endometrium"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369604009",
+        "display": "Malignant tumor involving an organ by separate metastasis from fallopian tube"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369605005",
+        "display": "Malignant tumor involving an organ by separate metastasis from ovary"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369606006",
+        "display": "Malignant tumor involving an organ by separate metastasis from prostate"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369607002",
+        "display": "Malignant tumor involving an organ by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369608007",
+        "display": "Malignant tumor involving an organ by separate metastasis from uterus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369609004",
+        "display": "Malignant tumor involving an organ by separate metastasis from vagina"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369610009",
+        "display": "Malignant tumor involving left fallopian tube by separate metastasis from uterine cervix"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "372093008",
+        "display": "Secondary malignant neoplasm of axillary tail of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "399969009",
+        "display": "Secondary malignant neoplasm of blood vessel of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "400058002",
+        "display": "Secondary malignant neoplasm of blood vessel of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402537005",
+        "display": "Metastatic basal cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402563000",
+        "display": "Metastatic malignant melanoma with diffuse hypermelanosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "402879006",
+        "display": "T-cell leukemic infiltration of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "403906006",
+        "display": "Metastatic squamous cell carcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404090003",
+        "display": "Malignant infiltration of oral cavity by underlying tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404091004",
+        "display": "Malignant infiltration of skin by underlying tumor (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404092006",
+        "display": "Carcinomatous metastasis in skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404093001",
+        "display": "Sarcomatous metastasis in skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404094007",
+        "display": "Metastasis involving oral cavity (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404122003",
+        "display": "Leukemic infiltration of skin (chronic T-cell lymphocytic leukemia) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404123008",
+        "display": "Leukemic infiltration of skin (T-cell prolymphocytic leukemia) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404124002",
+        "display": "Leukemic infiltration of skin (T-cell lymphoblastic leukemia) (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404139001",
+        "display": "Leukemic infiltration of skin in hairy-cell leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404151004",
+        "display": "Leukemic infiltration of skin in myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404152006",
+        "display": "Leukemic infiltration of skin in acute myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404153001",
+        "display": "Leukemic infiltration of skin in chronic myeloid leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404154007",
+        "display": "Leukemic infiltration of skin in monocytic leukemia (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404156009",
+        "display": "Leukemic infiltration of skin (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "404157000",
+        "display": "Specific skin infiltration in Hodgkin's disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "405843009",
+        "display": "Widespread metastatic malignant neoplastic disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "414676007",
+        "display": "Metastatic neuroblastoma of orbit proper (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "418529003",
+        "display": "Secondary malignant neoplasm of lacrimal drainage structure"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "422782004",
+        "display": "Primary malignant neoplasm of ovary, with widespread metastatic disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423032007",
+        "display": "Leukemic infiltration of orbit (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423384009",
+        "display": "Secondary malignant neoplasm of lacrimal gland duct"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423595004",
+        "display": "Adenocarcinoma carcinomatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "423987006",
+        "display": "Primary malignant neoplasm of vulva, with widespread metastatic disease (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424052001",
+        "display": "Small cell carcinoma carcinomatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424887002",
+        "display": "Primary malignant neoplasm of thyroid gland, metastatic to bone (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "424954002",
+        "display": "Undifferentiated large cell carcinomatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "425303004",
+        "display": "Squamous cell carcinomatosis (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443144000",
+        "display": "Metastatic sarcoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "443493003",
+        "display": "Metastatic malignant melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449630001",
+        "display": "Secondary malignant neoplasm of skin of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449631002",
+        "display": "Secondary malignant neoplasm of skin of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449632009",
+        "display": "Secondary malignant neoplasm of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "449633004",
+        "display": "Secondary malignant neoplasm of upper arm"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "702392008",
+        "display": "Metastatic renal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "704152002",
+        "display": "Metastatic neuroblastoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "705176003",
+        "display": "Metastatic carcinoid tumor"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "709285002",
+        "display": "Secondary malignant neoplasm of lumbosacral plexus"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "712849003",
+        "display": "Carcinoma of prostate with bony metastases"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "720587009",
+        "display": "Donor derived melanoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722671009",
+        "display": "Metastatic malignant neoplasm of meninges (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "722707001",
+        "display": "Metastatic malignant neoplasm of peripheral nervous system (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "767444009",
+        "display": "Germline BRCA-mutated, HER2-negative metastatic breast cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "781076008",
+        "display": "Secondary malignant neoplasm of colon and/or rectum"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "827186009",
+        "display": "Secondary malignant neoplasm of skin of hip and skin of lower leg"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "836274002",
+        "display": "Carcinomatosis of peritoneum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "836486002",
+        "display": "Lymphomatous infiltrate of kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "866087009",
+        "display": "Metastatic fracture of vertebra"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1155991005",
+        "display": "Secondary malignant neoplasm of leptomeninges"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1186612004",
+        "display": "Metastatic liver cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1187285005",
+        "display": "Metastatic clear cell renal cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197285007",
+        "display": "Metastatic squamous cell carcinoma of thoracic lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197292002",
+        "display": "Metastatic squamous cell carcinoma of pelvic lymph node (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197293007",
+        "display": "Metastatic squamous cell carcinoma of lymph nodes of head and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197295000",
+        "display": "Metastatic squamous cell carcinoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197297008",
+        "display": "Metastatic squamous cell carcinoma of lymph node of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197299006",
+        "display": "Metastatic squamous cell carcinoma of lymph node of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197310007",
+        "display": "Metastatic adenocarcinoma of lymph node of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197311006",
+        "display": "Metastatic adenocarcinoma of lymph node of upper limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197312004",
+        "display": "Metastatic adenocarcinoma of abdominal lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197313009",
+        "display": "Metastatic adenocarcinoma of lymph node of head and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197322005",
+        "display": "Metastatic squamous cell carcinoma of abdominal lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197323000",
+        "display": "Metastatic carcinoma of thoracic lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197324006",
+        "display": "Metastatic malignant melanoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197325007",
+        "display": "Metastatic carcinoma of pelvic lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197326008",
+        "display": "Metastatic carcinoma of lymph node of head and neck"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197327004",
+        "display": "Metastatic carcinoma of lymph node of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197328009",
+        "display": "Metastatic adenocarcinoma of thoracic lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197329001",
+        "display": "Metastatic carcinoma of abdominal lymph node (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197330006",
+        "display": "Metastatic adenocarcinoma of lymph nodes of multiple sites"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1197331005",
+        "display": "Metastatic adenocarcinoma of pelvic lymph node"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1217692004",
+        "display": "Metastasis from malignant neoplasm of colon and/or rectum (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1661000119106",
+        "display": "Metastasis to lung from adenocarcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1671000119100",
+        "display": "Metastasis to lymph node from squamous cell carcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1681000119102",
+        "display": "Metastasis to lymph node from adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1691000119104",
+        "display": "Metastasis to liver from adenocarcinoma (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "78461000119105",
+        "display": "Secondary squamous cell carcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91191000119108",
+        "display": "Secondary adenocarcinoma of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91211000119109",
+        "display": "Secondary small cell carcinoma of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91221000119102",
+        "display": "Secondary malignant melanoma of pleura"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91231000119104",
+        "display": "Secondary adenocarcinoma of skin"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91271000119101",
+        "display": "Secondary squamous cell carcinoma of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "91281000119103",
+        "display": "Secondary adenocarcinoma of bone"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "96981000119102",
+        "display": "Malignant neoplasm of rectosigmoid junction metastatic to brain"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "105041000119109",
+        "display": "Secondary squamous cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "105051000119106",
+        "display": "Secondary undifferentiated large cell carcinoma of lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107811000119106",
+        "display": "Secondary small cell carcinoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "107831000119101",
+        "display": "Secondary squamous cell carcinoma of liver"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116811000119106",
+        "display": "Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of lower limb"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116821000119104",
+        "display": "Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of upper limb (disorder)"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "145501000119108",
+        "display": "Secondary malignant neoplasm of breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "145511000119106",
+        "display": "Secondary malignant neoplasm of genital organ"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353561000119103",
+        "display": "Cancer metastatic to right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353571000119109",
+        "display": "Secondary malignant neoplasm of right adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353721000119100",
+        "display": "Secondary malignant neoplasm of left adrenal gland"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "353741000119106",
+        "display": "Cancer metastatic to left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "354081000119101",
+        "display": "Secondary adenocarcinoma"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079531000119106",
+        "display": "Secondary malignant neoplasm of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1079541000119102",
+        "display": "Secondary malignant neoplasm of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082601000112109",
+        "display": "Metastatic malignant neoplasm of viscera"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1082901000112103",
+        "display": "Lymph node positive breast cancer"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "11717361000119108",
+        "display": "Secondary malignant neoplasm of soft tissue of back"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12241031000119108",
+        "display": "Secondary malignant neoplasm of left breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12241071000119106",
+        "display": "Secondary malignant neoplasm of right breast"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12246481000119106",
+        "display": "Bilateral secondary malignant neoplasm of kidneys"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12246561000119101",
+        "display": "Secondary malignant neoplasm of bilateral adrenal glands"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "12246641000119104",
+        "display": "Secondary malignant neoplasm of bilateral breasts"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "13351431000119102",
+        "display": "Secondary malignant neoplasm of lymph nodes of neck from thyroid"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15930821000119105",
+        "display": "Secondary malignant neoplasm of bilateral ovaries"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956181000119102",
+        "display": "Secondary adenocarcinoma of bilateral lungs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956221000119105",
+        "display": "Secondary adenocarcinoma of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956261000119100",
+        "display": "Secondary adenocarcinoma of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956661000119102",
+        "display": "Secondary small cell carcinoma of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956701000119109",
+        "display": "Secondary small cell carcinoma of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15956741000119106",
+        "display": "Secondary small cell carcinoma of both lungs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15957141000119109",
+        "display": "Secondary squamous cell carcinoma of both lungs"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15957181000119104",
+        "display": "Secondary squamous cell carcinoma of right lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15957221000119107",
+        "display": "Secondary squamous cell carcinoma of left lung"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958181000119103",
+        "display": "Secondary adenocarcinoma of bilateral kidneys"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958221000119106",
+        "display": "Secondary adenocarcinoma of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958261000119101",
+        "display": "Secondary adenocarcinoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958301000119109",
+        "display": "Secondary squamous cell carcinoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958381000119101",
+        "display": "Secondary squamous cell carcinoma of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958661000119103",
+        "display": "Secondary malignant melanoma of left kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958701000119105",
+        "display": "Secondary malignant melanoma of both kidneys"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15958741000119107",
+        "display": "Secondary malignant melanoma of right kidney"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15977551000119100",
+        "display": "Bilateral secondary malignant neoplasm of eyes"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15977591000119105",
+        "display": "Secondary malignant neoplasm of right eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "15977631000119105",
+        "display": "Secondary malignant neoplasm of left eye"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "16260631000119101",
+        "display": "Metastatic malignant neoplasm to lymph node from primary malignant neoplasm of female breast (disorder)"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77",
+        "display": "SECONDARY AND UNSPECIFIED MALIGNANT NEOPLASM OF LYMPH NODES"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.0",
+        "display": "Secondary and unspecified malignant neoplasm of lymph nodes of head, face and neck"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.1",
+        "display": "Secondary and unspecified malignant neoplasm of intrathoracic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.2",
+        "display": "Secondary and unspecified malignant neoplasm of intra-abdominal lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.3",
+        "display": "Secondary and unspecified malignant neoplasm of axilla and upper limb lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.4",
+        "display": "Secondary and unspecified malignant neoplasm of inguinal and lower limb lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.5",
+        "display": "Secondary and unspecified malignant neoplasm of intrapelvic lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.8",
+        "display": "Secondary and unspecified malignant neoplasm of lymph nodes of multiple regions"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C77.9",
+        "display": "Secondary and unspecified malignant neoplasm of lymph node, unspecified"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78",
+        "display": "SECONDARY MALIGNANT NEOPLASM OF RESPIRATORY AND DIGESTIVE ORGANS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.0",
+        "display": "Secondary malignant neoplasm of lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.00",
+        "display": "Secondary malignant neoplasm of unspecified lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.01",
+        "display": "Secondary malignant neoplasm of right lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.02",
+        "display": "Secondary malignant neoplasm of left lung"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.1",
+        "display": "Secondary malignant neoplasm of mediastinum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.2",
+        "display": "Secondary malignant neoplasm of pleura"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.3",
+        "display": "Secondary malignant neoplasm of other and unspecified respiratory organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.30",
+        "display": "Secondary malignant neoplasm of unspecified respiratory organ"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.39",
+        "display": "Secondary malignant neoplasm of other respiratory organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.4",
+        "display": "Secondary malignant neoplasm of small intestine"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.5",
+        "display": "Secondary malignant neoplasm of large intestine and rectum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.6",
+        "display": "Secondary malignant neoplasm of retroperitoneum and peritoneum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.7",
+        "display": "Secondary malignant neoplasm of liver and intrahepatic bile duct"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.8",
+        "display": "Secondary malignant neoplasm of other and unspecified digestive organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.80",
+        "display": "Secondary malignant neoplasm of unspecified digestive organ"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C78.89",
+        "display": "Secondary malignant neoplasm of other digestive organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79",
+        "display": "SECONDARY MALIGNANT NEOPLASM OF OTHER AND UNSPECIFIED SITES"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.0",
+        "display": "Secondary malignant neoplasm of kidney and renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.00",
+        "display": "Secondary malignant neoplasm of unspecified kidney and renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.01",
+        "display": "Secondary malignant neoplasm of right kidney and renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.02",
+        "display": "Secondary malignant neoplasm of left kidney and renal pelvis"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.1",
+        "display": "Secondary malignant neoplasm of bladder and other urinary organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.10",
+        "display": "Secondary malignant neoplasm of unspecified urinary organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.11",
+        "display": "Secondary malignant neoplasm of bladder"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.19",
+        "display": "Secondary malignant neoplasm of other urinary organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.2",
+        "display": "Secondary malignant neoplasm of skin"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.3",
+        "display": "Secondary malignant neoplasm of brain cerebral  meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.31",
+        "display": "Secondary malignant neoplasm of brain"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.32",
+        "display": "Secondary malignant neoplasm of cerebral meninges"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.4",
+        "display": "Secondary malignant neoplasm of other and unspecified of nervous system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.40",
+        "display": "Secondary malignant neoplasm of unspecified part of nervous system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.49",
+        "display": "Secondary malignant neoplasm of other parts of nervous system"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.5",
+        "display": "Secondary malignant neoplasm of bone and bone marrow"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.51",
+        "display": "Secondary malignant neoplasm of bone"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.52",
+        "display": "Secondary malignant neoplasm of bone marrow"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.6",
+        "display": "Secondary malignant neoplasm of ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.60",
+        "display": "Secondary malignant neoplasm of unspecified ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.61",
+        "display": "Secondary malignant neoplasm of right ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.62",
+        "display": "Secondary malignant neoplasm of left ovary"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.7",
+        "display": "Secondary malignant neoplasm of adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.70",
+        "display": "Secondary malignant neoplasm of unspecified adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.71",
+        "display": "Secondary malignant neoplasm of right adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.72",
+        "display": "Secondary malignant neoplasm of left adrenal gland"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.8",
+        "display": "Secondary malignant neoplasm of other specified sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.81",
+        "display": "Secondary malignant neoplasm of breast"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.82",
+        "display": "Secondary malignant neoplasm of genital organs"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.89",
+        "display": "Secondary malignant neoplasm of other specified sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C79.9",
+        "display": "Secondary malignant neoplasm of unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B",
+        "display": "SECONDARY NEUROENDOCRINE TUMORS"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.0",
+        "display": "Secondary carcinoid tumors"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.00",
+        "display": "Secondary carcinoid tumors, unspecified site"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.01",
+        "display": "Secondary carcinoid tumors of distant lymph nodes"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.02",
+        "display": "Secondary carcinoid tumors of liver"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.03",
+        "display": "Secondary carcinoid tumors of bone"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.04",
+        "display": "Secondary carcinoid tumors of peritoneum"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.09",
+        "display": "Secondary carcinoid tumors of other sites"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.1",
+        "display": "Secondary merkel cell carcinoma"
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "code": "C7B.8",
+        "display": "Other secondary neuroendocrine tumors"
+      }
+    ]
+  }
+}

--- a/src/lib/valueSets/ValueSet-mcode-tumor-marker-test-vs.json
+++ b/src/lib/valueSets/ValueSet-mcode-tumor-marker-test-vs.json
@@ -1,0 +1,2587 @@
+{
+  "resourceType": "ValueSet",
+  "id": "mcode-tumor-marker-test-vs",
+  "language": "en",
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-tumor-marker-test-vs",
+  "version": "2.1.0",
+  "name": "TumorMarkerTestVS",
+  "title": "Tumor Marker Test Value Set",
+  "status": "active",
+  "experimental": false,
+  "expansion": {
+    "identifier": "urn:uuid:337447f7-783b-4983-9bbc-d646201145ee",
+    "timestamp": "2022-10-05T22:13:15.270Z",
+    "parameter": [
+      {
+        "name": "expansion-source",
+        "valueUri": "ValueSet/mcode-tumor-marker-test-vs"
+      },
+      {
+        "name": "version",
+        "valueUri": "http://loinc.org|2.73"
+      }
+    ],
+    "contains": [
+      {
+        "system": "http://loinc.org",
+        "code": "62320-7",
+        "display": "T-cell receptor excision circle [#/volume] in DBS by NAA with probe detection"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92006-6",
+        "display": "T-cell receptor excision circle [Cycle Threshold #] in DBS"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92007-4",
+        "display": "T-cell receptor excision circle [Z-score] in DBS"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92008-2",
+        "display": "T-cell receptor excision circle [Multiple of the median] in DBS"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "69361-4",
+        "display": "PCA3 score in Urine by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "69362-2",
+        "display": "PCA3 score in Urine Qualitative by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19163-5",
+        "display": "Cancer Ag 19-9 [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2009-9",
+        "display": "Cancer Ag 19-9 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "24108-3",
+        "display": "Cancer Ag 19-9 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "26924-1",
+        "display": "Cancer Ag 19-9 [Units/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50779-8",
+        "display": "Cancer Ag 19-9 [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50780-6",
+        "display": "Cancer Ag 19-9 [Units/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50781-4",
+        "display": "Cancer Ag 19-9 [Units/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83084-4",
+        "display": "Cancer Ag 19-9 [Units/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97750-4",
+        "display": "Cancer Ag 19-9 [Units/volume] in Aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14041-8",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19174-2",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Amniotic fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19175-9",
+        "display": "Choriogonadotropin.beta subunit [Moles/volume] in Amniotic fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20415-6",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Serum or Plasma by Immunoassay (EIA) 3rd IS"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2111-3",
+        "display": "Choriogonadotropin.beta subunit [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2113-9",
+        "display": "Choriogonadotropin.beta subunit [Mass/time] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2114-7",
+        "display": "Choriogonadotropin.beta subunit [Moles/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21198-7",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "29154-2",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43799-6",
+        "display": "Choriogonadotropin.beta subunit [Presence] in Specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43800-2",
+        "display": "Choriogonadotropin.beta subunit [Presence] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55868-4",
+        "display": "Choriogonadotropin.beta subunit [Multiple of the median] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55869-2",
+        "display": "Choriogonadotropin.beta subunit [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56497-1",
+        "display": "Choriogonadotropin.beta subunit [Units] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "66762-6",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "66763-4",
+        "display": "Choriogonadotropin.beta subunit [Units/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10334-1",
+        "display": "Cancer Ag 125 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "11210-2",
+        "display": "Cancer Ag 125 [Units/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15156-3",
+        "display": "Cancer Ag 125 [Units/volume] in Body fluid by Dilution"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15157-1",
+        "display": "Cancer Ag 125 [Units/volume] in Serum or Plasma by Dilution"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19165-0",
+        "display": "Cancer Ag 125 [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2006-5",
+        "display": "Cancer Ag 125 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40618-1",
+        "display": "Cancer Ag 125 [Units/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48677-9",
+        "display": "Cancer Ag 125 [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50775-6",
+        "display": "Cancer Ag 125 [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59040-6",
+        "display": "Cancer Ag 125 [Units/volume] in Peritoneal dialysis fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68923-2",
+        "display": "Cancer Ag 125 [Units/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83082-8",
+        "display": "Cancer Ag 125 [Units/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97743-9",
+        "display": "Cancer Ag 125 [Units/volume] in Aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15035-9",
+        "display": "Calcitonin [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1992-7",
+        "display": "Calcitonin [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47369-4",
+        "display": "Calcitonin [Mass/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "75709-6",
+        "display": "Calcitonin [Mass/volume] in Lymph node fine needle aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "25587-7",
+        "display": "Chromogranin A [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "30169-7",
+        "display": "Chromogranin A [Units/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53047-7",
+        "display": "Chromogranin A [Mass/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59220-4",
+        "display": "Chromogranin A [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59226-1",
+        "display": "Chromogranin A [Units/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59227-9",
+        "display": "Chromogranin A [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59241-0",
+        "display": "Chromogranin A [Units/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "9811-1",
+        "display": "Chromogranin A [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15060-7",
+        "display": "Enolase.neuron specific [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19193-2",
+        "display": "Enolase.neuron specific [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19194-0",
+        "display": "Enolase.neuron specific [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2225-1",
+        "display": "Enolase.neuron specific [Enzymatic activity/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "44802-7",
+        "display": "Enolase.neuron specific [Mass/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47053-4",
+        "display": "Enolase.neuron specific [Mass/volume] in Cerebral spinal fluid by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48138-2",
+        "display": "Enolase.neuron specific [Mass/volume] in Serum or Plasma by Radioimmunoassay (RIA)"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48164-8",
+        "display": "Enolase.neuron specific [Mass/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57371-7",
+        "display": "Enolase.neuron specific [Mass/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68939-8",
+        "display": "Enolase.neuron specific [Mass/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68952-1",
+        "display": "Enolase.neuron specific [Mass/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "69560-1",
+        "display": "Enolase.neuron specific [Mass/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97744-7",
+        "display": "Enolase.neuron specific [Mass/volume] in Aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15072-2",
+        "display": "Gastrin [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2333-3",
+        "display": "Gastrin [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2960-3",
+        "display": "Somatostatin [Presence] in Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2961-1",
+        "display": "Somatostatin [Mass/volume] in Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49792-5",
+        "display": "Somatostatin [Moles/volume] in Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14918-7",
+        "display": "Thyroglobulin [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3013-0",
+        "display": "Thyroglobulin [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53920-5",
+        "display": "Thyroglobulin [Mass/volume] in Lymph node fine needle aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53922-1",
+        "display": "Thyroglobulin [Mass/volume] in Tissue fine needle aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97640-7",
+        "display": "Thyroglobulin [Moles/volume] in Tissue fine needle aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10861-3",
+        "display": "Progesterone receptor [Mass/mass] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16113-3",
+        "display": "Progesterone receptor [Interpretation] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31207-4",
+        "display": "Progesterone receptor [Moles/mass] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10873-8",
+        "display": "Beta-2-Microglobulin [Mass/time] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14626-6",
+        "display": "Beta-2-Microglobulin [Moles/volume] in Serum"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1951-3",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1952-1",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1953-9",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32301-4",
+        "display": "Beta-2-Microglobulin [Moles/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32302-2",
+        "display": "Beta-2-Microglobulin [Moles/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39458-5",
+        "display": "Beta-2-Microglobulin [Moles/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43818-4",
+        "display": "Beta-2-Microglobulin [Presence] in Serum"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43819-2",
+        "display": "Beta-2-Microglobulin [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43919-0",
+        "display": "Beta-2-Microglobulin [Presence] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48166-3",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49081-3",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Dialysis fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50824-2",
+        "display": "Beta-2-Microglobulin [Moles/volume] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "54356-1",
+        "display": "Beta-2-Microglobulin [Mass/volume] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56662-0",
+        "display": "Beta-2-Microglobulin [Moles/time] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59217-0",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59218-8",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "76484-5",
+        "display": "Beta-2-Microglobulin [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83076-0",
+        "display": "Beta-2-Microglobulin [Units/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83077-8",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Urine by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83078-6",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83079-4",
+        "display": "Beta-2-Microglobulin [Units/volume] in Urine by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "88711-7",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Peritoneal dialysis fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "11053-6",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Red Blood Cells"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14403-0",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Gastric fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14803-1",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14804-9",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14805-6",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17041-5",
+        "display": "Lactate dehydrogenase [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2527-0",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Amniotic fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2528-8",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2529-6",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2530-4",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2531-2",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2532-0",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2533-8",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2534-6",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32324-6",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "33367-4",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47678-8",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47863-6",
+        "display": "Lactate dehydrogenase [Enzymatic activity/time] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57664-5",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Semen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "5921-2",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Dialysis fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60017-1",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60018-9",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60019-7",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60020-5",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60021-3",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60022-1",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60023-9",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60024-7",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68387-0",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68452-2",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid by Pyruvate to lactate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68453-0",
+        "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid by Lactate to pyruvate reaction"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2007-3",
+        "display": "Cancer Ag 15-3 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "29153-4",
+        "display": "Cancer Ag 15-3 [Units/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50776-4",
+        "display": "Cancer Ag 15-3 [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50777-2",
+        "display": "Cancer Ag 15-3 [Units/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50778-0",
+        "display": "Cancer Ag 15-3 [Units/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "6875-9",
+        "display": "Cancer Ag 15-3 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83083-6",
+        "display": "Cancer Ag 15-3 [Units/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97749-6",
+        "display": "Cancer Ag 15-3 [Units/volume] in Aspirate"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2011-5",
+        "display": "Cancer Ag 242 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17842-6",
+        "display": "Cancer Ag 27-29 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19187-4",
+        "display": "Cancer Ag 27-29 [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2012-3",
+        "display": "Cancer Ag 27-29 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50782-2",
+        "display": "Cancer Ag 27-29 [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2013-1",
+        "display": "Cancer Ag 50 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34256-8",
+        "display": "Cancer Ag 50 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19189-0",
+        "display": "Cancer Ag 549 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19190-8",
+        "display": "Cancer Ag 549 [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2014-9",
+        "display": "Cancer Ag 549 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17843-4",
+        "display": "Cancer Ag 72-4 [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19164-3",
+        "display": "Cancer Ag 72-4 [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2015-6",
+        "display": "Cancer Ag 72-4 [Presence] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34161-0",
+        "display": "Cancer Ag 72-4 [Units/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47012-0",
+        "display": "Cancer Ag 72-4 [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68924-0",
+        "display": "Cancer Ag 72-4 [Units/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68925-7",
+        "display": "Cancer Ag 72-4 [Units/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68926-5",
+        "display": "Cancer Ag 72-4 [Units/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2506-4",
+        "display": "Isocitrate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72508-5",
+        "display": "UGT1A1 gene c.A(TA)7TAA(*28) [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21015-3",
+        "display": "CD33 cells [#/volume] in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74837-6",
+        "display": "CD20 cells [#/volume] in Specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "9558-8",
+        "display": "CD20 cells [#/volume] in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10508-0",
+        "display": "Prostate specific Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19195-7",
+        "display": "Prostate specific Ag [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19197-3",
+        "display": "Prostate specific Ag [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19198-1",
+        "display": "Prostate specific Ag [Units/volume] in Semen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19199-9",
+        "display": "Prostate specific Ag [Mass/volume] in Semen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19200-5",
+        "display": "Prostate specific Ag [Moles/volume] in Semen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2857-1",
+        "display": "Prostate specific Ag [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34611-4",
+        "display": "Prostate specific Ag [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "35741-8",
+        "display": "Prostate specific Ag [Mass/volume] in Serum or Plasma by Detection limit <= 0.01 ng/mL"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47738-0",
+        "display": "Prostate specific Ag [Mass/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59221-2",
+        "display": "Prostate specific Ag [Mass/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59223-8",
+        "display": "Prostate specific Ag [Mass/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59230-3",
+        "display": "Prostate specific Ag [Mass/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83112-3",
+        "display": "Prostate specific Ag [Mass/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13127-6",
+        "display": "Cancer Ag DM/70K [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13659-8",
+        "display": "Epidermal growth factor receptor [Mass/mass] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14050-9",
+        "display": "Epidermal growth factor receptor [Moles/mass] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21013-8",
+        "display": "CD22 cells [#/volume] in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14130-9",
+        "display": "Estrogen receptor [Moles/mass] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16112-5",
+        "display": "Estrogen receptor [Interpretation] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78205-2",
+        "display": "ALK gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78210-2",
+        "display": "ALK gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "91141-2",
+        "display": "TPMT activity in RBC by production of 6-MMP"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "91142-0",
+        "display": "TPMT activity in RBC by production of 6-MMP riboside"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "91143-8",
+        "display": "TPMT activity in RBC by production of 6-MTG riboside"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83059-6",
+        "display": "KRAS gene [VCF] in Cancer specimen by Sequencing"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "80717-2",
+        "display": "B-cell CD27 and IgD subsets panel - Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85299-6",
+        "display": "BRAF V600E mutant protein [Presence] in Cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32996-1",
+        "display": "HER2 [Mass/volume] in Serum"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "42914-2",
+        "display": "HER2 [Mass/volume] in Serum by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48676-1",
+        "display": "HER2 [Interpretation] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51981-9",
+        "display": "HER2 [Presence] in Serum by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72382-5",
+        "display": "HER2 [Units/volume] in Tissue by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72383-3",
+        "display": "HER2 [Presence] in Tissue by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85319-2",
+        "display": "HER2 [Presence] in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "28078-4",
+        "display": "Bladder tumor Ag [Presence] in Urine by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "28551-0",
+        "display": "Bladder tumor Ag [Units/volume] in Urine by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31729-7",
+        "display": "Bladder tumor Ag [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31730-5",
+        "display": "Bladder tumor Ag [Units/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "80386-6",
+        "display": "Bladder tumor Ag [Presence] in Urine by Rapid immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31134-0",
+        "display": "Nuclear matrix protein 22 [Units/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50666-7",
+        "display": "Nuclear matrix protein 22 [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34444-0",
+        "display": "Acarboxyprothrombin [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93768-0",
+        "display": "Acarboxyprothrombin [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "41292-4",
+        "display": "Soluble mesothelin related proteins [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43368-0",
+        "display": "Microsatellite instability [Identifier] in Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62862-8",
+        "display": "Microsatellite instability [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81695-9",
+        "display": "Microsatellite instability [Interpretation] in Cancer specimen Qualitative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43399-5",
+        "display": "JAK2 gene p.Val617Phe [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72333-8",
+        "display": "JAK2 gene p.Val617Phe [Presence] in Bone marrow by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31150-6",
+        "display": "ERBB2 gene duplication [Presence] in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48674-6",
+        "display": "Genetic diseases [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48684-5",
+        "display": "X and Y chromosome [Interpretation] in Blood or Marrow by FISH--post bone marrow transplant"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48730-6",
+        "display": "X linked heterotaxy [Identifier] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49028-4",
+        "display": "Microdeletion syndromes [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49039-1",
+        "display": "Subtelomere analysis [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49040-9",
+        "display": "Subtelomere analysis [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49063-1",
+        "display": "Microdeletion syndromes in Specimen by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49683-6",
+        "display": "ERBB2 gene copy number/Chromosome 17 copy number in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50020-7",
+        "display": "Microdeletion syndromes in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50659-2",
+        "display": "Chromosome analysis.interphase [Interpretation] in Bone marrow by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50684-0",
+        "display": "Chromosome analysis.interphase [Interpretation] in Blood by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51867-0",
+        "display": "t(9;22)(q34.1;q11)(ABL1,BCR) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53628-4",
+        "display": "20q chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55192-9",
+        "display": "Chromosome analysis.interphase [Interpretation] in Amniotic fluid by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55193-7",
+        "display": "Chromosome analysis.interphase [Interpretation] in Chorionic villus sample by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56030-0",
+        "display": "Karyotype [Identifier] in Urine by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56144-9",
+        "display": "CHIC2 gene 4q12 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57038-2",
+        "display": "Chromosome 12 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57317-0",
+        "display": "Chromosome 13+18+21+X+Y aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57318-8",
+        "display": "Chromosome 13+18+21+X+Y aneuploidy in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57453-3",
+        "display": "Chromosome 18 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57454-1",
+        "display": "Chromosome 13 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57802-1",
+        "display": "Chromosome analysis.interphase [Interpretation] in Blood or Marrow by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57906-0",
+        "display": "9p21 chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59050-5",
+        "display": "Chromosome analysis.interphase [Interpretation] in Specimen by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59267-5",
+        "display": "Karyotype [Identifier] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62344-7",
+        "display": "Chromosome analysis.metaphase panel - Blood by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62345-4",
+        "display": "Chromosome analysis.interphase panel - Blood by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62346-2",
+        "display": "Chromosome analysis.interphase panel - Amniotic fluid by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62347-0",
+        "display": "Chromosome analysis.prenatal panel by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62354-6",
+        "display": "Chromosome analysis.metaphase panel - Amniotic fluid by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62367-8",
+        "display": "Chromosome analysis panel by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "63068-1",
+        "display": "TOP2A gene copy number/Chromosome 17 copy number in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "63070-7",
+        "display": "TOP2A gene 17q21-22 deletion and duplication mutation analysis [Presence] in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "66950-7",
+        "display": "MALT1 18q21 gene rearrangements in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72652-1",
+        "display": "Subtelomere analysis.long arm [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72653-9",
+        "display": "Subtelomere analysis.short arm [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72654-7",
+        "display": "SNRPN gene 15q11 deletion and duplication mutation analysis [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72725-5",
+        "display": "t(11;14)(q13.2;q32)(MYEOV,IGH) fusion transcript [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72726-3",
+        "display": "t(4;14)(p16;q32)(FGFR3,IGH) fusion transcript [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72728-9",
+        "display": "Del(13)(q14) [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72824-6",
+        "display": "Del(17)(p13) [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72827-9",
+        "display": "dic(9;20)(p11-13;q11)(wcp9+,wcp20+) [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73558-9",
+        "display": "Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73749-4",
+        "display": "4p16.3 chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73750-2",
+        "display": "RAI1 gene 17p11.2 deletion and duplication mutation analysis [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73751-0",
+        "display": "5p15.2 (5p-) chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74034-0",
+        "display": "MAML2 11q21 gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74860-8",
+        "display": "ERBB2 gene copy number/nucleus in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74861-6",
+        "display": "Chromosome 17 copy number/nucleus in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74885-5",
+        "display": "ERBB2 gene (HER2) duplication associated observations panel - Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "76065-2",
+        "display": "6p25 and 6q23 and 11q and 8q24 and 9p21 chromosome partial aneuploidy in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77030-5",
+        "display": "t(1;19)(q23.3;p13.3)(PBX1,TCF3) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77031-3",
+        "display": "t(15;17)(q24.1;q21.1)(PML,RARA) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77032-1",
+        "display": "t(8;14)(q24;q32)(MYC,IGH) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77033-9",
+        "display": "t(14;16)(q32;q23)(IGH,MAF) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77034-7",
+        "display": "inv(16)(p13.1;q22.1)(MYH11,CBFB) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77035-4",
+        "display": "t(14;18)(q32;q21)(IGH,MALT1) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77036-2",
+        "display": "t(11;18)(q21;q21)(BIRC3,MALT1) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77037-0",
+        "display": "t(11;14)(q13;q32)(CCND1,IGH) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77038-8",
+        "display": "t(14;18)(q32;q21.3)(IGH,BCL2) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77039-6",
+        "display": "t(12;21)(p13;q22.3)(ETV6,RUNX1) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77040-4",
+        "display": "t(8;21)(q22;q22.3)(RUNX1T1,RUNX1) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77041-2",
+        "display": "inv(3)(q21;q26.2)+t(3;3)(q21;q26.2)(PSMD2,MECOM) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77042-0",
+        "display": "t(6;9)(p22;q34)(DEK,NUP214) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78201-1",
+        "display": "4q12 chromosome region rearrangements [Identifier] in Blood or Tissue by FISH Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78202-9",
+        "display": "9q34 chromosome region deletion [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78203-7",
+        "display": "BCL6 gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78204-5",
+        "display": "CCND1 gene duplication [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78206-0",
+        "display": "4q12 chromosome region rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78207-8",
+        "display": "9q34 chromosome region deletion [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78208-6",
+        "display": "BCL6 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78209-4",
+        "display": "CCND1 gene duplication [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78211-0",
+        "display": "Cells.4q12 chromosome region rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78212-8",
+        "display": "Cells.9q34 chromosome region deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78213-6",
+        "display": "Cells.BCL6 gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78214-4",
+        "display": "Cells.CCND1 gene duplication/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78215-1",
+        "display": "MYC gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78216-9",
+        "display": "TRA+TRD gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78217-7",
+        "display": "RARA gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78218-5",
+        "display": "BCL2 gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78219-3",
+        "display": "MLL gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78220-1",
+        "display": "PDGFRB gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78221-9",
+        "display": "IGH gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78222-7",
+        "display": "MYC gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78223-5",
+        "display": "TRA+TRD gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78224-3",
+        "display": "RARA gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78225-0",
+        "display": "BCL2 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78226-8",
+        "display": "MLL gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78227-6",
+        "display": "PDGFRB gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78228-4",
+        "display": "IGH gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78229-2",
+        "display": "Cells.MYC gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78230-0",
+        "display": "Cells.RARA gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78231-8",
+        "display": "Cells.TRA+TRD gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78232-6",
+        "display": "Cells.BCL2 gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78233-4",
+        "display": "Cells.ALK gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78234-2",
+        "display": "Cells.MLL gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78235-9",
+        "display": "Cells.PDGFRB gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78236-7",
+        "display": "Cells.IGH gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78237-5",
+        "display": "Chromosome 8 copy number/nucleus in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78238-3",
+        "display": "Chromosome 3 copy number/nucleus in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78245-8",
+        "display": "MYB gene deletion [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78342-3",
+        "display": "MYB gene deletion [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78343-1",
+        "display": "Cells.MYB gene deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78915-6",
+        "display": "FGFR1 gene rearrangements [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78916-4",
+        "display": "FGFR1 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78917-2",
+        "display": "Cells.FGFR1 gene rearrangements/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79206-9",
+        "display": "inv(2)(p21;p23)(EML4,ALK) fusion transcript [Presence] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81710-6",
+        "display": "PTEN gene [Presence] in Cancer specimen by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81746-0",
+        "display": "Chromosome region 17p13.1 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81747-8",
+        "display": "Chromosome region 6q22 rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81748-6",
+        "display": "Chromosome region Yp11.3 deletion AndOr rearrangement in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81749-4",
+        "display": "Chromosome region 13q14 deletion in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81751-0",
+        "display": "Chromosome 17p13.1 deletion and 14q32 rearrangements in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81752-8",
+        "display": "Chromosome region 1q21 duplication in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82238-7",
+        "display": "Chromosome region 15q11-13 deletion and duplication mutation analysis in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82239-5",
+        "display": "Chromosome region 16p13.3 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82240-3",
+        "display": "Chromosome region 16p13.3 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82241-1",
+        "display": "Chromosome region 17p11.2 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82242-9",
+        "display": "Chromosome region 17p13.3 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82243-7",
+        "display": "Chromosome region 17p13.3 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82244-5",
+        "display": "Chromosome region 1p36 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82245-2",
+        "display": "Chromosome region 22q11.2 deletion and duplication mutation analysis in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82246-0",
+        "display": "Chromosome region 22q11.2 deletion and duplication mutation analysis in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82247-8",
+        "display": "Chromosome region 7q11.23 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82248-6",
+        "display": "Chromosome region 7q11.23 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82249-4",
+        "display": "Chromosome region 8q23.3-24.13 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82250-2",
+        "display": "Chromosome region 1p subtelomere and 1p36 deletion and 1q25 rearrangement in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82251-0",
+        "display": "Chromosome 3 and 7 and 17 aneuploidy and chromosome region 9p21 deletion in Urine by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82253-6",
+        "display": "JAG1 gene deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82256-9",
+        "display": "Chromosome 12 trisomy and chromosome region 11q22.3 and 13q14 and 17p13.1 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82257-7",
+        "display": "SRY gene deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82258-5",
+        "display": "Subtelomere analysis in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82295-7",
+        "display": "Chromosome region Xp22.33 AndOr Yp11.32 deletion and duplication mutation analysis in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82597-6",
+        "display": "Chromosome painting analysis in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84912-5",
+        "display": "Cells.chromosome region 5q31 deletion/Cells counted in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84913-3",
+        "display": "Cells.chromosome 12 trisomy/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84914-1",
+        "display": "Cells.chromosome region 13q14 deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84915-8",
+        "display": "Cells.chromosome region 11q22.3 deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84916-6",
+        "display": "Cells.chromosome region 17p13.1 deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84917-4",
+        "display": "Chromosome Y aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84918-2",
+        "display": "Chromosome X aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84919-0",
+        "display": "Chromosome 21 aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84920-8",
+        "display": "Cells.chromosome region 5q31 deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84921-6",
+        "display": "Cells.chromosome region 7q31 deletion/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84922-4",
+        "display": "Cells.chromosome 7 monosomy/Cells counted in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85318-4",
+        "display": "ERBB2 gene duplication [Presence] in Breast cancer specimen by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "86239-1",
+        "display": "Cells.chromosome 3 monosomy/Cells counted in Cancer specimen by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "87436-2",
+        "display": "Chromosome X and Y aneuploidy in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "90043-1",
+        "display": "t(14;20)(q32;q12)(IGH,MAFB) fusion transcript in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "90926-7",
+        "display": "MET gene amplification in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "90927-5",
+        "display": "RET gene rearrangements in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92905-9",
+        "display": "Chromosome 7 copy number/nucleus in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92906-7",
+        "display": "MET gene copy number/nucleus in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92907-5",
+        "display": "MET gene copy number/Chromosome 7 copy number in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93796-1",
+        "display": "MYCN gene amplification in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93797-9",
+        "display": "MYCN gene copy number/Chromosome 2 copy number in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93798-7",
+        "display": "MYCN gene copy number/nucleus in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93799-5",
+        "display": "Chromosome 2 copy number/nucleus in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93800-1",
+        "display": "1p/1q chromosome deletion [# Ratio] in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93801-9",
+        "display": "Chromosome 1 polysomy [Presence] in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93802-7",
+        "display": "19q/19p chromosome deletion [# Ratio] in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93803-5",
+        "display": "Chromosome 19 polysomy [Presence] in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93804-3",
+        "display": "Chromosome 12 copy number/nucleus in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93805-0",
+        "display": "MDM2 gene copy number/nucleus in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93806-8",
+        "display": "EWSR1 gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93807-6",
+        "display": "FOXO1 gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93808-4",
+        "display": "MDM2 gene amplification in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93809-2",
+        "display": "MDM2 gene copy number/Chromosome 12 copy number in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93810-0",
+        "display": "SS18 gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "94338-1",
+        "display": "Chromosome 13+15+16+18+21+22+X+Y aneuploidy in Products of Conception by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95069-1",
+        "display": "Chromosome 1q and 9 and 11 and 15 aneuploidy and 13q deletion in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95070-9",
+        "display": "Chromosome 9 and 11 and 15 aneuploidy in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95071-7",
+        "display": "Chromosome region 14q32 rearrangements in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95551-8",
+        "display": "Chromosome region 17p11.2 deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95552-6",
+        "display": "4p16.3 chromosome deletion in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95553-4",
+        "display": "5p15.2 (5p-) chromosome deletion [Identifier] in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95779-5",
+        "display": "TFE3 gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95780-3",
+        "display": "TFEB gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95783-7",
+        "display": "ETV6 gene rearrangements in Blood or Marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95784-5",
+        "display": "FGFR2 gene rearrangements in Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96494-0",
+        "display": "ABL1 and ABL2 and PDGFRB gene rearrangements in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96495-7",
+        "display": "ABL2 gene rearrangements in Blood or Tissue by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96893-3",
+        "display": "ERBB2 gene duplication in Tumor by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "98014-4",
+        "display": "Plasma cell proliferation analysis in Bone marrow by FISH"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49490-6",
+        "display": "BCR-ABL1 b2a2 fusion protein [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55180-4",
+        "display": "Human epididymis protein 4 [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96044-3",
+        "display": "Human epididymis protein 4 [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60588-1",
+        "display": "t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72211-6",
+        "display": "t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript/control transcript [# Ratio] in Bone marrow by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72215-7",
+        "display": "t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript/control transcript [# Ratio] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10432-3",
+        "display": "CD30 Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10560-1",
+        "display": "Carcinoembryonic Ag [Units/volume] in Semen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "12515-3",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19166-8",
+        "display": "Carcinoembryonic Ag [Units/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19167-6",
+        "display": "Carcinoembryonic Ag [Moles/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19168-4",
+        "display": "Carcinoembryonic Ag [Units/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19169-2",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19170-0",
+        "display": "Carcinoembryonic Ag [Moles/volume] in Pleural fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2037-0",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2038-8",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Semen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2039-6",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Serum or Plasma"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40621-5",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Pericardial fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40622-3",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Peritoneal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83085-1",
+        "display": "Carcinoembryonic Ag [Mass/volume] in Serum or Plasma by Immunoassay"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14230-7",
+        "display": "Cells.progesterone receptor/100 cells in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40557-1",
+        "display": "Progesterone receptor Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85325-9",
+        "display": "Cells.progesterone receptor/100 cells in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85331-7",
+        "display": "Progesterone receptor fluorescence intensity [Type] in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85339-0",
+        "display": "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13485-8",
+        "display": "Beta-2-Microglobulin/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39773-7",
+        "display": "Beta-2-Microglobulin/Creatinine [Molar ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "44303-6",
+        "display": "Beta-2-Microglobulin/Creatinine [Mass Ratio] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56786-7",
+        "display": "Beta-2-Microglobulin.tumor marker [Mass/volume] in Serum"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59177-6",
+        "display": "Beta-2-Microglobulin/Creatinine [Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "87708-4",
+        "display": "Beta-2-Microglobulin [Mass/volume] in Serum or Plasma --post dialysis"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93729-2",
+        "display": "Beta-2-Microglobulin/Creatinine [Ratio] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14967-4",
+        "display": "CD33 Abnormal blood cells/Abnormal blood cells.total in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20601-1",
+        "display": "CD33 cells/100 cells in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51155-0",
+        "display": "CD33 blasts/100 blasts in Bone marrow"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51156-8",
+        "display": "CD33 blasts/100 blasts in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51157-6",
+        "display": "CD33 blasts [Units/volume] in Bone marrow"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51158-4",
+        "display": "CD33 blasts [Units/volume] in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51159-2",
+        "display": "CD33 blasts [Units/volume] in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51291-3",
+        "display": "CD33 cells/100 cells in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51292-1",
+        "display": "CD33 cells/100 cells in Cerebral spinal fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51293-9",
+        "display": "CD33 cells/100 cells in Bone marrow"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51294-7",
+        "display": "CD33 cells/100 cells in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "8102-6",
+        "display": "CD33 cells/100 cells in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10438-0",
+        "display": "CD20 Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13842-0",
+        "display": "CD20 blasts/100 blasts in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14966-6",
+        "display": "CD20 Abnormal blood cells/Abnormal blood cells.total in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20595-5",
+        "display": "CD20 cells/100 cells in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51115-4",
+        "display": "CD20 blasts/100 blasts in Bone marrow"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51116-2",
+        "display": "CD20 blasts/100 blasts in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57418-6",
+        "display": "CD20 cells/100 cells in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "8119-0",
+        "display": "CD20 cells/100 cells in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "29596-4",
+        "display": "CD25 Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32581-1",
+        "display": "Epidermal growth factor receptor Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39004-7",
+        "display": "Epidermal growth factor receptor Ag [Presence] in Tissue"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "42782-3",
+        "display": "Epidermal growth factor receptor.phosphorylated Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14017-8",
+        "display": "CD22 cells/100 cells in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20596-3",
+        "display": "CD22 cells/100 cells in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "42875-5",
+        "display": "CD22 cells/100 cells in Body fluid"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51124-6",
+        "display": "CD22 blasts/100 blasts in Bone marrow"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51125-3",
+        "display": "CD22 blasts/100 blasts in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51126-1",
+        "display": "CD22 blasts/100 blasts in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51127-9",
+        "display": "CD22 blasts [Units/volume] in Bone marrow"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51128-7",
+        "display": "CD22 blasts [Units/volume] in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51129-5",
+        "display": "CD22 blasts [Units/volume] in Unspecified specimen"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14228-1",
+        "display": "Cells.estrogen receptor/100 cells in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40556-3",
+        "display": "Estrogen receptor Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85310-1",
+        "display": "Estrogen receptor fluorescence intensity [Type] in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85329-1",
+        "display": "Cells.estrogen receptor/100 cells in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85337-4",
+        "display": "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21636-6",
+        "display": "BRCA1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21637-4",
+        "display": "BRCA1 gene.c.185 del AG [presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21638-2",
+        "display": "BRCA1 gene c.5382insC [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21639-0",
+        "display": "BRCA1 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79207-7",
+        "display": "BRCA1 gene mutation analysis limited to known familial mutations in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21702-6",
+        "display": "KRAS gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21703-4",
+        "display": "KRAS gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53620-1",
+        "display": "KRAS gene mutations found [Identifier] in Bone marrow by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "75974-6",
+        "display": "KRAS gene targeted mutation analysis in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81420-2",
+        "display": "KRAS and NRAS gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82535-6",
+        "display": "KRAS gene full mutation analysis in Blood or Tissue by Sequencing"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85509-8",
+        "display": "KRAS gene mutations found [Identifier] in Colorectal cancer specimen by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40552-2",
+        "display": "CD117 Ag [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51183-2",
+        "display": "CD117 Ag [Presence] in Bone marrow by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51184-0",
+        "display": "CD117 Ag [Presence] in Blood by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51185-7",
+        "display": "CD117 Ag [Presence] in Unspecified specimen by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "80706-5",
+        "display": "CD27+IgD- cells/100 CD19+CD20+ cells in Blood"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83052-1",
+        "display": "PD-L1 by clone 22C3 [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83053-9",
+        "display": "Cells.programmed cell death ligand 1/100 viable tumor cells in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83054-7",
+        "display": "PD-L1 by clone 22C3 [Interpretation] in Tissue by Immune stain Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83055-4",
+        "display": "PD-L1 by clone 28-8 [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83056-2",
+        "display": "PD-L1 by clone 28-8 [Interpretation] in Tissue by Immune stain Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83057-0",
+        "display": "PD-L1 by clone SP142 [Presence] in Tissue by Immune stain"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85147-7",
+        "display": "PD-L1 by clone 22C3 in Tissue by Immune stain Report"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85148-5",
+        "display": "PD-L1 by clone 28-8 in Tissue by Immune stain Report"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85149-3",
+        "display": "PD-L1 by clone SP142 in Tissue by Immune stain Report"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21640-8",
+        "display": "BRCA2 gene c.6174delT [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "38530-2",
+        "display": "BRCA2 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "38531-0",
+        "display": "BRCA2 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79208-5",
+        "display": "BRCA2 gene mutation analysis limited to known familial mutations in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "45284-7",
+        "display": "DPYD gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47958-4",
+        "display": "FLT3 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "54447-8",
+        "display": "FLT3 gene targeted mutation analysis in Bone marrow by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72520-0",
+        "display": "FLT3 gene p.Asp835+Ile836 [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79210-1",
+        "display": "FLT3 gene internal tandem duplication [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85100-6",
+        "display": "FLT3 gene internal tandem duplication [Presence] in Bone marrow by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92843-2",
+        "display": "FLT3 gene p.Asp835 mutations [Presence] in Blood or Tissue by Molecular genetics method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48972-4",
+        "display": "FGFR2 gene+FGFR3 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+      }
+    ]
+  }
+}

--- a/src/lib/valueSets/vs-expansion-explained.md
+++ b/src/lib/valueSets/vs-expansion-explained.md
@@ -1,0 +1,13 @@
+# Generating New ValueSets
+
+Follow the steps below to generate a new set of valuesets based on the latest version of mCODE's IG.
+
+It's best to have a clean working directory before generating new ValueSets, as it will overwrite existing ValueSets.
+
+1. Clone the fhir-mCODE-ig locally and _only run sushi to build FHIR resources_. This will build all mCODE Valuesets locally. You can find setup instructions for this repo on [HL7's GitHub](https://github.com/HL7/fhir-mCODE-ig). **Note**: you do not need to run the full `genonce` script; you only need to run `sushi`.
+2. Move all ValueSets into a folder, for ease of access by the MEF'S `vs-expansion-script`. Below is a series of commands that will help with this (on OSX), but you could also do this manually.
+   `cd some/path/to/local/fhir-mCODE-ig/fsh-generated/resources && mkdir valuesets && find * -name "ValueSet-*.json" | xargs -I '{}' cp {} ./valuesets`
+3. Remove all irrelevant ValueSets from this folder, leaving behind only the ones to be expanded.
+4. In the MEF, update the`PREEXPANSIONPATH` global variable in `vs-expansion-script.js` to point to the folder made to house the ValueSets in step 2.
+5. Run `vs-expansion-script.js` using node.
+6. For all failed expansions, determine if manual expansion is feasible (i.e. if there is just 1-2 codes that reference codeSystems GG's server do not support). If feasible, manually expand those VS.

--- a/src/lib/valueSets/vs-expansion-explained.md
+++ b/src/lib/valueSets/vs-expansion-explained.md
@@ -8,6 +8,6 @@ It's best to have a clean working directory before generating new ValueSets, as 
 2. Move all ValueSets into a folder, for ease of access by the MEF'S `vs-expansion-script`. Below is a series of commands that will help with this (on OSX), but you could also do this manually.
    `cd some/path/to/local/fhir-mCODE-ig/fsh-generated/resources && mkdir valuesets && find * -name "ValueSet-*.json" | xargs -I '{}' cp {} ./valuesets`
 3. Remove all irrelevant ValueSets from this folder, leaving behind only the ones to be expanded.
-4. In the MEF, update the`PREEXPANSIONPATH` global variable in `vs-expansion-script.js` to point to the folder made to house the ValueSets in step 2.
+4. In `vs-expansion-script.js`, update the`PREEXPANSIONPATH` global variable to point to the ValueSets' folder defined by step 2.
 5. Run `vs-expansion-script.js` using node.
 6. For all failed expansions, determine if manual expansion is feasible (i.e. if there is just 1-2 codes that reference codeSystems GG's server do not support). If feasible, manually expand those VS.

--- a/src/lib/valueSets/vs-expansion-script.js
+++ b/src/lib/valueSets/vs-expansion-script.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+
+// NOTE: Update this to point to pre-expansion valuesets on your local machine
+const PREEXPANSIONPATH = path.resolve(__dirname, '../../../../fhir-mCODE-ig/fsh-generated/resources/valuesets');
+
+function readVsFromPath(vsPath) {
+  return JSON.parse(fs.readFileSync(path.resolve(PREEXPANSIONPATH, vsPath)));
+}
+
+function writeVs(vsObj) {
+  const { vsPath, vs } = vsObj;
+  fs.writeFileSync(path.resolve(__dirname, vsPath), JSON.stringify(vs, null, '  '));
+}
+
+function listVsForExpansion() {
+  return fs.readdirSync(PREEXPANSIONPATH);
+}
+
+function makeExpansionRequest(vsPath, vs) {
+  const vsStringify = JSON.stringify(vs);
+
+  const config = {
+    method: 'post',
+    url: 'http://tx.fhir.org/r4/ValueSet/$expand',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    data: vsStringify,
+  };
+
+  return axios(config)
+    .then((response) => {
+      const expansion = response.data;
+      console.log(`SUCCESS: ${vsPath} was expanded`);
+      return { status: 'success', vsPath, vs: expansion };
+    })
+    .catch((error) => {
+      console.error(`FAILURE: ${vsPath} expansion failed, reverting to original VS`);
+      console.error(`FAILURE: ${error.message}`);
+      return { status: 'failure', vsPath, vs };
+    });
+}
+
+function expandVs() {
+  let vsPaths;
+  try {
+    vsPaths = listVsForExpansion();
+  } catch (e) {
+    console.error(
+      'FAILURE: PREEXPANSIONPATH does not point to a valid directory; make sure you update this variable based on you local machine',
+    );
+    process.exit(1);
+  }
+  // Aggregate requests for each vsPath we have
+  const requests = [];
+  vsPaths.forEach((vsPath) => {
+    const vs = readVsFromPath(vsPath);
+
+    requests.push(makeExpansionRequest(vsPath, vs));
+  });
+
+  // After all requests are finished, write the expanded files
+  Promise.all(requests).then((expandedValueSets) => {
+    console.log('\nPost-expansion\n');
+    // Print all the failed expansions
+    console.log('All Failed Expansions: \n======================');
+    expandedValueSets.filter(({ status }) => status === 'failure').map(({ vsPath }) => console.log(`${vsPath}`));
+    console.log('');
+
+    // Save all the successful expansions
+    expandedValueSets.forEach(writeVs);
+    console.log('DONE: Wrote all files to disc');
+  });
+}
+
+expandVs();

--- a/src/lib/valueSets/vs-expansion-script.js
+++ b/src/lib/valueSets/vs-expansion-script.js
@@ -34,7 +34,7 @@ function makeExpansionRequest(vsPath, vs) {
   return axios(config)
     .then((response) => {
       const expansion = response.data;
-      console.log(`SUCCESS: ${vsPath} was expanded`);
+      console.info(`SUCCESS: ${vsPath} was expanded`);
       return { status: 'success', vsPath, vs: expansion };
     })
     .catch((error) => {
@@ -64,15 +64,15 @@ function expandVs() {
 
   // After all requests are finished, write the expanded files
   Promise.all(requests).then((expandedValueSets) => {
-    console.log('\nPost-expansion\n');
+    console.info('\nPost-expansion\n');
     // Print all the failed expansions
-    console.log('All Failed Expansions: \n======================');
-    expandedValueSets.filter(({ status }) => status === 'failure').map(({ vsPath }) => console.log(`${vsPath}`));
-    console.log('');
+    console.info('All Failed Expansions: \n======================');
+    expandedValueSets.filter(({ status }) => status === 'failure').map(({ vsPath }) => console.info(`${vsPath}`));
+    console.info('');
 
     // Save all the successful expansions
     expandedValueSets.forEach(writeVs);
-    console.log('DONE: Wrote all files to disc');
+    console.info('DONE: Wrote all files to disc');
   });
 }
 

--- a/test/assessmentCoverage.test.js
+++ b/test/assessmentCoverage.test.js
@@ -2,7 +2,7 @@ const testBundle = require('./bundles/assessmentBundle.json');
 const { getAssessmentCoverage } = require('../src/lib/coverageChecker/assessmentCoverage');
 
 describe('getAssessmentCoverage()', () => {
-  const res = getAssessmentCoverage(testBundle);
+  let res = getAssessmentCoverage(testBundle);
 
   test('Section object should have length equal to number of profiles in section', () => {
     expect(res.data.length).toBe(3);
@@ -12,6 +12,22 @@ describe('getAssessmentCoverage()', () => {
     expect(res.data[0].coverage.length).toBe(2);
     expect(res.data[1].coverage.length).toBe(2);
     expect(res.data[2].coverage.length).toBe(2);
+  });
+
+  test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
+    let emptyComorbidity = testBundle.entry.find((entry) => entry.resource.id === 'empty-comorbidities');
+    delete emptyComorbidity.resource.meta;
+
+    let emptyECOG = testBundle.entry.find((entry) => entry.resource.id === 'empty-ecog');
+    delete emptyECOG.resource.meta;
+
+    let emptyKarnof = testBundle.entry.find((entry) => entry.resource.id === 'empty-karnofsky');
+    delete emptyKarnof.resource.meta;
+
+    let updatedRes = getAssessmentCoverage(testBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
   });
 
   test('All values should be true when Karnofsky performance status has all fields covered', () => {
@@ -28,18 +44,18 @@ describe('getAssessmentCoverage()', () => {
 
   test('All values should be true when comorbidities has all fields covered', () => {
     const coveredComorbidities = res.data[1].coverage[1].data;
-    expect(coveredComorbidities["Risk Score"].covered).toBe(true);
-    expect(coveredComorbidities["Present/Absent"].covered).toBe(true);
-    expect(coveredComorbidities["Condition Code"].covered).toBe(true);
-    expect(coveredComorbidities["Condition Reference"].covered).toBe(true);
+    expect(coveredComorbidities['Risk Score'].covered).toBe(true);
+    expect(coveredComorbidities['Present/Absent'].covered).toBe(true);
+    expect(coveredComorbidities['Condition Code'].covered).toBe(true);
+    expect(coveredComorbidities['Condition Reference'].covered).toBe(true);
   });
 
   test('All values should be false when comorbidities is missing every field', () => {
     const emptyComorbidities = res.data[1].coverage[0].data;
-    expect(emptyComorbidities["Risk Score"].covered).toBe(false);
-    expect(emptyComorbidities["Present/Absent"].covered).toBe(false);
-    expect(emptyComorbidities["Condition Code"].covered).toBe(false);
-    expect(emptyComorbidities["Condition Reference"].covered).toBe(false);
+    expect(emptyComorbidities['Risk Score'].covered).toBe(false);
+    expect(emptyComorbidities['Present/Absent'].covered).toBe(false);
+    expect(emptyComorbidities['Condition Code'].covered).toBe(false);
+    expect(emptyComorbidities['Condition Reference'].covered).toBe(false);
   });
 
   test('All values should be true when ECOG performance status has all fields covered', () => {

--- a/test/assessmentCoverage.test.js
+++ b/test/assessmentCoverage.test.js
@@ -1,8 +1,9 @@
+/* eslint-disable global-require */
 const testBundle = require('./bundles/assessmentBundle.json');
 const { getAssessmentCoverage } = require('../src/lib/coverageChecker/assessmentCoverage');
 
 describe('getAssessmentCoverage()', () => {
-  let res = getAssessmentCoverage(testBundle);
+  const res = getAssessmentCoverage(testBundle);
 
   test('Section object should have length equal to number of profiles in section', () => {
     expect(res.data.length).toBe(3);
@@ -19,9 +20,9 @@ describe('getAssessmentCoverage()', () => {
     const modifiedTestBundle = require('./bundles/assessmentBundle.json');
     modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta.profile);
+      .forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
-    let updatedRes = getAssessmentCoverage(modifiedTestBundle);
+    const updatedRes = getAssessmentCoverage(modifiedTestBundle);
     expect(updatedRes.data[0].coverage.length).toBe(1);
     expect(updatedRes.data[1].coverage.length).toBe(1);
     expect(updatedRes.data[2].coverage.length).toBe(1);
@@ -31,7 +32,7 @@ describe('getAssessmentCoverage()', () => {
     // Iterate through all resources and delete their profile arrays
     const modifiedTestBundle = require('./bundles/assessmentBundle.json');
     modifiedTestBundle.entry.forEach((entry) => {
-      delete entry.resource.meta.profile;
+      delete entry.resource.meta.profile; // eslint-disable-line no-param-reassign
     });
 
     const updatedRes = getAssessmentCoverage(modifiedTestBundle);

--- a/test/assessmentCoverage.test.js
+++ b/test/assessmentCoverage.test.js
@@ -15,16 +15,27 @@ describe('getAssessmentCoverage()', () => {
   });
 
   test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
-    let emptyComorbidity = testBundle.entry.find((entry) => entry.resource.id === 'empty-comorbidities');
-    delete emptyComorbidity.resource.meta;
+    // Iterate through our empty resources and delete their profile arrays
+    const modifiedTestBundle = require('./bundles/assessmentBundle.json');
+    modifiedTestBundle.entry
+      .filter((entry) => entry.resource.id.startsWith('empty'))
+      .forEach((entry) => delete entry.resource.meta.profile);
 
-    let emptyECOG = testBundle.entry.find((entry) => entry.resource.id === 'empty-ecog');
-    delete emptyECOG.resource.meta;
+    let updatedRes = getAssessmentCoverage(modifiedTestBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+  });
 
-    let emptyKarnof = testBundle.entry.find((entry) => entry.resource.id === 'empty-karnofsky');
-    delete emptyKarnof.resource.meta;
+  test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through all resources and delete their profile arrays
+    const modifiedTestBundle = require('./bundles/assessmentBundle.json');
+    modifiedTestBundle.entry.forEach((entry) => {
+      delete entry.resource.meta.profile;
+    });
 
-    let updatedRes = getAssessmentCoverage(testBundle);
+    const updatedRes = getAssessmentCoverage(modifiedTestBundle);
+
     expect(updatedRes.data[0].coverage.length).toBe(1);
     expect(updatedRes.data[1].coverage.length).toBe(1);
     expect(updatedRes.data[2].coverage.length).toBe(1);

--- a/test/bundles/outcomeBundle.json
+++ b/test/bundles/outcomeBundle.json
@@ -140,6 +140,14 @@
             }
           ]
         },
+        "morphology": {
+          "coding": [
+            {
+              "code": "367651003",
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        },
         "patient": {
           "reference": "Patient/cancer-patient-eve-anyperson"
         }

--- a/test/bundles/treatmentBundle.json
+++ b/test/bundles/treatmentBundle.json
@@ -556,8 +556,8 @@
           "coding": [
             {
               "system": "http://snomed.info/sct",
-              "code": "111111111",
-              "display": "test"
+              "code": "228793007",
+              "display": "Planning target volume (observable entity)"
             }
           ]
         },

--- a/test/diseaseCoverage.test.js
+++ b/test/diseaseCoverage.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const testBundle = require('./bundles/diseaseBundle.json');
 const { getDiseaseCoverage } = require('../src/lib/coverageChecker/diseaseCoverage');
 
@@ -23,7 +24,7 @@ describe('getDiseaseCoverage()', () => {
     const modifiedTestBundle = require('./bundles/diseaseBundle.json');
     modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta.profile);
+      .forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getDiseaseCoverage(modifiedTestBundle);
 
@@ -39,7 +40,7 @@ describe('getDiseaseCoverage()', () => {
   test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
     // Iterate through all resources and delete their profile arrays
     const modifiedTestBundle = require('./bundles/diseaseBundle.json');
-    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getDiseaseCoverage(modifiedTestBundle);
 

--- a/test/diseaseCoverage.test.js
+++ b/test/diseaseCoverage.test.js
@@ -18,6 +18,23 @@ describe('getDiseaseCoverage()', () => {
     expect(res.data[6].coverage.length).toBe(2);
   });
 
+  test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through our empty resources and delete their profile arrays
+    testBundle.entry
+      .filter((entry) => entry.resource.id.startsWith('empty'))
+      .forEach((entry) => delete entry.resource.meta.profile);
+
+    const updatedRes = getDiseaseCoverage(testBundle);
+
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+    expect(updatedRes.data[4].coverage.length).toBe(1);
+    expect(updatedRes.data[5].coverage.length).toBe(1);
+    expect(updatedRes.data[6].coverage.length).toBe(1);
+  });
+
   test('All values should be true when tumor marker test has all fields covered', () => {
     const coveredTumorMarker = res.data[0].coverage[1].data;
     expect(coveredTumorMarker['Result Value'].covered).toBe(true);

--- a/test/diseaseCoverage.test.js
+++ b/test/diseaseCoverage.test.js
@@ -20,11 +20,28 @@ describe('getDiseaseCoverage()', () => {
 
   test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
     // Iterate through our empty resources and delete their profile arrays
-    testBundle.entry
+    const modifiedTestBundle = require('./bundles/diseaseBundle.json');
+    modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
       .forEach((entry) => delete entry.resource.meta.profile);
 
-    const updatedRes = getDiseaseCoverage(testBundle);
+    const updatedRes = getDiseaseCoverage(modifiedTestBundle);
+
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+    expect(updatedRes.data[4].coverage.length).toBe(1);
+    expect(updatedRes.data[5].coverage.length).toBe(1);
+    expect(updatedRes.data[6].coverage.length).toBe(1);
+  });
+
+  test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through all resources and delete their profile arrays
+    const modifiedTestBundle = require('./bundles/diseaseBundle.json');
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+
+    const updatedRes = getDiseaseCoverage(modifiedTestBundle);
 
     expect(updatedRes.data[0].coverage.length).toBe(1);
     expect(updatedRes.data[1].coverage.length).toBe(1);

--- a/test/genomicsCoverage.test.js
+++ b/test/genomicsCoverage.test.js
@@ -17,11 +17,25 @@ describe('getGenomicsCoverage()', () => {
 
   test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
     // Iterate through our empty resources and delete their profile arrays
-    testBundle.entry
+    const modifiedTestBundle = require('./bundles/genomicsBundle.json');
+    modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta);
+      .forEach((entry) => delete entry.resource.meta.profile);
 
-    const updatedRes = getGenomicsCoverage(testBundle);
+    const updatedRes = getGenomicsCoverage(modifiedTestBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+  });
+
+  test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through all resources and delete their profile arrays
+    const modifiedTestBundle = require('./bundles/genomicsBundle.json');
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+
+    const updatedRes = getGenomicsCoverage(modifiedTestBundle);
+
     expect(updatedRes.data[0].coverage.length).toBe(1);
     expect(updatedRes.data[1].coverage.length).toBe(1);
     expect(updatedRes.data[2].coverage.length).toBe(1);

--- a/test/genomicsCoverage.test.js
+++ b/test/genomicsCoverage.test.js
@@ -15,6 +15,19 @@ describe('getGenomicsCoverage()', () => {
     expect(res.data[3].coverage.length).toBe(2);
   });
 
+  test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through our empty resources and delete their profile arrays
+    testBundle.entry
+      .filter((entry) => entry.resource.id.startsWith('empty'))
+      .forEach((entry) => delete entry.resource.meta);
+
+    const updatedRes = getGenomicsCoverage(testBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+  });
+
   test('All values should be true when genomic region studied has all fields covered', () => {
     const coveredRegionStudied = res.data[0].coverage[1].data;
     expect(coveredRegionStudied.Component.covered).toBe(true);

--- a/test/genomicsCoverage.test.js
+++ b/test/genomicsCoverage.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const testBundle = require('./bundles/genomicsBundle.json');
 const { getGenomicsCoverage } = require('../src/lib/coverageChecker/genomicsCoverage');
 
@@ -20,7 +21,7 @@ describe('getGenomicsCoverage()', () => {
     const modifiedTestBundle = require('./bundles/genomicsBundle.json');
     modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta.profile);
+      .forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getGenomicsCoverage(modifiedTestBundle);
     expect(updatedRes.data[0].coverage.length).toBe(1);
@@ -32,7 +33,7 @@ describe('getGenomicsCoverage()', () => {
   test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
     // Iterate through all resources and delete their profile arrays
     const modifiedTestBundle = require('./bundles/genomicsBundle.json');
-    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getGenomicsCoverage(modifiedTestBundle);
 

--- a/test/outcomeCoverage.test.js
+++ b/test/outcomeCoverage.test.js
@@ -17,11 +17,25 @@ describe('getOutcomeCoverage()', () => {
 
   test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
     // Iterate through our empty resources and delete their profile arrays
-    testBundle.entry
+    const modifiedTestBundle = require('./bundles/outcomeBundle.json');
+    modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta);
+      .forEach((entry) => delete entry.resource.meta.profile);
 
-    const updatedRes = getOutcomeCoverage(testBundle);
+    const updatedRes = getOutcomeCoverage(modifiedTestBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+  });
+
+  test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through all resources and delete their profile arrays
+    const modifiedTestBundle = require('./bundles/outcomeBundle.json');
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+
+    const updatedRes = getOutcomeCoverage(modifiedTestBundle);
+
     expect(updatedRes.data[0].coverage.length).toBe(1);
     expect(updatedRes.data[1].coverage.length).toBe(1);
     expect(updatedRes.data[2].coverage.length).toBe(1);

--- a/test/outcomeCoverage.test.js
+++ b/test/outcomeCoverage.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const testBundle = require('./bundles/outcomeBundle.json');
 const { getOutcomeCoverage } = require('../src/lib/coverageChecker/outcomeCoverage');
 
@@ -20,7 +21,7 @@ describe('getOutcomeCoverage()', () => {
     const modifiedTestBundle = require('./bundles/outcomeBundle.json');
     modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta.profile);
+      .forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getOutcomeCoverage(modifiedTestBundle);
     expect(updatedRes.data[0].coverage.length).toBe(1);
@@ -32,7 +33,7 @@ describe('getOutcomeCoverage()', () => {
   test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
     // Iterate through all resources and delete their profile arrays
     const modifiedTestBundle = require('./bundles/outcomeBundle.json');
-    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getOutcomeCoverage(modifiedTestBundle);
 

--- a/test/outcomeCoverage.test.js
+++ b/test/outcomeCoverage.test.js
@@ -15,6 +15,19 @@ describe('getOutcomeCoverage()', () => {
     expect(res.data[3].coverage.length).toBe(2);
   });
 
+  test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through our empty resources and delete their profile arrays
+    testBundle.entry
+      .filter((entry) => entry.resource.id.startsWith('empty'))
+      .forEach((entry) => delete entry.resource.meta);
+
+    const updatedRes = getOutcomeCoverage(testBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+  });
+
   test('All values should be true when disease status has all fields covered', () => {
     const coveredDiseaseStatus = res.data[0].coverage[1].data;
     expect(coveredDiseaseStatus['Evidence Type'].covered).toBe(true);

--- a/test/treatmentCoverage.test.js
+++ b/test/treatmentCoverage.test.js
@@ -18,11 +18,26 @@ describe('getTreatmentCoverage()', () => {
 
   test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
     // Iterate through our empty resources and delete their profile arrays
-    testBundle.entry
+    const modifiedTestBundle = require('./bundles/treatmentBundle.json');
+    modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta);
+      .forEach((entry) => delete entry.resource.meta.profile);
 
-    const updatedRes = getTreatmentCoverage(testBundle);
+    const updatedRes = getTreatmentCoverage(modifiedTestBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+    expect(updatedRes.data[4].coverage.length).toBe(1);
+  });
+
+  test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through all resources and delete their profile arrays
+    const modifiedTestBundle = require('./bundles/treatmentBundle.json');
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+
+    const updatedRes = getTreatmentCoverage(modifiedTestBundle);
+
     expect(updatedRes.data[0].coverage.length).toBe(1);
     expect(updatedRes.data[1].coverage.length).toBe(1);
     expect(updatedRes.data[2].coverage.length).toBe(1);

--- a/test/treatmentCoverage.test.js
+++ b/test/treatmentCoverage.test.js
@@ -16,52 +16,66 @@ describe('getTreatmentCoverage()', () => {
     expect(res.data[4].coverage.length).toBe(2);
   });
 
+  test('Coverage arrays should not include non-compliant resources if they do not include a meta.profile element', () => {
+    // Iterate through our empty resources and delete their profile arrays
+    testBundle.entry
+      .filter((entry) => entry.resource.id.startsWith('empty'))
+      .forEach((entry) => delete entry.resource.meta);
+
+    const updatedRes = getTreatmentCoverage(testBundle);
+    expect(updatedRes.data[0].coverage.length).toBe(1);
+    expect(updatedRes.data[1].coverage.length).toBe(1);
+    expect(updatedRes.data[2].coverage.length).toBe(1);
+    expect(updatedRes.data[3].coverage.length).toBe(1);
+    expect(updatedRes.data[4].coverage.length).toBe(1);
+  });
+
   test('All values should be true when cancer related medication request has all fields covered', () => {
     const coveredCRMR = res.data[0].coverage[1].data;
     expect(coveredCRMR.Medication.covered).toBe(true);
     expect(coveredCRMR.Reason.covered).toBe(true);
-    expect(coveredCRMR["Procedure Intent"].covered).toBe(true);
-    expect(coveredCRMR["Termination Reason"].covered).toBe(true);
+    expect(coveredCRMR['Procedure Intent'].covered).toBe(true);
+    expect(coveredCRMR['Termination Reason'].covered).toBe(true);
   });
 
   test('All values should be false when cancer related medication request is missing every field', () => {
     const emptyCRMR = res.data[0].coverage[0].data;
     expect(emptyCRMR.Medication.covered).toBe(false);
     expect(emptyCRMR.Reason.covered).toBe(false);
-    expect(emptyCRMR["Procedure Intent"].covered).toBe(false);
-    expect(emptyCRMR["Termination Reason"].covered).toBe(false);
+    expect(emptyCRMR['Procedure Intent'].covered).toBe(false);
+    expect(emptyCRMR['Termination Reason'].covered).toBe(false);
   });
 
   test('All values should be true when cancer related medication administration has all fields covered', () => {
     const coveredCRMA = res.data[1].coverage[1].data;
     expect(coveredCRMA.Medication.covered).toBe(true);
     expect(coveredCRMA.Reason.covered).toBe(true);
-    expect(coveredCRMA["Procedure Intent"].covered).toBe(true);
-    expect(coveredCRMA["Termination Reason"].covered).toBe(true);
+    expect(coveredCRMA['Procedure Intent'].covered).toBe(true);
+    expect(coveredCRMA['Termination Reason'].covered).toBe(true);
   });
 
   test('All values should be false when cancer related medication administration is missing every field', () => {
     const emptyCRMA = res.data[1].coverage[0].data;
     expect(emptyCRMA.Medication.covered).toBe(false);
     expect(emptyCRMA.Reason.covered).toBe(false);
-    expect(emptyCRMA["Procedure Intent"].covered).toBe(false);
-    expect(emptyCRMA["Termination Reason"].covered).toBe(false);
+    expect(emptyCRMA['Procedure Intent'].covered).toBe(false);
+    expect(emptyCRMA['Termination Reason'].covered).toBe(false);
   });
 
   test('All values should be true when cancer related surgical procedure has all fields covered', () => {
     const coveredCRSP = res.data[2].coverage[1].data;
-    expect(coveredCRSP["Procedure Code"].covered).toBe(true);
-    expect(coveredCRSP["Body Site"].covered).toBe(true);
+    expect(coveredCRSP['Procedure Code'].covered).toBe(true);
+    expect(coveredCRSP['Body Site'].covered).toBe(true);
     expect(coveredCRSP.Laterality.covered).toBe(true);
-    expect(coveredCRSP["Location Qualifier"].covered).toBe(true);
+    expect(coveredCRSP['Location Qualifier'].covered).toBe(true);
   });
 
   test('All values should be false when cancer related surgical procedure is missing every field', () => {
     const emptyCRSP = res.data[2].coverage[0].data;
-    expect(emptyCRSP["Procedure Code"].covered).toBe(false);
-    expect(emptyCRSP["Body Site"].covered).toBe(false);
+    expect(emptyCRSP['Procedure Code'].covered).toBe(false);
+    expect(emptyCRSP['Body Site'].covered).toBe(false);
     expect(emptyCRSP.Laterality.covered).toBe(false);
-    expect(emptyCRSP["Location Qualifier"].covered).toBe(false);
+    expect(emptyCRSP['Location Qualifier'].covered).toBe(false);
   });
 
   test('All values should be true when radiotherapy course summary has all fields covered', () => {
@@ -90,15 +104,15 @@ describe('getTreatmentCoverage()', () => {
 
   test('All values should be true when radiotherapy volume has all fields covered', () => {
     const coveredVolume = res.data[4].coverage[1].data;
-    expect(coveredVolume["Volume Type"].covered).toBe(true);
+    expect(coveredVolume['Volume Type'].covered).toBe(true);
     expect(coveredVolume.Location.covered).toBe(true);
-    expect(coveredVolume["Location Qualifier"].covered).toBe(true);
+    expect(coveredVolume['Location Qualifier'].covered).toBe(true);
   });
 
   test('All values should be false when radiotherapy volume is missing every field', () => {
     const emptyVolume = res.data[4].coverage[0].data;
-    expect(emptyVolume["Volume Type"].covered).toBe(false);
+    expect(emptyVolume['Volume Type'].covered).toBe(false);
     expect(emptyVolume.Location.covered).toBe(false);
-    expect(emptyVolume["Location Qualifier"].covered).toBe(false);
+    expect(emptyVolume['Location Qualifier'].covered).toBe(false);
   });
 });

--- a/test/treatmentCoverage.test.js
+++ b/test/treatmentCoverage.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const testBundle = require('./bundles/treatmentBundle.json');
 const { getTreatmentCoverage } = require('../src/lib/coverageChecker/treatmentCoverage');
 
@@ -21,7 +22,7 @@ describe('getTreatmentCoverage()', () => {
     const modifiedTestBundle = require('./bundles/treatmentBundle.json');
     modifiedTestBundle.entry
       .filter((entry) => entry.resource.id.startsWith('empty'))
-      .forEach((entry) => delete entry.resource.meta.profile);
+      .forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getTreatmentCoverage(modifiedTestBundle);
     expect(updatedRes.data[0].coverage.length).toBe(1);
@@ -34,7 +35,7 @@ describe('getTreatmentCoverage()', () => {
   test('Coverage arrays should still include compliant resources if they do not include a meta.profile element', () => {
     // Iterate through all resources and delete their profile arrays
     const modifiedTestBundle = require('./bundles/treatmentBundle.json');
-    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile);
+    modifiedTestBundle.entry.forEach((entry) => delete entry.resource.meta.profile); // eslint-disable-line no-param-reassign
 
     const updatedRes = getTreatmentCoverage(modifiedTestBundle);
 


### PR DESCRIPTION
# Description
Issue: 909

Implements constraint-based filtering for all mCODE resource types

## (Bugfix) Solution
The functionality still uses the meta profiled filters if they produce valid results, but will fall back on the constraint-based filters if the meta-based filters fail. Each contraint-based filter references the IG where appropriate. Roughly, there are three kinds of filters: 
- A resource has a particular code that identifies it as an mCODE concept;
- A resource has a code from a codesystem from an mCODE ValueSet; 
- A resource references another resource in another way which identifies it as an mCODE concept.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

- New constraint-based filters for each resource filter 
- Adds valuesets used in filtering, as well as code for expanding future valuesets (borrowed from the MEF)
- Adds a ValueSetChecker class which references imported VS's to check if a given code is in a particular valueset 
- Moves resourceUtils up a folder, ensuring all files in the coverageChecker folder are doing actual coverage checking.
- Renames the resourceUtils files to resourceFilter 

## Testing Recommendations
- Ensure that this new approach doesn't change any of the statistics you can see on the [live demo](https://mcode.github.io/mcode-coverage-checker/)
- Ensure codes used in filtering match the codes mentioned in the IG 
- Pause to consider if there is a more comprehensive filter for a given resource.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA issue reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
