### PR TITLE
Adding Rankings section

### DIFF
--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { getAllFieldCoveredCounts } from '../lib/coverageStats/statsUtils';
+
+const SectionColors = {
+  Patient: 'fill-[#D24200]',
+  Outcome: 'fill-[#8A45D9]',
+  Disease: 'fill-[#F2B84B]',
+  Treatment: 'fill-[#04B2D9]',
+  Assessment: 'fill-[#F2913D]',
+  Genomics: 'fill-[#26C485]',
+};
+const MINNUMSHOWN = 5;
+
+function Rankings({ coverageData }) {
+  const fields = getAllFieldCoveredCounts(coverageData).sort((a, b) => a.percentage - b.percentage);
+  const [numShown, setNumShown] = useState(MINNUMSHOWN);
+  const [buttonText, setButtonText] = useState(`See All ${fields.length}`);
+
+  function toggleRankingsShown() {
+    if (numShown === MINNUMSHOWN) {
+      setNumShown(fields.length);
+      setButtonText('Hide');
+    } else {
+      setNumShown(MINNUMSHOWN);
+      setButtonText(`See All ${fields.length}`);
+    }
+  }
+
+  return (
+    <div>
+      <h1 className="font-bold text-xl pb-3">Rankings</h1>
+      <table className="w-1/3">
+        <tbody>
+          {fields.slice(0, numShown).map((field) => (
+            <tr key={[field.profile, field.name].join()}>
+              <td>
+                <svg className={`${SectionColors[field.section]}`} width="5" height="40">
+                  <rect width="5" height="40" />
+                </svg>
+              </td>
+              <td>
+                <p className="text-[15px]">{field.name}</p>
+                <p className="text-xs text-gray-400">{field.profile}</p>
+              </td>
+              <td className="text-[15px]">{`${field.covered}/${field.total}`}</td>
+            </tr>
+          ))}
+          <tr>
+            <td colSpan="3" className="text-center">
+              <button onClick={() => toggleRankingsShown()} type="button">
+                {buttonText}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default Rankings;

--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -1,14 +1,7 @@
 import { useState } from 'react';
 import { getAllFieldCoveredCounts } from '../lib/coverageStats/statsUtils';
+import { sectionColors } from '../lib/coverageSectionIds';
 
-const SectionColors = {
-  Patient: 'fill-[#D24200]',
-  Outcome: 'fill-[#8A45D9]',
-  Disease: 'fill-[#F2B84B]',
-  Treatment: 'fill-[#04B2D9]',
-  Assessment: 'fill-[#F2913D]',
-  Genomics: 'fill-[#26C485]',
-};
 const MINNUMSHOWN = 5;
 
 function Rankings({ coverageData }) {
@@ -33,20 +26,20 @@ function Rankings({ coverageData }) {
         <tbody>
           {fields.slice(0, numShown).map((field) => (
             <tr key={[field.profile, field.name].join()}>
-              <td>
-                <svg className={`${SectionColors[field.section]}`} width="5" height="40">
-                  <rect width="5" height="40" />
+              <td className="w-5 py-1">
+                <svg className={`${sectionColors[field.section]}`} width="5" height="40">
+                  <rect width="5" height="40" rx="1" />
                 </svg>
               </td>
-              <td>
+              <td className="py-1">
                 <p className="text-[15px]">{field.name}</p>
                 <p className="text-xs text-gray-400">{field.profile}</p>
               </td>
-              <td className="text-[15px]">{`${field.covered}/${field.total}`}</td>
+              <td className="text-[15px] py-1">{`${field.covered}/${field.total}`}</td>
             </tr>
           ))}
           <tr>
-            <td colSpan="3" className="text-center">
+            <td colSpan="3" className="text-center py-1">
               <button onClick={() => toggleRankingsShown()} type="button">
                 {buttonText}
               </button>

--- a/src/lib/coverageProfileIds.js
+++ b/src/lib/coverageProfileIds.js
@@ -38,7 +38,7 @@ const genomicsProfileIds = {
   genomicsReportId: 'Genomics Report',
   genomicSpecimenId: 'Genomic Specimen',
   genomicVariantId: 'Genomic Variant',
-  genomicRegionStidiedId: 'Genomic Region Studied',
+  genomicRegionStudiedId: 'Genomic Region Studied',
 };
 
 module.exports = {

--- a/src/lib/coverageSectionIds.js
+++ b/src/lib/coverageSectionIds.js
@@ -6,6 +6,15 @@ const treatmentSectionId = 'Treatment';
 const assessmentSectionId = 'Assessment';
 const genomicsSectionId = 'Genomics';
 
+const sectionColors = {
+  Patient: 'fill-patient',
+  Outcome: 'fill-outcome',
+  Disease: 'fill-disease',
+  Treatment: 'fill-treatment',
+  Assessment: 'fill-assessment',
+  Genomics: 'fill-genomics',
+};
+
 module.exports = {
   patientSectionId,
   outcomeSectionId,
@@ -13,4 +22,5 @@ module.exports = {
   treatmentSectionId,
   assessmentSectionId,
   genomicsSectionId,
+  sectionColors,
 };

--- a/src/lib/coverageStats/statsUtils.js
+++ b/src/lib/coverageStats/statsUtils.js
@@ -8,6 +8,40 @@ function getProfileCoveredCount(profileObject) {
   );
 }
 
+function getProfileFieldsCoveredCount(profileObject, section) {
+  if (profileObject.coverage.length === 0) {
+    return [];
+  }
+  const fields = Object.keys(profileObject.coverage[0].data);
+  const fieldCounts = [];
+  const totalCount = profileObject.coverage.length;
+  fields.forEach((field) => {
+    const coveredCount = profileObject.coverage.reduce(
+      (accum, coverageObject) => accum + (coverageObject.data[field].covered ? 1 : 0),
+      0,
+    );
+    fieldCounts.push({
+      name: field,
+      profile: profileObject.profile,
+      section,
+      covered: coveredCount,
+      total: totalCount,
+      percentage: coveredCount / totalCount,
+    });
+  });
+  return fieldCounts;
+}
+
+function getAllFieldCoveredCounts(coverageData) {
+  const allFieldsCoveredCount = [];
+  coverageData.forEach((section) => {
+    section.data.forEach((profile) => {
+      allFieldsCoveredCount.push(...getProfileFieldsCoveredCount(profile, section.section));
+    });
+  });
+  return allFieldsCoveredCount;
+}
+
 // Number of total coverable-fields nested in a profile object's several coverage objects
 function getProfileTotalCount(profileObject) {
   return profileObject.coverage.reduce((accum2, coverageObject) => accum2 + Object.keys(coverageObject.data).length, 0);
@@ -44,4 +78,5 @@ function getAllSectionsCoverage(coverageData) {
 
 module.exports = {
   getAllSectionsCoverage,
+  getAllFieldCoveredCounts,
 };

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -4,6 +4,7 @@ import coverageChecker from '../lib/coverageChecker/coverageChecker';
 import testbundle from '../data/fullBundle.json';
 import styles from './App.module.css';
 import MainSvg from '../components/oldSvg/MainSvg';
+import Rankings from '../components/Rankings';
 
 function App() {
   const coverageData = coverageChecker(testbundle);
@@ -16,6 +17,7 @@ function App() {
       </header>
       <div className={styles.app}>
         <MainVisualization coverageData={coverageData} className={styles.app} />
+        <Rankings coverageData={coverageData} />
         <MainSvg />
       </div>
     </>


### PR DESCRIPTION
# Description
Issue: STEAM-990

This PR adds a rankings section that shows an ordering of all fields in all profiles by how many are covered.

## Important Changes
Adds ranking component to display fields sorted by coverage as well as accompanying function to compute individual field coverage based on the coverage data.

_General changes_

`Rankings.js`
- Contains the ranking component

`statsUtils.js`
- New functions `getProfileFieldsCoveredCount()` and `getAllFieldCoveredCounts()` for computing all field coverage and returning them as an array of objects containing relevant data for the Rankings table

`App.js`
- Added new Ranking component to the main page of the app

`coverageProfileIds.js`
- Typo fix

## Testing Recommendations
- Run the coverage checker and see that the new Rankings component shows up and properly displays all fields sorted by the amount of coverage.
- Make sure the Rankings component matches the design in the mockup and style guide (I did my best with the styling but could definitely use feedback/help with that)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA issue reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
