### PR TITLE
Styling, sizing and alignment fixes

### DIFF
--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -3,7 +3,7 @@ import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, A
 export default function LineChart({ className, data, xKey, yKey, hexColor }) {
   return (
     <div className={className}>
-      <ResponsiveContainer height={400}>
+      <ResponsiveContainer>
         <AreaChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
           {/* Defines a linear gradient SVG that we can reference for our Area's fill color */}
           <defs>

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -13,8 +13,8 @@ export default function LineChart({ className, data, xKey, yKey, hexColor }) {
               <stop offset="95%" stopColor={hexColor} stopOpacity={0} />
             </linearGradient>
           </defs>
-          <XAxis dataKey={xKey} />
-          <YAxis />
+          <XAxis style={{ fontWeight: 'bold' }} dataKey={xKey} />
+          <YAxis style={{ fontWeight: 'bold' }} />
           <CartesianGrid strokeDasharray="3 3" />
           <Tooltip />
           <Area type="monotone" dataKey={yKey} stroke={hexColor} fillOpacity={1} fill="url(#colorGradient)" />

--- a/src/components/LongitudinalSection.js
+++ b/src/components/LongitudinalSection.js
@@ -130,11 +130,12 @@ function Longitudinal({ selectedSection, coverageData }) {
   };
 
   return (
-    <div className="bg-white p-5 w-1/2 float-right rounded-lg shadow-widgit">
+    <div className="bg-white px-5 my-2 w-1/2 h-[500px] float-right rounded-lg shadow-widgit">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-bold">
+        <h3 className="py-4 font-sans font-semibold text-xl">
           <span className={`${sectionTextColors[selectedSection]}`}>{selectedSection}</span> Longitudinal Data
-        </h2>
+        </h3>
         <div className="float-right">
           <select
             className="bg-white border rounded-lg p-2 shadow-widgit"
@@ -149,8 +150,9 @@ function Longitudinal({ selectedSection, coverageData }) {
           </select>
         </div>
       </div>
+      {/* Body */}
       <LineChart
-        className="p-2"
+        className="p-2 h-72"
         data={dataStatic}
         xKey="name"
         yKey="uv"

--- a/src/components/MainVisualization.js
+++ b/src/components/MainVisualization.js
@@ -1,3 +1,4 @@
+import { Icon } from '@iconify/react';
 import SectionCard from './SectionCard';
 import {
   getAssessmentStats,
@@ -54,7 +55,12 @@ function MainVisualization({ className, coverageData, selectedSection, setSelect
         className={selectedSection === overallSectionId ? 'h-48 border-2 border-black' : 'h-48'}
         buttonClassName="col-span-3"
         header={<p className="font-sans font-bold text-4xl">Overall mCODE Coverage</p>}
-        text={<p className="text-s text-gray-400">{patient.possible} Patients</p>}
+        text={
+          <div className="flex flex-row">
+            <Icon icon="bi:people-fill" height="24" color="#9ca3af" className="pr-2" />
+            <p className="text-s text-gray-400">{patient.possible} Patients</p>
+          </div>
+        }
         gaugeSize="h-44 w-44"
         percentage={overall.percentage}
         color="#000000"

--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -19,7 +19,7 @@ const sectionColors = {
   [genomicsSectionId]: 'fill-genomics',
 };
 
-const MINNUMSHOWN = 5;
+const MINNUMSHOWN = 7;
 
 function Rankings({ coverageData, className }) {
   const fields = getAllFieldCoveredSums(coverageData);
@@ -42,55 +42,55 @@ function Rankings({ coverageData, className }) {
   };
 
   return (
-    <div className={`flex-auto ${className}`}>
-      <div className="bg-white rounded-widgit">
-        <div className="p-4 flex flex-row justify-between">
-          <h1 className="font-bold text-xl">Rankings</h1>
-          <select
-            className="mx-2 px-2 bg-white border-2 rounded-widgit shadow-widgit border-background"
-            id="sortSelect"
-            onChange={(e) => setSortFunction(e.target.value)}
-          >
-            {Object.keys(SORT_FUNCTIONS).map((sort) => (
-              <option value={sort} key={sort}>
-                {sort}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="px-2 h-72 overflow-y-auto">
-          <table className="table-auto">
-            <tbody>
-              {fields
-                .sort(SORT_FUNCTIONS[sortFunction])
-                .slice(0, numShown)
-                .map((field) => (
-                  <tr key={[field.profile, field.name].join()}>
-                    <td className="w-5 py-1">
-                      <svg className={`${sectionColors[field.section]}`} width="5" height="40">
-                        <rect width="5" height="40" rx="1" />
-                      </svg>
-                    </td>
-                    <td className="w-full py-1">
-                      <p className="text-[15px]">{field.name}</p>
-                      <p className="text-xs text-gray-400">{field.profile}</p>
-                    </td>
-                    <td className="px-2">
-                      <Sparkline data={StaticData} />
-                    </td>
-                    <td className="text-[15px] py-1">{`${field.covered}/${field.total}`}</td>
-                  </tr>
-                ))}
-              <tr>
-                <td colSpan="3" className="text-center py-1">
-                  <button onClick={() => toggleRankingsShown()} type="button">
-                    {numShown === MINNUMSHOWN ? `See All ${fields.length}` : 'Hide'}
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+    <div className={`flex-auto ${className} bg-white rounded-widgit flex flex-col`}>
+      {/* Header */}
+      <div className="p-4 flex flex-row justify-between">
+        <h1 className="font-bold text-xl">Rankings</h1>
+        <select
+          className="mx-2 px-2 bg-white border-2 rounded-widgit shadow-widgit border-background"
+          id="sortSelect"
+          onChange={(e) => setSortFunction(e.target.value)}
+        >
+          {Object.keys(SORT_FUNCTIONS).map((sort) => (
+            <option value={sort} key={sort}>
+              {sort}
+            </option>
+          ))}
+        </select>
+      </div>
+      {/* Table of fields */}
+      <div className="px-2 h-96 overflow-y-auto">
+        <table className="table-auto">
+          <tbody>
+            {fields
+              .sort(SORT_FUNCTIONS[sortFunction])
+              .slice(0, numShown)
+              .map((field) => (
+                <tr key={[field.profile, field.name].join()}>
+                  <td className="w-5 py-1">
+                    <svg className={`${sectionColors[field.section]}`} width="5" height="40">
+                      <rect width="5" height="40" rx="1" />
+                    </svg>
+                  </td>
+                  <td className="w-full py-1">
+                    <p className="text-[15px]">{field.name}</p>
+                    <p className="text-xs text-gray-400">{field.profile}</p>
+                  </td>
+                  <td className="px-2">
+                    <Sparkline data={StaticData} />
+                  </td>
+                  <td className="text-[15px] py-1">{`${field.covered}/${field.total}`}</td>
+                </tr>
+              ))}
+            <tr>
+              <td colSpan="3" className="text-center py-1">
+                <button onClick={() => toggleRankingsShown()} type="button">
+                  {numShown === MINNUMSHOWN ? `See All ${fields.length}` : 'Hide'}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/src/components/Rankings.js
+++ b/src/components/Rankings.js
@@ -59,7 +59,7 @@ function Rankings({ coverageData, className }) {
         </select>
       </div>
       {/* Table of fields */}
-      <div className="px-2 h-96 overflow-y-auto">
+      <div className="px-4 h-96 overflow-y-auto">
         <table className="table-auto">
           <tbody>
             {fields
@@ -67,7 +67,7 @@ function Rankings({ coverageData, className }) {
               .slice(0, numShown)
               .map((field) => (
                 <tr key={[field.profile, field.name].join()}>
-                  <td className="w-5 py-1">
+                  <td className="w-5 py-1 pr-2">
                     <svg className={`${sectionColors[field.section]}`} width="5" height="40">
                       <rect width="5" height="40" rx="1" />
                     </svg>

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -93,13 +93,13 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
         <table className="w-full table-fixed text-left">
           <thead className="bg-gray-100 text-gray-500 font-thin rounded">
             <tr>
-              <th scope="col" className="px-6 font-normal py-3">
+              <th scope="col" className="px-6 font-normal py-2">
                 Name
               </th>
-              <th scope="col" className="font-normal py-3">
+              <th scope="col" className="font-normal py-2">
                 Coverage
               </th>
-              <th scope="col" className="font-normal py-3">
+              <th scope="col" className="font-normal py-2">
                 Link
               </th>
             </tr>

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -83,7 +83,7 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
   const [open, setOpen] = useState(initialOpen);
 
   return (
-    <div className={`${className} flex flex-col bg-white my-2 rounded-widgit w-1/2 h-96`}>
+    <div className={`${className} flex flex-col bg-white my-2 rounded-widgit w-1/2 h-[500px]`}>
       {/* Header */}
       <h3 className="p-4 font-sans font-semibold text-xl">
         <span className={`${sectionTextColors[selectedSection]}`}>{selectedSection}</span> Subcategories

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -22,24 +22,26 @@ function App() {
   );
 
   return (
-    <div className="-mt-6">
-      {/* Negative margin sized to height of fileSelect –  moves select moved up into margins, aligns titles */}
-      <FileSelect files={files} onChange={changeDataSource} />
-      <h1 className="font-sans font-bold text-4xl">Coverage Overview</h1>
-      <p className="text-sm text-gray-600 pb-2">Select a category to analyze it in finer detail</p>
-      <div className="flex flex-row pb-5 gap-5 items-stretch">
-        <MainVisualization
-          coverageData={coverageData}
-          selectedSection={selectedSection}
-          setSelectedSection={setSelectedSection}
-        />
-        <Rankings coverageData={coverageData} />
-      </div>
-      <h2 className="font-sans font-semibold text-2xl">Analysis</h2>
-      <p className="text-sm text-gray-600">Fine tune your analysis through your selection of subcategories</p>
-      <div className="flex flex-row gap-5 items-start">
-        <SubcategoryTable selectedSection={selectedSection} coverageData={coverageData} />
-        <Longitudinal selectedSection={selectedSection} coverageData={coverageData} />
+    <div className="flex justify-center">
+      <div className="-mt-6 max-w-6xl">
+        {/* Negative margin sized to height of fileSelect –  moves select moved up into margins, aligns titles */}
+        <FileSelect files={files} onChange={changeDataSource} />
+        <h1 className="font-sans font-bold text-4xl">Coverage Overview</h1>
+        <p className="text-sm text-gray-600 pb-2">Select a category to analyze it in finer detail</p>
+        <div className="flex flex-row pb-5 gap-5 items-stretch">
+          <MainVisualization
+            coverageData={coverageData}
+            selectedSection={selectedSection}
+            setSelectedSection={setSelectedSection}
+          />
+          <Rankings coverageData={coverageData} />
+        </div>
+        <h2 className="font-sans font-semibold text-2xl">Analysis</h2>
+        <p className="text-sm text-gray-600">Fine tune your analysis through your selection of subcategories</p>
+        <div className="flex flex-row gap-5 items-start">
+          <SubcategoryTable selectedSection={selectedSection} coverageData={coverageData} />
+          <Longitudinal selectedSection={selectedSection} coverageData={coverageData} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -26,8 +26,8 @@ function App() {
       {/* Negative margin sized to height of fileSelect –  moves select moved up into margins, aligns titles */}
       <FileSelect files={files} onChange={changeDataSource} />
       <h1 className="font-sans font-bold text-4xl">Coverage Overview</h1>
-      <p className="text-sm text-gray-600">Select a category to analyze it in finer detail</p>
-      <div className="flex flex-row pb-5 gap-5 items-start">
+      <p className="text-sm text-gray-600 pb-2">Select a category to analyze it in finer detail</p>
+      <div className="flex flex-row pb-5 gap-5 items-stretch">
         <MainVisualization
           coverageData={coverageData}
           selectedSection={selectedSection}

--- a/src/pages/FileUploadPage.js
+++ b/src/pages/FileUploadPage.js
@@ -3,14 +3,16 @@ import FileUpload from '../components/FileUpload';
 
 function FileUploadPage() {
   return (
-    <div className="h-screen overflow-auto">
-      <div className="mb-6">
-        <h1 className="font-sans font-bold text-4xl">Upload Files</h1>
-        <p className="text-sm text-gray-600">Upload your files here to view them in the dashboard</p>
-        <FileUpload />
-      </div>
-      <div className="mb-6">
-        <UploadedFiles />
+    <div className="flex justify-center">
+      <div className="h-screen max-w-6xl overflow-auto">
+        <div className="mb-6">
+          <h1 className="font-sans font-bold text-4xl">Upload Files</h1>
+          <p className="text-sm text-gray-600">Upload your files here to view them in the dashboard</p>
+          <FileUpload />
+        </div>
+        <div className="mb-6">
+          <UploadedFiles />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
# Description
Issue: STEAM-1076

A bunch of random styling, sizing and alignment changes to get the app more in line with the mockup

## Important Changes
- Rankings section and Main viz now match in height
- Subcategory table and Longitudinal section now match in height and alignment
- Modified subcategory and longitudinal section title's to match style
- Added a bit of padding below Coverage Overview and it's description
- A few misc. reorganizations and comments added to clean up some complicated sections

Some possible issues to note for future styling changes / resizing:
- I once again encountered weird issues with the `ResponsiveContainer` component on the line chart. I removed the height parameter to try and make it just flex and fill the containing div, but that made the whole graph disappear so I ended up having to add a fixed tailwind height class to it
- I had to give both sections that use overflow for a scroll bar (Rankings and Subcategories) a fixed height. Any other dynamic height changing would result in the container growing to fill space and not properly using a scrollbar. There might be some other way to not use a fixed height and keep the scroll bar but I couldn't figure it out for now.

## Testing Recommendations
- Run the app and check for the changes mentioned above
- Compare the app to the mockup to check for any other small styling changes that may need to be made

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA issue reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
