### PR TITLE
Line chart viz

### DIFF
--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1,21 +1,22 @@
 import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, Area } from 'recharts';
 
-export default function LineChart({ data, xKey, yKey, color }) {
+export default function LineChart({ data, xKey, yKey, hexColor }) {
   return (
     <ResponsiveContainer height={400}>
       <AreaChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+        {/* Defines a linear gradient SVG that we can reference for our Area's fill color */}
         <defs>
           <linearGradient id="colorGradient" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor={color} stopOpacity={0.8} />
-            <stop offset="60%" stopColor={color} stopOpacity={0.2} />
-            <stop offset="95%" stopColor={color} stopOpacity={0} />
+            <stop offset="5%" stopColor={hexColor} stopOpacity={0.8} />
+            <stop offset="60%" stopColor={hexColor} stopOpacity={0.2} />
+            <stop offset="95%" stopColor={hexColor} stopOpacity={0} />
           </linearGradient>
         </defs>
         <XAxis dataKey={xKey} />
         <YAxis />
         <CartesianGrid strokeDasharray="3 3" />
         <Tooltip />
-        <Area type="monotone" dataKey={yKey} stroke={color} fillOpacity={1} fill="url(#colorGradient)" />
+        <Area type="monotone" dataKey={yKey} stroke={hexColor} fillOpacity={1} fill="url(#colorGradient)" />
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -7,6 +7,7 @@ export default function LineChart({ data, xKey, yKey, color }) {
         <defs>
           <linearGradient id="colorGradient" x1="0" y1="0" x2="0" y2="1">
             <stop offset="5%" stopColor={color} stopOpacity={0.8} />
+            <stop offset="60%" stopColor={color} stopOpacity={0.2} />
             <stop offset="95%" stopColor={color} stopOpacity={0} />
           </linearGradient>
         </defs>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1,0 +1,21 @@
+import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, Area } from 'recharts';
+
+export default function LineChart({ data, xKey, yKey, color }) {
+  return (
+    <ResponsiveContainer height={400}>
+      <AreaChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id="colorGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor={color} stopOpacity={0.8} />
+            <stop offset="95%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <XAxis dataKey={xKey} />
+        <YAxis />
+        <CartesianGrid strokeDasharray="3 3" />
+        <Tooltip />
+        <Area type="monotone" dataKey={yKey} stroke={color} fillOpacity={1} fill="url(#colorGradient)" />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -5,11 +5,57 @@ import testbundle from '../data/fullBundle.json';
 import MainSvg from '../components/oldSvg/MainSvg';
 import Rankings from '../components/Rankings';
 import styles from '../styles/App.module.css';
+import LineChart from '../components/LineChart';
 
 function App() {
   const coverageData = coverageChecker(testbundle);
   // TODO: Remove this when website is in 1.0
   log(coverageData);
+  const dataStatic = [
+    {
+      name: 'Page A',
+      uv: 4000,
+      pv: 2400,
+      amt: 2400,
+    },
+    {
+      name: 'Page B',
+      uv: 3000,
+      pv: 1398,
+      amt: 2210,
+    },
+    {
+      name: 'Page C',
+      uv: 2000,
+      pv: 9800,
+      amt: 2290,
+    },
+    {
+      name: 'Page D',
+      uv: 2780,
+      pv: 3908,
+      amt: 2000,
+    },
+    {
+      name: 'Page E',
+      uv: 1890,
+      pv: 4800,
+      amt: 2181,
+    },
+    {
+      name: 'Page F',
+      uv: 2390,
+      pv: 3800,
+      amt: 2500,
+    },
+    {
+      name: 'Page G',
+      uv: 3490,
+      pv: 4300,
+      amt: 2100,
+    },
+  ];
+
   return (
     <>
       <header className={styles['app-header']}>
@@ -20,6 +66,7 @@ function App() {
           <MainVisualization coverageData={coverageData} className={styles.app} />
           <Rankings coverageData={coverageData} />
         </div>
+        <LineChart data={dataStatic} xKey="name" yKey="uv" color="#8884d8" />
         <MainSvg />
       </div>
     </>

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -66,7 +66,7 @@ function App() {
           <MainVisualization coverageData={coverageData} className={styles.app} />
           <Rankings coverageData={coverageData} />
         </div>
-        <LineChart data={dataStatic} xKey="name" yKey="uv" color="#8884d8" />
+        <LineChart data={dataStatic} xKey="name" yKey="uv" hexColor="#8884d8" />
         <MainSvg />
       </div>
     </>


### PR DESCRIPTION
Pretty straightforward component that consumes data (formatted how ReCharts expects) and arguments for where x-data lives on a data element,`xKey`, where y-data lives on a data elemetn, `yKey`, and what hex-coded color to use for the curve/area under it, `hexColor`.  I've added a toy example to the Application for the time being, which we will eventually replace with data surrounding the currently selected coverage section.