### PR TITLE
STEAM-1008: Updating rankings card

### DIFF
--- a/src/components/MainVisualization.js
+++ b/src/components/MainVisualization.js
@@ -1,10 +1,3 @@
-import OverallStatsViz from './OverallStatsViz';
-import PatientStatsViz from './PatientStatsViz';
-import OutcomeStatsViz from './OutcomeStatsViz';
-import DiseaseStatsViz from './DiseaseStatsViz';
-import TreatmentStatsViz from './TreatmentStatsViz';
-import AssessmentStatsViz from './AssessmentStatsViz';
-import GenomicsStatsViz from './GenomicsStatsViz';
 import SectionCard from './SectionCard';
 import {
   getAssessmentStats,
@@ -47,67 +40,58 @@ function MainVisualization({ coverageData }) {
   }/${fields.filter((field) => field.section === 'Genomics').length}`;
 
   return (
-    <>
-      <div className="grid grid-cols-3 gap-5">
-        <SectionCard
-          className="h-48 col-span-3"
-          header={<p className="font-sans font-bold text-4xl">Overall mCODE Coverage</p>}
-          text={<p className="text-s text-gray-400">{patient.possible} Patients</p>}
-          gaugeSize="h-44 w-44"
-          percentage={overall.percentage}
-          color="#000000"
-        />
-        <SectionCard
-          header={<p className="font-sans font-bold text-{32px}">Patient</p>}
-          text={<p className="text-xs text-gray-400">{patientSubcategories} Subcategories</p>}
-          gaugeSize="h-24 w-24"
-          percentage={patient.percentage}
-          color="#d24200"
-        />
-        <SectionCard
-          header={<p className="font-sans font-bold text-{32px}">Outcome</p>}
-          text={<p className="text-xs text-gray-400">{outcomeSubcategories} Subcategories</p>}
-          gaugeSize="h-24 w-24"
-          percentage={outcome.percentage}
-          color="#8a45d9"
-        />
-        <SectionCard
-          header={<p className="font-sans font-bold text-{32px}">Disease</p>}
-          text={<p className="text-xs text-gray-400">{diseaseSubcategories} Subcategories</p>}
-          gaugeSize="h-24 w-24"
-          percentage={disease.percentage}
-          color="#f2b84b"
-        />
-        <SectionCard
-          header={<p className="font-sans font-bold text-{32px}">Treatment</p>}
-          text={<p className="text-xs text-gray-400">{treatmentSubcategories} Subcategories</p>}
-          gaugeSize="h-24 w-24"
-          percentage={treatment.percentage}
-          color="#04b2d9"
-        />
-        <SectionCard
-          header={<p className="font-sans font-bold text-{32px}">Assessment</p>}
-          text={<p className="text-xs text-gray-400">{assessmentSubcategories} Subcategories</p>}
-          gaugeSize="h-24 w-24"
-          percentage={assessment.percentage}
-          color="#f2913d"
-        />
-        <SectionCard
-          header={<p className="font-sans font-bold text-{32px}">Genomics</p>}
-          text={<p className="text-xs text-gray-400">{genomicsSubcategories} Subcategories</p>}
-          gaugeSize="h-24 w-24"
-          percentage={genomics.percentage}
-          color="#26c485"
-        />
-      </div>
-      <OverallStatsViz coverageData={coverageData} />
-      <PatientStatsViz coverageData={coverageData} />
-      <OutcomeStatsViz coverageData={coverageData} />
-      <DiseaseStatsViz coverageData={coverageData} />
-      <TreatmentStatsViz coverageData={coverageData} />
-      <AssessmentStatsViz coverageData={coverageData} />
-      <GenomicsStatsViz coverageData={coverageData} />
-    </>
+    <div className="grid grid-cols-3 gap-5">
+      <SectionCard
+        className="h-48 col-span-3"
+        header={<p className="font-sans font-bold text-4xl">Overall mCODE Coverage</p>}
+        text={<p className="text-s text-gray-400">{patient.possible} Patients</p>}
+        gaugeSize="h-44 w-44"
+        percentage={overall.percentage}
+        color="#000000"
+      />
+      <SectionCard
+        header={<p className="font-sans font-bold text-{32px}">Patient</p>}
+        text={<p className="text-xs text-gray-400">{patientSubcategories} Subcategories</p>}
+        gaugeSize="h-24 w-24"
+        percentage={patient.percentage}
+        color="#d24200"
+      />
+      <SectionCard
+        header={<p className="font-sans font-bold text-{32px}">Outcome</p>}
+        text={<p className="text-xs text-gray-400">{outcomeSubcategories} Subcategories</p>}
+        gaugeSize="h-24 w-24"
+        percentage={outcome.percentage}
+        color="#8a45d9"
+      />
+      <SectionCard
+        header={<p className="font-sans font-bold text-{32px}">Disease</p>}
+        text={<p className="text-xs text-gray-400">{diseaseSubcategories} Subcategories</p>}
+        gaugeSize="h-24 w-24"
+        percentage={disease.percentage}
+        color="#f2b84b"
+      />
+      <SectionCard
+        header={<p className="font-sans font-bold text-{32px}">Treatment</p>}
+        text={<p className="text-xs text-gray-400">{treatmentSubcategories} Subcategories</p>}
+        gaugeSize="h-24 w-24"
+        percentage={treatment.percentage}
+        color="#04b2d9"
+      />
+      <SectionCard
+        header={<p className="font-sans font-bold text-{32px}">Assessment</p>}
+        text={<p className="text-xs text-gray-400">{assessmentSubcategories} Subcategories</p>}
+        gaugeSize="h-24 w-24"
+        percentage={assessment.percentage}
+        color="#f2913d"
+      />
+      <SectionCard
+        header={<p className="font-sans font-bold text-{32px}">Genomics</p>}
+        text={<p className="text-xs text-gray-400">{genomicsSubcategories} Subcategories</p>}
+        gaugeSize="h-24 w-24"
+        percentage={genomics.percentage}
+        color="#26c485"
+      />
+    </div>
   );
 }
 

--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -20,33 +20,37 @@ function Rankings({ coverageData }) {
   }
 
   return (
-    <div>
-      <h1 className="font-bold text-xl pb-3">Rankings</h1>
-      <table className="w-1/3">
-        <tbody>
-          {fields.slice(0, numShown).map((field) => (
-            <tr key={[field.profile, field.name].join()}>
-              <td className="w-5 py-1">
-                <svg className={`${sectionColors[field.section]}`} width="5" height="40">
-                  <rect width="5" height="40" rx="1" />
-                </svg>
-              </td>
-              <td className="py-1">
-                <p className="text-[15px]">{field.name}</p>
-                <p className="text-xs text-gray-400">{field.profile}</p>
-              </td>
-              <td className="text-[15px] py-1">{`${field.covered}/${field.total}`}</td>
-            </tr>
-          ))}
-          <tr>
-            <td colSpan="3" className="text-center py-1">
-              <button onClick={() => toggleRankingsShown()} type="button">
-                {buttonText}
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <div className="flex-auto">
+      <div className="bg-white p-2 rounded-widgit">
+        <h1 className="font-bold text-xl pb-3">Rankings</h1>
+        <div className="h-72 overflow-y-auto">
+          <table className="table-auto">
+            <tbody>
+              {fields.slice(0, numShown).map((field) => (
+                <tr key={[field.profile, field.name].join()}>
+                  <td className="w-5 py-1">
+                    <svg className={`${sectionColors[field.section]}`} width="5" height="40">
+                      <rect width="5" height="40" rx="1" />
+                    </svg>
+                  </td>
+                  <td className="w-full py-1">
+                    <p className="text-[15px]">{field.name}</p>
+                    <p className="text-xs text-gray-400">{field.profile}</p>
+                  </td>
+                  <td className="text-[15px] py-1">{`${field.covered}/${field.total}`}</td>
+                </tr>
+              ))}
+              <tr>
+                <td colSpan="3" className="text-center py-1">
+                  <button onClick={() => toggleRankingsShown()} type="button">
+                    {buttonText}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -16,8 +16,10 @@ function App() {
         <div className={styles['app-header-content']}>mCODE Coverage Checker</div>
       </header>
       <div className={styles.app}>
-        <MainVisualization coverageData={coverageData} className={styles.app} />
-        <Rankings coverageData={coverageData} />
+        <div className="flex flex-row gap-5 items-start">
+          <MainVisualization coverageData={coverageData} className={styles.app} />
+          <Rankings coverageData={coverageData} />
+        </div>
         <MainSvg />
       </div>
     </>


### PR DESCRIPTION
# Description
Issue: STEAM-1008

This PR updates the rankings card to be contained in a card and properly oriented next to the section cards.

## Important Changes

_General changes_

`App.js`
- Wrapped Main Visualization and Rankings card in a div to control their layout on the main page

`MainVisualization.js`
- Removed old text-based stat visualizations, so MainVisualization is now a component that just contains all section cards

`Rankings.js`
- Added white background and styling as well as limited height so that when "See All" is pressed, the card will not grow but add a scroll bar to view the overflowed content

## Testing Recommendations
Run the app and see that the new layout of the main page and rankings card matches the mockups. Also be sure to check that the Rankings card's scroll bar overflow works properly.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA issue reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
