### PR TITLE
Adding sorting options to Ranking card

### DIFF
--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -5,7 +5,9 @@ import { sectionColors } from '../lib/coverageSectionIds';
 const MINNUMSHOWN = 5;
 
 function Rankings({ coverageData }) {
-  const fields = getAllFieldCoveredCounts(coverageData).sort((a, b) => a.percentage - b.percentage);
+  const [fields, setFields] = useState(
+    getAllFieldCoveredCounts(coverageData).sort((a, b) => a.percentage - b.percentage),
+  );
   const [numShown, setNumShown] = useState(MINNUMSHOWN);
   const [buttonText, setButtonText] = useState(`See All ${fields.length}`);
 
@@ -19,10 +21,37 @@ function Rankings({ coverageData }) {
     }
   }
 
+  const SORT_FUNCTIONS = {
+    Ascending: (a, b) => a.percentage - b.percentage,
+    Descending: (a, b) => b.percentage - a.percentage,
+    Alphabetical: (a, b) => a.name.localeCompare(b.name),
+    ReverseAlphabetical: (a, b) => b.name.localeCompare(a.name),
+  };
+
+  function changeSort(event) {
+    setFields([...fields].sort(SORT_FUNCTIONS[event.target.value]));
+  }
+
   return (
     <div className="flex-auto">
       <div className="bg-white p-2 rounded-widgit">
-        <h1 className="font-bold text-xl pb-3">Rankings</h1>
+        <div className="flex flex-row justify-between">
+          <h1 className="font-bold text-xl pb-3">Rankings</h1>
+          <select id="sortSelect" onChange={changeSort}>
+            <option value="Ascending" key="Ascending">
+              Ascending
+            </option>
+            <option value="Descending" key="Descending">
+              Descending
+            </option>
+            <option value="Alphabetical" key="Alphabetical">
+              Alphabetical
+            </option>
+            <option value="ReverseAlphabetical" key="ReverseAphabetical">
+              Reverse Alphabetical
+            </option>
+          </select>
+        </div>
         <div className="h-72 overflow-y-auto">
           <table className="table-auto">
             <tbody>

--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -25,7 +25,7 @@ function Rankings({ coverageData }) {
     Ascending: (a, b) => a.percentage - b.percentage,
     Descending: (a, b) => b.percentage - a.percentage,
     Alphabetical: (a, b) => a.name.localeCompare(b.name),
-    ReverseAlphabetical: (a, b) => b.name.localeCompare(a.name),
+    'Reverse Alphabetical': (a, b) => b.name.localeCompare(a.name),
   };
 
   function changeSort(event) {
@@ -35,21 +35,18 @@ function Rankings({ coverageData }) {
   return (
     <div className="flex-auto">
       <div className="bg-white p-2 rounded-widgit">
-        <div className="flex flex-row justify-between">
-          <h1 className="font-bold text-xl pb-3">Rankings</h1>
-          <select id="sortSelect" onChange={changeSort}>
-            <option value="Ascending" key="Ascending">
-              Ascending
-            </option>
-            <option value="Descending" key="Descending">
-              Descending
-            </option>
-            <option value="Alphabetical" key="Alphabetical">
-              Alphabetical
-            </option>
-            <option value="ReverseAlphabetical" key="ReverseAphabetical">
-              Reverse Alphabetical
-            </option>
+        <div className="pb-3 flex flex-row justify-between">
+          <h1 className="font-bold text-xl">Rankings</h1>
+          <select
+            className="mx-2 px-2 bg-white border-2 rounded-widgit shadow-widgit border-background"
+            id="sortSelect"
+            onChange={changeSort}
+          >
+            {Object.keys(SORT_FUNCTIONS).map((sort) => (
+              <option value={sort} key={sort}>
+                {sort}
+              </option>
+            ))}
           </select>
         </div>
         <div className="h-72 overflow-y-auto">


### PR DESCRIPTION
# Description
Issue: STEAM-1009

This PR adds a dropdown to Rankings card allowing users to sort in different ways. Ascending and descending by coverage and alphabetical and reverse alphabetical by name are the current sorting options but more could easily be added.

## Important Changes

_General changes_

`Rankings.js`
- Array of fields changed to use `useState()` so it can be re-sorted
- `SORT_FUNCTIONS` object added, which holds sort functions
- Dropdown component added to the card to allow users to select which sorting option to use

## Testing Recommendations
Run the coverage checker and see that the dropdown on the rankings card properly changes the way the rankings are sorted

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA issue reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
