### PR TITLE
STEAM-988: Adding circle gauge component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mcode-coverage-checker",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.10.4",
@@ -16,6 +17,7 @@
         "fhirpath": "^2.12.0",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
+        "react-circular-progressbar": "^2.1.0",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.0",
@@ -14204,6 +14206,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-circular-progressbar": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.1.0.tgz",
+      "integrity": "sha512-xp4THTrod4aLpGy68FX/k1Q3nzrfHUjUe5v6FsdwXBl3YVMwgeXYQKDrku7n/D6qsJA9CuunarAboC2xCiKs1g==",
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -27638,6 +27648,12 @@
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
       }
+    },
+    "react-circular-progressbar": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.1.0.tgz",
+      "integrity": "sha512-xp4THTrod4aLpGy68FX/k1Q3nzrfHUjUe5v6FsdwXBl3YVMwgeXYQKDrku7n/D6qsJA9CuunarAboC2xCiKs1g==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "fhirpath": "^2.12.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
+    "react-circular-progressbar": "^2.1.0",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",

--- a/src/components/AssessmentStatsViz.js
+++ b/src/components/AssessmentStatsViz.js
@@ -1,10 +1,16 @@
 import { getAssessmentStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function AssessmentStatsViz({ coverageData }) {
   const stats = getAssessmentStats(coverageData);
 
-  return <SimpleStatsViz title="Assessment Coverage" stats={stats} />;
+  return (
+    <>
+      <SimpleStatsViz title="Assessment Coverage" stats={stats} />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#F2913D" />
+    </>
+  );
 }
 
 export default AssessmentStatsViz;

--- a/src/components/CircleGauge.js
+++ b/src/components/CircleGauge.js
@@ -1,0 +1,24 @@
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
+
+function gaugeDisplayText(percentage) {
+  return `${(percentage * 100).toFixed(2).toString()}%`;
+}
+
+function CircleGauge({ percentage, width, height, color }) {
+  return (
+    <div style={{ width, height }}>
+      <CircularProgressbar
+        value={percentage * 100}
+        text={gaugeDisplayText(percentage)}
+        styles={buildStyles({
+          pathColor: color,
+          textColor: color,
+          textSize: '90%',
+        })}
+      />
+    </div>
+  );
+}
+
+export default CircleGauge;

--- a/src/components/DiseaseStatsViz.js
+++ b/src/components/DiseaseStatsViz.js
@@ -1,10 +1,16 @@
 import { getDiseaseStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function DiseaseStatsViz({ coverageData }) {
   const stats = getDiseaseStats(coverageData);
 
-  return <SimpleStatsViz title="Disease Coverage" stats={stats} />;
+  return (
+    <>
+      <SimpleStatsViz title="Disease Coverage" stats={stats} />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#F2B84B" />
+    </>
+  );
 }
 
 export default DiseaseStatsViz;

--- a/src/components/GenomicsStatsViz.js
+++ b/src/components/GenomicsStatsViz.js
@@ -1,0 +1,16 @@
+import { getGenomicsStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
+import SimpleStatsViz from './SimpleStatsViz';
+
+function DiseaseStatsViz({ coverageData }) {
+  const stats = getGenomicsStats(coverageData);
+
+  return (
+    <>
+      <SimpleStatsViz title="Genomics Coverage" stats={stats} />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#26C485" />
+    </>
+  );
+}
+
+export default DiseaseStatsViz;

--- a/src/components/MainVisualization.js
+++ b/src/components/MainVisualization.js
@@ -4,6 +4,7 @@ import OutcomeStatsViz from './OutcomeStatsViz';
 import DiseaseStatsViz from './DiseaseStatsViz';
 import TreatmentStatsViz from './TreatmentStatsViz';
 import AssessmentStatsViz from './AssessmentStatsViz';
+import GenomicsStatsViz from './GenomicsStatsViz';
 
 function MainVisualization({ coverageData }) {
   return (
@@ -14,6 +15,7 @@ function MainVisualization({ coverageData }) {
       <DiseaseStatsViz coverageData={coverageData} />
       <TreatmentStatsViz coverageData={coverageData} />
       <AssessmentStatsViz coverageData={coverageData} />
+      <GenomicsStatsViz coverageData={coverageData} />
     </>
   );
 }

--- a/src/components/OutcomeStatsViz.js
+++ b/src/components/OutcomeStatsViz.js
@@ -1,10 +1,16 @@
 import { getOutcomeStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function OutcomeStatsViz({ coverageData }) {
   const stats = getOutcomeStats(coverageData);
 
-  return <SimpleStatsViz title="Outcome Coverage" stats={stats} />;
+  return (
+    <>
+      <SimpleStatsViz title="Outcome Coverage" stats={stats} />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#8A45D9" />
+    </>
+  );
 }
 
 export default OutcomeStatsViz;

--- a/src/components/OverallStatsViz.js
+++ b/src/components/OverallStatsViz.js
@@ -1,10 +1,16 @@
 import { getOverallStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function OverallStatsViz({ coverageData }) {
   const stats = getOverallStats(coverageData);
 
-  return <SimpleStatsViz title="Overall Coverage" stats={stats} larger />;
+  return (
+    <>
+      <SimpleStatsViz title="Overall Coverage" stats={stats} larger />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#000000" />
+    </>
+  );
 }
 
 export default OverallStatsViz;

--- a/src/components/PatientStatsViz.js
+++ b/src/components/PatientStatsViz.js
@@ -1,10 +1,16 @@
 import { getPatientStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function PatientStatsViz({ coverageData }) {
   const stats = getPatientStats(coverageData);
 
-  return <SimpleStatsViz title="Patient Coverage" stats={stats} />;
+  return (
+    <>
+      <SimpleStatsViz title="Patient Coverage" stats={stats} />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#D24200" />
+    </>
+  );
 }
 
 export default PatientStatsViz;

--- a/src/components/TreatmentStatsViz.js
+++ b/src/components/TreatmentStatsViz.js
@@ -1,10 +1,16 @@
 import { getTreatmentStats } from '../lib/coverageStats/coverageStats';
+import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function TreatmentStatsViz({ coverageData }) {
   const stats = getTreatmentStats(coverageData);
 
-  return <SimpleStatsViz title="Treatment Coverage" stats={stats} />;
+  return (
+    <>
+      <SimpleStatsViz title="Treatment Coverage" stats={stats} />
+      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#04B2D9" />
+    </>
+  );
 }
 
 export default TreatmentStatsViz;

--- a/src/lib/coverageStats/coverageStats.js
+++ b/src/lib/coverageStats/coverageStats.js
@@ -4,6 +4,7 @@ const {
   diseaseSectionId,
   treatmentSectionId,
   assessmentSectionId,
+  genomicsSectionId,
 } = require('../coverageSectionIds');
 const { getAllSectionsCoverage } = require('./statsUtils');
 
@@ -66,6 +67,16 @@ function getAssessmentStats(coverageData) {
   return getOverallStats(assessmentData);
 }
 
+/**
+ * Compute coverage stats across only the Genomics section
+ * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
+ * @returns An object reporting percentage coverage and raw counts
+ */
+function getGenomicsStats(coverageData) {
+  const genomicsData = coverageData.filter((sectionObject) => sectionObject.section === genomicsSectionId);
+  return getOverallStats(genomicsData);
+}
+
 module.exports = {
   getOverallStats,
   getPatientStats,
@@ -73,4 +84,5 @@ module.exports = {
   getDiseaseStats,
   getTreatmentStats,
   getAssessmentStats,
+  getGenomicsStats,
 };


### PR DESCRIPTION
# Description
Issue: STEAM-988

This PR adds a circle gauge component for visually representing coverage. Decided to go with a [new library](https://github.com/kevinsqi/react-circular-progressbar) for this since I ran into issues with recharts and the library I found worked very well right out of the box without having to do any hacky workarounds

## Important Changes
New `CircleGauge` component created and added to each sections Viz component

_General changes_
- `CircleGauge.js` contains the new component and currently takes percentage, width, height and color as props
- Added the gauge to each Section Stats Viz component for now, obviously this will change as we add more of the new components (colors based on the Coverage Checker style guide)
- `GenomicsStatsViz.js` didn't exist so I added it in
- Also added accompanying helper function to `coverageStats.js`

## Testing Recommendations
To test, run the app and look at the new gauges added to each coverage section and see that they display the correct color and coverage percentage

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA issue reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
