### PR TITLE
STEAM-1085 Subcatagory Table Checkmarks

### DIFF
--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -33,6 +33,16 @@ const sectionBarColors = {
   [overallSectionId]: 'bg-black',
 };
 
+const sectionIconColors = {
+  [patientSectionId]: '#d24200',
+  [outcomeSectionId]: '#8a45d9',
+  [diseaseSectionId]: '#f2b84b',
+  [treatmentSectionId]: '#04b2d9',
+  [assessmentSectionId]: '#f2913d',
+  [genomicsSectionId]: '#26c485',
+  [overallSectionId]: '#000000',
+};
+
 function SubcategoryTable({ className, selectedSection, coverageData }) {
   let profiles;
   if (selectedSection === overallSectionId) {
@@ -146,13 +156,11 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
                       </td>
                       <td>
                         <div className="flex flex-row flex-nowrap items-center">
-                          <ProgressBar
-                            percentage={(field.covered / field.total) * 100}
-                            color={sectionBarColors[profile.section]}
+                          <Icon
+                            icon={field.covered ? 'ph:check-circle-fill' : 'ph:x-circle-fill'}
+                            color={field.covered ? sectionIconColors[profile.section] : '#808080'}
+                            height="24"
                           />
-                          <p className="text-[12px]">
-                            {field.covered}/{field.total}
-                          </p>
                         </div>
                       </td>
                       <td>


### PR DESCRIPTION
# Description
Issue: STEAM-1085

Added checkmarks in place of progress bars to better represent the coverage of fields within the subcatagory table.

## (Feature) Demo/Screenshots
![image](https://user-images.githubusercontent.com/87581687/221001130-5ef66f54-d726-460b-ad2a-deee143a8da5.png)

## Important Changes
`SubcategoryTable.js`
- used a conditional operator to determine what icon and color should be displayed within the fields section. 
- removed the text displaying the fraction
- added a new const `sectionIconColors` to supply correctly formatted color values to the icon. (let me know if there is a easier way to do this by just using the `sectionBarColors` const)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA issue reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
