### PR TITLE
Adding selected file and section to recoil state to persis across page +  longitudinal section updates

### DIFF
--- a/src/components/FileSelect.js
+++ b/src/components/FileSelect.js
@@ -1,10 +1,15 @@
+import { useRecoilValue } from 'recoil';
+import { selectedFileState } from '../recoil_state';
+
 function FileSelect({ files, onChange }) {
+  const selectedFile = useRecoilValue(selectedFileState);
+
   return (
     <label className="text-gray-600 font-bold w-full text-right inline-block" htmlFor="dataSourceSelect">
       Current File:
       <select className="w-48 bg-background text-gray-600 pl-1" id="dataSourceSelect" onChange={onChange}>
         {files.map((file) => (
-          <option value={file.id} key={file.id}>
+          <option value={file.id} key={file.id} selected={file.name === selectedFile}>
             {file.name}
           </option>
         ))}

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -2,7 +2,6 @@ import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, A
 
 const formatDate = (tickValue) => new Date(tickValue).toLocaleDateString();
 
-// eslint-disable-next-line no-unused-vars
 function CustomizedDot({ cx, cy, payload, selectedFile, color }) {
   if (payload.name === selectedFile) {
     return <Dot cx={cx} cy={cy} r={5} stroke="white" fill={color} />;

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -1,6 +1,15 @@
-import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, Area } from 'recharts';
+import { ResponsiveContainer, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, Area, Dot } from 'recharts';
 
 const formatDate = (tickValue) => new Date(tickValue).toLocaleDateString();
+
+// eslint-disable-next-line no-unused-vars
+function CustomizedDot({ cx, cy, payload, selectedFile, color }) {
+  if (payload.name === selectedFile) {
+    return <Dot cx={cx} cy={cy} r={5} stroke="white" fill={color} />;
+  }
+
+  return <svg />;
+}
 
 function CustomTooltip({ active, payload, label }) {
   if (active && payload && payload.length) {
@@ -16,7 +25,7 @@ function CustomTooltip({ active, payload, label }) {
   return null;
 }
 
-export default function LineChart({ className, data, xKey, yKey, hexColor }) {
+export default function LineChart({ className, data, xKey, yKey, hexColor, selectedFile }) {
   const formatPercent = (tickValue) => `${tickValue}%`;
 
   return (
@@ -42,6 +51,7 @@ export default function LineChart({ className, data, xKey, yKey, hexColor }) {
             strokeWidth={2}
             fillOpacity={1}
             fill="url(#colorGradient)"
+            dot={<CustomizedDot selectedFile={selectedFile} color={hexColor} />}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/src/components/MainVisualization.js
+++ b/src/components/MainVisualization.js
@@ -1,4 +1,5 @@
 import { Icon } from '@iconify/react';
+import { useRecoilState } from 'recoil';
 import SectionCard from './SectionCard';
 import {
   getAssessmentStats,
@@ -19,8 +20,10 @@ import {
   genomicsSectionId,
   overallSectionId,
 } from '../lib/coverageSectionIds';
+import { selectedSectionState } from '../recoil_state';
 
-function MainVisualization({ className, coverageData, selectedSection, setSelectedSection }) {
+function MainVisualization({ className, coverageData }) {
+  const [selectedSection, setSelectedSection] = useRecoilState(selectedSectionState);
   const overall = getOverallStats(coverageData);
   const patient = getPatientStats(coverageData);
   const outcome = getOutcomeStats(coverageData);

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { useState } from 'react';
 import { Icon } from '@iconify/react';
+import { useRecoilValue } from 'recoil';
 import {
   patientSectionId,
   outcomeSectionId,
@@ -13,6 +14,7 @@ import {
 import { getProfileFieldsCoveredSum, getProfileFieldsCoveredCount } from '../lib/coverageStats/statsUtils';
 import ProgressBar from './ProgressBar';
 import FieldCountPopup from './FieldCountPopup';
+import { selectedSectionState } from '../recoil_state';
 
 const sectionTextColors = {
   [patientSectionId]: 'text-patient',
@@ -44,7 +46,8 @@ const sectionIconColors = {
   [overallSectionId]: '#000000',
 };
 
-function SubcategoryTable({ className, selectedSection, coverageData }) {
+function SubcategoryTable({ className, coverageData }) {
+  const selectedSection = useRecoilValue(selectedSectionState);
   let profiles;
   if (selectedSection === overallSectionId) {
     profiles = [];

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -1,18 +1,18 @@
 import { useCallback, useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import { uploadedFiles } from '../recoil_state';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { uploadedFiles, selectedFileState } from '../recoil_state';
 import MainVisualization from '../components/MainVisualization';
 import coverageChecker from '../lib/coverageChecker/coverageChecker';
 import FileSelect from '../components/FileSelect';
 import SubcategoryTable from '../components/SubcategoryTable';
-import { overallSectionId } from '../lib/coverageSectionIds';
 import Longitudinal from '../components/LongitudinalSection';
 
 function App() {
   const files = useRecoilValue(uploadedFiles);
-  const [coverageData, setCoverageData] = useState(coverageChecker(files[0].body));
-  const [selectedSection, setSelectedSection] = useState(overallSectionId);
-  const [selectedFile, setSelectedFile] = useState(files[0].name);
+  const [selectedFile, setSelectedFile] = useRecoilState(selectedFileState);
+  const [coverageData, setCoverageData] = useState(
+    coverageChecker(files.find((file) => file.name === selectedFile).body),
+  );
 
   const changeDataSource = useCallback(
     (event) => {
@@ -30,28 +30,13 @@ function App() {
       <h1 className="font-sans font-bold text-4xl">Coverage Overview</h1>
       <p className="text-sm text-gray-600 pb-2">Select a category to analyze it in finer detail</p>
       <div className="flex flex-row max-lg:flex-wrap pb-5 gap-5 items-stretch">
-        <MainVisualization
-          className="max-lg:w-full lg:w-3/5"
-          coverageData={coverageData}
-          selectedSection={selectedSection}
-          setSelectedSection={setSelectedSection}
-        />
-        <Longitudinal
-          className="h-[500px] lg:w-2/5 max-lg:w-full"
-          selectedSection={selectedSection}
-          selectedFile={selectedFile}
-          coverageData={coverageData}
-          data={files}
-        />
+        <MainVisualization className="max-lg:w-full lg:w-3/5" coverageData={coverageData} />
+        <Longitudinal className="h-[500px] lg:w-2/5 max-lg:w-full" coverageData={coverageData} data={files} />
       </div>
       <h2 className="font-sans font-semibold text-2xl">Analysis</h2>
       <p className="text-sm text-gray-600">Fine tune your analysis through your selection of subcategories</p>
       <div className="flex flex-row max-lg:flex-wrap gap-5 items-start">
-        <SubcategoryTable
-          className="max-h-[500px] min-h-[300px] max-lg:w-full"
-          selectedSection={selectedSection}
-          coverageData={coverageData}
-        />
+        <SubcategoryTable className="max-h-[500px] min-h-[300px] max-lg:w-full" coverageData={coverageData} />
       </div>
     </div>
   );

--- a/src/recoil_state.js
+++ b/src/recoil_state.js
@@ -18,7 +18,6 @@ const uploadedFiles = selector({
 const selectedSectionState = atom({ key: 'selectedSectionState', default: overallSectionId });
 const selectedFile = atom({ key: 'selectedFile', default: 'bundle1.json' });
 
-// some sort of selector to act as a wrapper and check if a file got deleted on get
 const selectedFileState = selector({
   key: 'selectedFileState',
   get: ({ get }) => {

--- a/src/recoil_state.js
+++ b/src/recoil_state.js
@@ -1,5 +1,6 @@
 import { atom, selector } from 'recoil';
 import defaultUploadedFiles from './data/DefaultUploadedFiles.json';
+import { overallSectionId } from './lib/coverageSectionIds';
 
 const uploadedFilesLookup = atom({
   key: 'uploadedFilesLookup',
@@ -14,4 +15,21 @@ const uploadedFiles = selector({
   },
 });
 
-export { uploadedFilesLookup, uploadedFiles };
+const selectedSectionState = atom({ key: 'selectedSectionState', default: overallSectionId });
+const selectedFile = atom({ key: 'selectedFile', default: 'bundle1.json' });
+
+// some sort of selector to act as a wrapper and check if a file got deleted on get
+const selectedFileState = selector({
+  key: 'selectedFileState',
+  get: ({ get }) => {
+    const files = get(uploadedFilesLookup);
+    const fileNames = Object.values(files).map((file) => file.name);
+    if (fileNames.find((file) => file === get(selectedFile))) {
+      return get(selectedFile);
+    }
+    return fileNames[0];
+  },
+  set: ({ set }, newValue) => set(selectedFile, newValue),
+});
+
+export { uploadedFilesLookup, uploadedFiles, selectedSectionState, selectedFileState };


### PR DESCRIPTION
This PR:
- Updates the other metric to be percent increase instead of average
- Adds a dot to the line chart representing the currently selected file
- Adds the currently selected file and currently selected selection to the recoil state so they persist across page changes
- Updates other uses of the above information to call from the recoil state instead of passing props around