### PR TITLE
Re-implementing number of fields covered by instance of resource

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @julianxcarter @dmendelowitz @dtphelan1 @AldenB0
+*   @dmendelowitz

--- a/src/components/FieldCountPopup.js
+++ b/src/components/FieldCountPopup.js
@@ -1,0 +1,39 @@
+function FieldCountPopup({ fieldCounts }) {
+  return (
+    <div className="absolute left-full top-1/2 z-20 ml-3 -translate-y-1/4 whitespace-nowrap rounded bg-gray-300 py-[6px] px-4 text-sm text-black opacity-0 group-hover:opacity-100">
+      <span className="absolute left-[-3px] top-1/4 -z-10 h-2 w-2 -translate-y-1/2 rotate-45 rounded-sm bg-gray-300" />
+      <div className="flex flex-row">
+        <ul>
+          {fieldCounts.slice(0, 8).map((field) => (
+            <li className="pr-2" key={field.name}>
+              {field.name}
+            </li>
+          ))}
+        </ul>
+        <ul>
+          {fieldCounts.slice(0, 8).map((field) => (
+            <li key={field.name}>
+              {field.covered}/{field.total}
+            </li>
+          ))}
+        </ul>
+        <ul>
+          {fieldCounts.slice(8).map((field) => (
+            <li className="pl-1" key={field.name}>
+              {field.name}
+            </li>
+          ))}
+        </ul>
+        <ul>
+          {fieldCounts.slice(8).map((field) => (
+            <li className="pl-2" key={field.name}>
+              {field.covered}/{field.total}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default FieldCountPopup;

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -10,8 +10,9 @@ import {
   genomicsSectionId,
   overallSectionId,
 } from '../lib/coverageSectionIds';
-import { getProfileFieldsCoveredCount } from '../lib/coverageStats/statsUtils';
+import { getProfileFieldsCoveredSum, getProfileFieldsCoveredCount } from '../lib/coverageStats/statsUtils';
 import ProgressBar from './ProgressBar';
+import FieldCountPopup from './FieldCountPopup';
 
 const sectionTextColors = {
   [patientSectionId]: 'text-patient',
@@ -54,9 +55,11 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
           return {
             name: profile.profile,
             section: section.section,
+            count: profile.coverage.length,
             covered: fields.map((f) => f.covered).reduce((a, b) => a + b, 0),
             total: fields.map((f) => f.total).reduce((a, b) => a + b, 0),
             fields,
+            fieldSums: getProfileFieldsCoveredSum(profile, selectedSection),
           };
         }),
       );
@@ -69,9 +72,11 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
         return {
           name: profile.profile,
           section: selectedSection,
+          count: profile.coverage.length,
           covered: fields.map((f) => f.covered).reduce((a, b) => a + b, 0),
           total: fields.map((f) => f.total).reduce((a, b) => a + b, 0),
           fields,
+          fieldSums: getProfileFieldsCoveredSum(profile, selectedSection),
         };
       });
   }
@@ -122,7 +127,13 @@ function SubcategoryTable({ className, selectedSection, coverageData }) {
                         height="12"
                         rotate={open[profile.name] ? '0deg' : '270deg'}
                       />
-                      <p className="pl-2 text-[15px] font-medium">{profile.name}</p>
+                      <div className="group relative">
+                        <p className="pl-2">
+                          <span className="text-[15px] font-medium">{profile.name}</span>{' '}
+                          <span className="text-[10px] italic text-gray-400">{profile.count} instances</span>
+                        </p>
+                        <FieldCountPopup fieldCounts={profile.fieldSums} />
+                      </div>
                     </div>
                   </td>
                   <td>

--- a/src/lib/coverageStats/statsUtils.js
+++ b/src/lib/coverageStats/statsUtils.js
@@ -43,10 +43,7 @@ function getProfileFieldsCoveredCount(profileObject, section) {
 // This counts each instance of a field being covered across all resources
 // Thus total will be the number of resources present and covered can be between 0 and the number of resources
 function getProfileFieldsCoveredSum(profileObject, section) {
-  if (profileObject.coverage.length === 0) {
-    return [];
-  }
-  const fields = Object.keys(profileObject.coverage[0].data);
+  const fields = fieldIds[profileObject.profile];
   const fieldCounts = [];
   const totalCount = profileObject.coverage.length;
   fields.forEach((field) => {
@@ -129,6 +126,7 @@ function getAllSectionsCoverage(coverageData) {
 export {
   getAllSectionsCoverage,
   getProfileFieldsCoveredCount,
+  getProfileFieldsCoveredSum,
   getAllFieldCoveredCounts,
   getProfileCoveredSum,
   getAllFieldCoveredSums,

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -48,7 +48,7 @@ function App() {
       <p className="text-sm text-gray-600">Fine tune your analysis through your selection of subcategories</p>
       <div className="flex flex-row max-lg:flex-wrap gap-5 items-start">
         <SubcategoryTable
-          className="max-h-[500px] max-lg:w-full"
+          className="max-h-[500px] min-h-[300px] max-lg:w-full"
           selectedSection={selectedSection}
           coverageData={coverageData}
         />


### PR DESCRIPTION
This PR reimplements the old metrics used for the Rankings section an reimplements them into the Subcategory section as a popup to show the user how many instances of each field are covered across all instances of any given resource.