### PR TITLE
STEAM-989 Adding Section stats card

### DIFF
--- a/src/components/AssessmentStatsViz.js
+++ b/src/components/AssessmentStatsViz.js
@@ -1,16 +1,10 @@
 import { getAssessmentStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function AssessmentStatsViz({ coverageData }) {
   const stats = getAssessmentStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Assessment Coverage" stats={stats} />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#F2913D" />
-    </>
-  );
+  return <SimpleStatsViz title="Assessment Coverage" stats={stats} />;
 }
 
 export default AssessmentStatsViz;

--- a/src/components/CircleGauge.js
+++ b/src/components/CircleGauge.js
@@ -5,9 +5,9 @@ function gaugeDisplayText(percentage) {
   return `${(percentage * 100).toFixed(2).toString()}%`;
 }
 
-function CircleGauge({ percentage, width, height, color }) {
+function CircleGauge({ className, percentage, color }) {
   return (
-    <div style={{ width, height }}>
+    <div className={className}>
       <CircularProgressbar
         value={percentage * 100}
         text={gaugeDisplayText(percentage)}

--- a/src/components/DiseaseStatsViz.js
+++ b/src/components/DiseaseStatsViz.js
@@ -1,16 +1,10 @@
 import { getDiseaseStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function DiseaseStatsViz({ coverageData }) {
   const stats = getDiseaseStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Disease Coverage" stats={stats} />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#F2B84B" />
-    </>
-  );
+  return <SimpleStatsViz title="Disease Coverage" stats={stats} />;
 }
 
 export default DiseaseStatsViz;

--- a/src/components/GenomicsStatsViz.js
+++ b/src/components/GenomicsStatsViz.js
@@ -1,16 +1,10 @@
 import { getGenomicsStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function DiseaseStatsViz({ coverageData }) {
   const stats = getGenomicsStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Genomics Coverage" stats={stats} />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#26C485" />
-    </>
-  );
+  return <SimpleStatsViz title="Genomics Coverage" stats={stats} />;
 }
 
 export default DiseaseStatsViz;

--- a/src/components/MainVisualization.js
+++ b/src/components/MainVisualization.js
@@ -5,10 +5,89 @@ import DiseaseStatsViz from './DiseaseStatsViz';
 import TreatmentStatsViz from './TreatmentStatsViz';
 import AssessmentStatsViz from './AssessmentStatsViz';
 import GenomicsStatsViz from './GenomicsStatsViz';
+import SectionCard from './SectionCard';
+import OverallCard from './OverallCard';
+import {
+  getAssessmentStats,
+  getDiseaseStats,
+  getGenomicsStats,
+  getOutcomeStats,
+  getOverallStats,
+  getPatientStats,
+  getTreatmentStats,
+} from '../lib/coverageStats/coverageStats';
+import { getAllFieldCoveredCounts } from '../lib/coverageStats/statsUtils';
 
 function MainVisualization({ coverageData }) {
+  const overall = getOverallStats(coverageData);
+  const patient = getPatientStats(coverageData);
+  const outcome = getOutcomeStats(coverageData);
+  const disease = getDiseaseStats(coverageData);
+  const treatment = getTreatmentStats(coverageData);
+  const assessment = getAssessmentStats(coverageData);
+  const genomics = getGenomicsStats(coverageData);
+
+  const fields = getAllFieldCoveredCounts(coverageData);
+  const patientSubcategories = `${
+    fields.filter((field) => field.section === 'Patient' && field.percentage === 1).length
+  }/${fields.filter((field) => field.section === 'Patient').length}`;
+  const outcomeSubcategories = `${
+    fields.filter((field) => field.section === 'Outcome' && field.percentage === 1).length
+  }/${fields.filter((field) => field.section === 'Outcome').length}`;
+  const diseaseSubcategories = `${
+    fields.filter((field) => field.section === 'Disease' && field.percentage === 1).length
+  }/${fields.filter((field) => field.section === 'Disease').length}`;
+  const treatmentSubcategories = `${
+    fields.filter((field) => field.section === 'Treatment' && field.percentage === 1).length
+  }/${fields.filter((field) => field.section === 'Treatment').length}`;
+  const assessmentSubcategories = `${
+    fields.filter((field) => field.section === 'Assessment' && field.percentage === 1).length
+  }/${fields.filter((field) => field.section === 'Assessment').length}`;
+  const genomicsSubcategories = `${
+    fields.filter((field) => field.section === 'Genomics' && field.percentage === 1).length
+  }/${fields.filter((field) => field.section === 'Genomics').length}`;
+
   return (
     <>
+      <div className="grid grid-cols-3 gap-5">
+        <OverallCard percentage={overall.percentage} numPatients={patient.possible} />
+        <SectionCard
+          section="Patient"
+          percentage={patient.percentage}
+          subcategories={patientSubcategories}
+          color="#d24200"
+        />
+        <SectionCard
+          section="Outcome"
+          percentage={outcome.percentage}
+          subcategories={outcomeSubcategories}
+          color="#8a45d9"
+        />
+        <SectionCard
+          section="Disease"
+          percentage={disease.percentage}
+          subcategories={diseaseSubcategories}
+          color="#f2b84b"
+        />
+        <SectionCard
+          section="Treatment"
+          percentage={treatment.percentage}
+          subcategories={treatmentSubcategories}
+          color="#04b2d9"
+        />
+        <SectionCard
+          section="Assessment"
+          percentage={assessment.percentage}
+          subcategories={assessmentSubcategories}
+          color="#f2913d"
+        />
+        <SectionCard
+          section="Genomics"
+          percentage={genomics.percentage}
+          subcategories={genomicsSubcategories}
+          color="#26c485"
+        />
+      </div>
       <OverallStatsViz coverageData={coverageData} />
       <PatientStatsViz coverageData={coverageData} />
       <OutcomeStatsViz coverageData={coverageData} />

--- a/src/components/OutcomeStatsViz.js
+++ b/src/components/OutcomeStatsViz.js
@@ -1,16 +1,10 @@
 import { getOutcomeStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function OutcomeStatsViz({ coverageData }) {
   const stats = getOutcomeStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Outcome Coverage" stats={stats} />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#8A45D9" />
-    </>
-  );
+  return <SimpleStatsViz title="Outcome Coverage" stats={stats} />;
 }
 
 export default OutcomeStatsViz;

--- a/src/components/OverallCard.js
+++ b/src/components/OverallCard.js
@@ -1,0 +1,17 @@
+import CircleGauge from './CircleGauge';
+
+function OverallCard({ percentage, numPatients }) {
+  return (
+    <div className="h-48 col-span-3 bg-white shadow-widgit flex flex-nowrap justify-around">
+      <CircleGauge className="h-48 w-48" percentage={percentage} color="#000000" />
+      <div className="grid place-items-center">
+        <div className="flex flex-col items-center">
+          <p className="font-sans font-bold text-4xl">Overall mCODE Coverage</p>
+          <p className="text-s text-gray-400">{`${numPatients} Patients`}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OverallCard;

--- a/src/components/OverallStatsViz.js
+++ b/src/components/OverallStatsViz.js
@@ -1,16 +1,10 @@
 import { getOverallStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function OverallStatsViz({ coverageData }) {
   const stats = getOverallStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Overall Coverage" stats={stats} larger />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#000000" />
-    </>
-  );
+  return <SimpleStatsViz title="Overall Coverage" stats={stats} larger />;
 }
 
 export default OverallStatsViz;

--- a/src/components/PatientStatsViz.js
+++ b/src/components/PatientStatsViz.js
@@ -1,16 +1,10 @@
 import { getPatientStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function PatientStatsViz({ coverageData }) {
   const stats = getPatientStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Patient Coverage" stats={stats} />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#D24200" />
-    </>
-  );
+  return <SimpleStatsViz title="Patient Coverage" stats={stats} />;
 }
 
 export default PatientStatsViz;

--- a/src/components/SectionCard.js
+++ b/src/components/SectionCard.js
@@ -1,0 +1,17 @@
+import CircleGauge from './CircleGauge';
+
+function SectionCard({ section, percentage, subcategories, color }) {
+  return (
+    <div className="bg-white shadow-widgit flex flex-nowrap justify-around">
+      <CircleGauge className="h-24 w-24" percentage={percentage} color={color} />
+      <div className="grid place-items-center">
+        <div className="flex flex-col items-center">
+          <p className="font-sans font-bold text-{32px}">{section}</p>
+          <p className="text-xs text-gray-400">{subcategories} Subcategories</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SectionCard;

--- a/src/components/TreatmentStatsViz.js
+++ b/src/components/TreatmentStatsViz.js
@@ -1,16 +1,10 @@
 import { getTreatmentStats } from '../lib/coverageStats/coverageStats';
-import CircleGauge from './CircleGauge';
 import SimpleStatsViz from './SimpleStatsViz';
 
 function TreatmentStatsViz({ coverageData }) {
   const stats = getTreatmentStats(coverageData);
 
-  return (
-    <>
-      <SimpleStatsViz title="Treatment Coverage" stats={stats} />
-      <CircleGauge percentage={stats.percentage} width={200} height={200} color="#04B2D9" />
-    </>
-  );
+  return <SimpleStatsViz title="Treatment Coverage" stats={stats} />;
 }
 
 export default TreatmentStatsViz;

--- a/src/styles/App.module.css
+++ b/src/styles/App.module.css
@@ -6,10 +6,10 @@
   max-width: 1080px;
   margin: 0 auto;
   padding: 0 1rem;
+  background-color: #ececec;
 }
 
 .app-header {
-  background-color: #ececec;
   width: 100vw;
   min-height: 70px;
   display: flex;


### PR DESCRIPTION
# Description
Issue: STEAM-989

This PR adds A section stats card and overall stats card which now contain the circle gauges and display coverage for each section

## Important Changes
Section cards have been added to the main visualization component in a grid to match the mockup design. In addition to coverage percentage, the section cards also show a fraction of how many of the total fields are completely covered.

_General changes_

`SectionCard.js`
- Contains the section card component

`OverallCard.js`
- Contains the overall stats card component

`MainVisualization.js`
- Now contains a grid with the overall and section cards

`CircleGauge.js`
- Modified to accept `className` as an input so tailwind classes can be used to manipulate the `div` containing the circle gauge

`PatientStatsViz.js`, etc.
- Removed placeholder circle gauges from all old stats viz components

## Testing Recommendations
- Run the coverage checker and see that the new section cards are displayed on the main page of the app with the proper information in them
- Make sure the Section cards match the design in the mockup and style guide

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA issue reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
