### PR TITLE
STEAM-1091 hid rankings

### DIFF
--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1,6 +1,7 @@
 import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, Area } from 'recharts';
 
 export default function LineChart({ className, data, xKey, yKey, hexColor }) {
+  const formatPercent = (tickValue) => `${tickValue}%`;
   return (
     <div className={className}>
       <ResponsiveContainer>
@@ -13,11 +14,18 @@ export default function LineChart({ className, data, xKey, yKey, hexColor }) {
               <stop offset="95%" stopColor={hexColor} stopOpacity={0} />
             </linearGradient>
           </defs>
-          <XAxis style={{ fontWeight: 'bold' }} dataKey={xKey} />
-          <YAxis style={{ fontWeight: 'bold' }} />
-          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis style={{ fontSize: 12 }} dataKey={xKey} />
+          <YAxis style={{ fontSize: 12 }} tickFormatter={formatPercent} />
+          <CartesianGrid strokeDasharray="3 7" horizontal={false} />
           <Tooltip />
-          <Area type="monotone" dataKey={yKey} stroke={hexColor} fillOpacity={1} fill="url(#colorGradient)" />
+          <Area
+            type="monotone"
+            dataKey={yKey}
+            stroke={hexColor}
+            strokeWidth={2}
+            fillOpacity={1}
+            fill="url(#colorGradient)"
+          />
         </AreaChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/LongitudinalSection.js
+++ b/src/components/LongitudinalSection.js
@@ -54,44 +54,44 @@ const sectionPercentages = {
 function Longitudinal({ className, selectedSection, coverageData }) {
   const dataStatic = [
     {
-      name: 'Page A',
-      uv: 4000,
+      name: 'Jan',
+      uv: 20,
       pv: 2400,
       amt: 2400,
     },
     {
-      name: 'Page B',
-      uv: 3000,
+      name: 'Feb',
+      uv: 26,
       pv: 1398,
       amt: 2210,
     },
     {
-      name: 'Page C',
-      uv: 2000,
+      name: 'Mar',
+      uv: 37,
       pv: 9800,
       amt: 2290,
     },
     {
-      name: 'Page D',
-      uv: 2780,
+      name: 'Apr',
+      uv: 20,
       pv: 3908,
       amt: 2000,
     },
     {
-      name: 'Page E',
-      uv: 1890,
+      name: 'May',
+      uv: 30,
       pv: 4800,
       amt: 2181,
     },
     {
-      name: 'Page F',
-      uv: 2390,
+      name: 'Jun',
+      uv: 50,
       pv: 3800,
       amt: 2500,
     },
     {
-      name: 'Page G',
-      uv: 3490,
+      name: 'Jul',
+      uv: 55,
       pv: 4300,
       amt: 2100,
     },
@@ -138,7 +138,7 @@ function Longitudinal({ className, selectedSection, coverageData }) {
         </h3>
         <div className="float-right">
           <select
-            className="bg-white border rounded-lg p-2 shadow-widgit"
+            className="hidden bg-white border rounded-lg p-2 shadow-widgit"
             value={selectedOption}
             onChange={handleOptionChange}
           >
@@ -159,6 +159,7 @@ function Longitudinal({ className, selectedSection, coverageData }) {
         hexColor={sectionLineColors[selectedSection]}
       />
       <div className="flex items-center justify-center">
+        {/* hiding for now */}
         <Metrics
           percentage={percentage}
           rotation="180deg"

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,6 +1,6 @@
 function ProgressBar({ className, color, percentage }) {
   return (
-    <div className={`${className} grow rounded-full bg-gray-300`}>
+    <div className={`${className} grow rounded-full bg-gray-300`} style={{ maxWidth: '300px' }}>
       <div style={{ width: `${percentage}%` }} className={`h-2.5 rounded-full ${color}`} />
     </div>
   );

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -88,7 +88,7 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
       <h3 className="p-4 font-sans font-semibold text-xl">
         <span className={`${sectionTextColors[selectedSection]}`}>{selectedSection}</span> Subcategories
       </h3>
-      <div className="grow overflow-y-auto">
+      <div className="grow-0 overflow-y-auto">
         {/* Table of profiles */}
         <table className="w-full table-fixed text-left">
           <thead className="bg-gray-100 text-gray-500 font-thin rounded">
@@ -128,6 +128,7 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
                   <td>
                     <div className="flex flex-row flex-nowrap items-center">
                       <ProgressBar
+                        className="mr-1"
                         percentage={(profile.covered / profile.total) * 100}
                         color={sectionBarColors[profile.section]}
                       />

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -88,7 +88,7 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
       <h3 className="p-4 font-sans font-semibold text-xl">
         <span className={`${sectionTextColors[selectedSection]}`}>{selectedSection}</span> Subcategories
       </h3>
-      <div className="grow-0 overflow-y-auto">
+      <div className="grow overflow-y-auto">
         {/* Table of profiles */}
         <table className="w-full table-fixed text-left">
           <thead className="bg-gray-100 text-gray-500 font-thin rounded">

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -22,7 +22,7 @@ function App() {
   );
 
   return (
-    <div className="-mt-6 max-w-6xl w-full">
+    <div className="-mt-6 max-w-7xl w-full">
       {/* Negative margin sized to height of fileSelect –  moves select moved up into margins, aligns titles */}
       <FileSelect files={files} onChange={changeDataSource} />
       <h1 className="font-sans font-bold text-4xl">Coverage Overview</h1>
@@ -34,18 +34,18 @@ function App() {
           selectedSection={selectedSection}
           setSelectedSection={setSelectedSection}
         />
-        <Rankings className="max-lg:w-full lg:w-2/5" coverageData={coverageData} />
+        <Longitudinal
+          className="h-[500px] lg:w-2/5 max-lg:w-full"
+          selectedSection={selectedSection}
+          coverageData={coverageData}
+        />
+        <Rankings className="hidden max-lg:w-full lg:w-2/5" coverageData={coverageData} />
       </div>
       <h2 className="font-sans font-semibold text-2xl">Analysis</h2>
       <p className="text-sm text-gray-600">Fine tune your analysis through your selection of subcategories</p>
       <div className="flex flex-row max-lg:flex-wrap gap-5 items-start">
         <SubcategoryTable
-          className="h-[500px] lg:w-1/2 max-lg:w-full"
-          selectedSection={selectedSection}
-          coverageData={coverageData}
-        />
-        <Longitudinal
-          className="h-[500px] lg:w-1/2 max-lg:w-full"
+          className="max-h-[500px] max-lg:w-full"
           selectedSection={selectedSection}
           coverageData={coverageData}
         />

--- a/src/pages/FileUploadPage.js
+++ b/src/pages/FileUploadPage.js
@@ -3,7 +3,7 @@ import FileUpload from '../components/FileUpload';
 
 function FileUploadPage() {
   return (
-    <div className="h-screen max-w-6xl min-w-[600px]">
+    <div className="h-screen max-w-7xl min-w-[600px]">
       <div className="mb-6">
         <h1 className="font-sans font-bold text-4xl">Upload Files</h1>
         <p className="text-sm text-gray-600">Upload your files here to view them in the dashboard</p>


### PR DESCRIPTION
# Description
Issue: STEAM-1091

Hid rankings, removed filtering button, and made an array of other adjustments to support these changes.

## Important Changes
`app.js`
- Hid rankings
- Moved the line chart up.

_General changes_

`app.js`
- Set the table to a max height of 500px instead of a fixed height of 500px to better support scenarios where the table only contatins a few items.
- Slightly increased the max width of the visualizations to make more room for the line chart.

`SubcategoryTable`
- Added a little space between the progress bar and the fractions.

`linechart.js`
- Simplified the chart grid.
- Reduced font weight and reduced size.
- Y-axis now shows % after the value.
- Increased stroke width.

`LongitudinalSection.js'
- Hid filtering
- Adjusting static data to match the change to % values.

`ProgressBar.js`
- Gave it a max width now that there is more space for the table.

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA issue reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
