### PR TITLE
Adding trends and average to longitudinal metrics

### DIFF
--- a/src/components/LongitudinalSection.js
+++ b/src/components/LongitudinalSection.js
@@ -51,12 +51,19 @@ const sectionPercentages = {
   [overallSectionId]: getOverallStats,
 };
 
-function Longitudinal({ className, selectedSection, coverageData, data }) {
-  const lineChartData = data.map((file) => ({
-    name: file.name,
-    date: Date.parse(file.dateAdded),
-    coverage: file.stats[selectedSection],
-  }));
+function Longitudinal({ className, selectedSection, selectedFile, coverageData, data }) {
+  const lineChartData = data
+    .map((file) => ({
+      name: file.name,
+      date: Date.parse(file.dateAdded),
+      coverage: file.stats[selectedSection],
+    }))
+    .sort((a, b) => a.date - b.date);
+
+  const index = lineChartData.findIndex((item) => item.name === selectedFile);
+  const isGreater = index === 0 ? true : lineChartData[index].coverage - lineChartData[index - 1].coverage > 0;
+
+  const average = (lineChartData.reduce((accum, item) => accum + item.coverage, 0) / lineChartData.length).toFixed(2);
 
   const fields = getAllFieldCoveredCounts(coverageData);
   const sectionFractions = {
@@ -83,13 +90,7 @@ function Longitudinal({ className, selectedSection, coverageData, data }) {
 
   const sectionPercentage = sectionPercentages[selectedSection](coverageData);
   const percentage = (sectionPercentage.percentage * 100).toFixed(2);
-  /* hiding filtering pt.1 
-  const [selectedOption, setSelectedOption] = useState('Last 7 days');
 
-  const handleOptionChange = (event) => {
-    setSelectedOption(event.target.value);
-  };
-  */
   return (
     <div className={`${className} bg-white px-5 my-2 rounded-lg shadow-widgit`}>
       {/* Header */}
@@ -97,21 +98,6 @@ function Longitudinal({ className, selectedSection, coverageData, data }) {
         <h3 className="py-4 font-sans font-semibold text-xl">
           <span className={`${sectionTextColors[selectedSection]}`}>{selectedSection}</span> Longitudinal Data
         </h3>
-        {/* hiding filtering pt.2
-        <div className="float-right">
-          <select
-            className="bg-white border rounded-lg p-2 shadow-widgit"
-            value={selectedOption}
-            onChange={handleOptionChange}
-          >
-            <option value="Last 7 days">Last 7 days</option>
-            <option value="Last 30 days">Last 30 days</option>
-            <option value="Last quarter">Last quarter</option>
-            <option value="Last year">Last year</option>
-            <option value="All time">All time</option>
-          </select>
-        </div>
-        */}
       </div>
       {/* Body */}
       <LineChart
@@ -121,22 +107,9 @@ function Longitudinal({ className, selectedSection, coverageData, data }) {
         yKey="coverage"
         hexColor={sectionLineColors[selectedSection]}
       />
-      <div className="flex items-center justify-center">
-        {/* hiding for now */}
-        <Metrics
-          percentage={percentage}
-          rotation="180deg"
-          color="#d24200"
-          fraction={sectionFractions[selectedSection]}
-          title="Current"
-        />
-        <Metrics
-          percentage={percentage}
-          rotation="0deg"
-          color="#26c485"
-          fraction={sectionFractions[selectedSection]}
-          title="Monthly Average"
-        />
+      <div className="flex items-start justify-center">
+        <Metrics percentage={percentage} up={isGreater} fraction={sectionFractions[selectedSection]} title="Current" />
+        <Metrics percentage={average} title="Average" noTrend />
       </div>
     </div>
   );

--- a/src/components/LongitudinalSection.js
+++ b/src/components/LongitudinalSection.js
@@ -108,7 +108,12 @@ function Longitudinal({ className, selectedSection, selectedFile, coverageData, 
         hexColor={sectionLineColors[selectedSection]}
       />
       <div className="flex items-start justify-center">
-        <Metrics percentage={percentage} up={isGreater} fraction={sectionFractions[selectedSection]} title="Current" />
+        <Metrics
+          percentage={percentage}
+          trendUp={isGreater}
+          fraction={sectionFractions[selectedSection]}
+          title="Current"
+        />
         <Metrics percentage={average} title="Average" noTrend />
       </div>
     </div>

--- a/src/components/Metrics.js
+++ b/src/components/Metrics.js
@@ -1,15 +1,21 @@
 import React from 'react';
 import { Icon } from '@iconify/react';
 
-function Metrics({ percentage, fraction, color, rotation, title }) {
+function Metrics({ percentage, fraction, noTrend, trendUp, title }) {
   return (
     <div className="w-full flex justify-center p-4">
       <div className="relative">
         <h1 className="text-slate-500 font-semibold">{title}</h1>
         <p className="text-4xl font-bold">{percentage}%</p>
         <div className="flex items-center">
-          <Icon icon="fa-solid:arrow-alt-circle-up" style={{ color }} rotate={rotation} />
-          <p className="text-slate-500 pl-2 font-medium">{fraction}</p>
+          {!noTrend && (
+            <Icon
+              icon="fa-solid:arrow-alt-circle-up"
+              style={{ color: trendUp ? '#26c485' : '#d24200' }}
+              rotate={trendUp ? '0deg' : '180deg'}
+            />
+          )}
+          {fraction && <p className="text-slate-500 pl-2 font-medium">{fraction}</p>}
         </div>
       </div>
     </div>

--- a/src/data/DefaultUploadedFiles.json
+++ b/src/data/DefaultUploadedFiles.json
@@ -4,7 +4,7 @@
     "name": "bundle1.json",
     "size": "500 KB",
     "type": "application/json",
-    "dateAdded": "1/1/2022",
+    "dateAdded": "6/1/2022",
     "body": {
       "resourceType": "Bundle",
       "id": "mcode-patient-bundle-jenny-m",
@@ -3038,7 +3038,7 @@
     "name": "bundle2.json",
     "size": "500 KB",
     "type": "application/json",
-    "dateAdded": "6/1/2022",
+    "dateAdded": "1/1/2022",
     "body": {
       "resourceType": "Bundle",
       "id": "5dbfda1c-ed0b-4184-95ee-2324061fe3c0",

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -12,10 +12,13 @@ function App() {
   const files = useRecoilValue(uploadedFiles);
   const [coverageData, setCoverageData] = useState(coverageChecker(files[0].body));
   const [selectedSection, setSelectedSection] = useState(overallSectionId);
+  const [selectedFile, setSelectedFile] = useState(files[0].name);
 
   const changeDataSource = useCallback(
     (event) => {
-      setCoverageData(coverageChecker(files.find((file) => file.id === event.target.value).body));
+      const newFile = files.find((file) => file.id === event.target.value);
+      setCoverageData(coverageChecker(newFile.body));
+      setSelectedFile(newFile.name);
     },
     [files],
   );
@@ -36,12 +39,10 @@ function App() {
         <Longitudinal
           className="h-[500px] lg:w-2/5 max-lg:w-full"
           selectedSection={selectedSection}
+          selectedFile={selectedFile}
           coverageData={coverageData}
           data={files}
         />
-        {/*
-        <Rankings className="max-lg:w-full lg:w-2/5" coverageData={coverageData} />
-        */}
       </div>
       <h2 className="font-sans font-semibold text-2xl">Analysis</h2>
       <p className="text-sm text-gray-600">Fine tune your analysis through your selection of subcategories</p>


### PR DESCRIPTION
# Description
Issue: STEAM-1105

This PR adds checking to see if the currently selected bundle has greater or lesser coverage than the chronologically previous bundle and displays an accompanying arrow symbol in the metrics section.

This PR also adds an actual calculated value for the Average metric, but I think we may want to discuss whether this is a useful metric or not or if we should change it to something else. Since the goal is to get to 100% coverage, I have some doubts about how useful an average is as metric since the goal should just be to monotonically increase to 100%, right? Maybe there are some other metrics to consider like percent increase from the previous bundle, etc. Curious to hear other opinions.

## Important Changes

_General changes_

`App.js`
- Added the name of the currently selected file as a state variable, so that it can be passed to the longitudinal section

`LongitudinalSection.js`
- Data is now sorted by date, so that we can find the index of the currently selected file and compare that to the chronologically previous bundle to check for a increase or decrease
- The first bundle in the list will always have an upwards trend arrow, this was an edge case I had to hard code and I think it makes sense
- We also now calculate average coverage to display in the associated metric component

`Metrics.js`
- Simplified some of the parameters to work better with the functionality above, and added more options like hiding the trend arrow or hiding the fraction

`DefaultUploadedFiles.js`
- Flipped some dates around to show off all variations of the trend arrow

## Testing Recommendations
Switch between the various default bundles and see that the behavior described above works properly.

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA issue reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

@ACCT1 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] You have tried to break the code
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
