### PR TITLE
Implementing field filters in coverage checking and stats functions

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -1,9 +1,9 @@
 import { useState, useMemo, useCallback } from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { Icon } from '@iconify/react';
 import { v4 as uuidv4 } from 'uuid';
-import { uploadedFilesLookup } from '../recoil_state';
+import { filterState, uploadedFilesLookup } from '../recoil_state';
 import formatBytes from '../lib/fileSize';
 import {
   getAssessmentStats,
@@ -20,6 +20,7 @@ import Endpoint from './FHIRendpoint';
 import coverageChecker from '../lib/coverageChecker/coverageChecker';
 
 function FileUpload() {
+  const fieldFilter = useRecoilValue(filterState);
   const setFilesLookup = useSetRecoilState(uploadedFilesLookup);
   // What files are valid to upload
   function relevantFileFilter(file) {
@@ -77,13 +78,13 @@ function FileUpload() {
       const body = JSON.parse(fileReader.result);
       const coverageData = coverageChecker(body);
       const stats = {
-        Overall: (getOverallStats(coverageData).percentage * 100).toFixed(2),
-        Assessment: (getAssessmentStats(coverageData).percentage * 100).toFixed(2),
-        Treatment: (getTreatmentStats(coverageData).percentage * 100).toFixed(2),
-        Genomics: (getGenomicsStats(coverageData).percentage * 100).toFixed(2),
-        Patient: (getPatientStats(coverageData).percentage * 100).toFixed(2),
-        Disease: (getDiseaseStats(coverageData).percentage * 100).toFixed(2),
-        Outcome: (getOutcomeStats(coverageData).percentage * 100).toFixed(2),
+        Overall: (getOverallStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
+        Assessment: (getAssessmentStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
+        Treatment: (getTreatmentStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
+        Genomics: (getGenomicsStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
+        Patient: (getPatientStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
+        Disease: (getDiseaseStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
+        Outcome: (getOutcomeStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
       };
       const fileWithBody = { ...newFile, body, stats };
       resolve(fileWithBody);

--- a/src/components/LongitudinalSection.js
+++ b/src/components/LongitudinalSection.js
@@ -21,7 +21,7 @@ import {
   getTreatmentStats,
   getOverallStats,
 } from '../lib/coverageStats/coverageStats';
-import { selectedFileState, selectedSectionState } from '../recoil_state';
+import { filterState, selectedFileState, selectedSectionState } from '../recoil_state';
 
 const sectionTextColors = {
   [patientSectionId]: 'text-patient',
@@ -54,6 +54,7 @@ const sectionPercentages = {
 };
 
 function Longitudinal({ className, coverageData, data }) {
+  const fieldFilter = useRecoilValue(filterState);
   const selectedSection = useRecoilValue(selectedSectionState);
   const selectedFile = useRecoilValue(selectedFileState);
   const lineChartData = data
@@ -75,7 +76,7 @@ function Longitudinal({ className, coverageData, data }) {
           100
         ).toFixed(2); // (lineChartData.reduce((accum, item) => accum + item.coverage, 0) / lineChartData.length).toFixed(2);
 
-  const fields = getAllFieldCoveredCounts(coverageData);
+  const fields = getAllFieldCoveredCounts(coverageData, fieldFilter);
   const sectionFractions = {
     [patientSectionId]: `${
       fields.filter((field) => field.section === patientSectionId && field.percentage === 1).length
@@ -98,7 +99,7 @@ function Longitudinal({ className, coverageData, data }) {
     [overallSectionId]: `${fields.filter((field) => field.percentage === 1).length}/${fields.length}`,
   };
 
-  const sectionPercentage = sectionPercentages[selectedSection](coverageData);
+  const sectionPercentage = sectionPercentages[selectedSection](coverageData, fieldFilter);
   const percentage = (sectionPercentage.percentage * 100).toFixed(2);
 
   return (

--- a/src/components/MainVisualization.js
+++ b/src/components/MainVisualization.js
@@ -1,5 +1,5 @@
 import { Icon } from '@iconify/react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import SectionCard from './SectionCard';
 import {
   getAssessmentStats,
@@ -20,19 +20,20 @@ import {
   genomicsSectionId,
   overallSectionId,
 } from '../lib/coverageSectionIds';
-import { selectedSectionState } from '../recoil_state';
+import { filterState, selectedSectionState } from '../recoil_state';
 
 function MainVisualization({ className, coverageData }) {
+  const fieldFilter = useRecoilValue(filterState);
   const [selectedSection, setSelectedSection] = useRecoilState(selectedSectionState);
-  const overall = getOverallStats(coverageData);
-  const patient = getPatientStats(coverageData);
-  const outcome = getOutcomeStats(coverageData);
-  const disease = getDiseaseStats(coverageData);
-  const treatment = getTreatmentStats(coverageData);
-  const assessment = getAssessmentStats(coverageData);
-  const genomics = getGenomicsStats(coverageData);
+  const overall = getOverallStats(coverageData, fieldFilter);
+  const patient = getPatientStats(coverageData, fieldFilter);
+  const outcome = getOutcomeStats(coverageData, fieldFilter);
+  const disease = getDiseaseStats(coverageData, fieldFilter);
+  const treatment = getTreatmentStats(coverageData, fieldFilter);
+  const assessment = getAssessmentStats(coverageData, fieldFilter);
+  const genomics = getGenomicsStats(coverageData, fieldFilter);
 
-  const fields = getAllFieldCoveredCounts(coverageData);
+  const fields = getAllFieldCoveredCounts(coverageData, fieldFilter);
   const patientSubcategories = `${
     fields.filter((field) => field.section === patientSectionId && field.percentage === 1).length
   }/${fields.filter((field) => field.section === patientSectionId).length}`;

--- a/src/components/SubcategoryTable.js
+++ b/src/components/SubcategoryTable.js
@@ -14,7 +14,7 @@ import {
 import { getProfileFieldsCoveredSum, getProfileFieldsCoveredCount } from '../lib/coverageStats/statsUtils';
 import ProgressBar from './ProgressBar';
 import FieldCountPopup from './FieldCountPopup';
-import { selectedSectionState } from '../recoil_state';
+import { filterState, selectedSectionState } from '../recoil_state';
 
 const sectionTextColors = {
   [patientSectionId]: 'text-patient',
@@ -47,6 +47,7 @@ const sectionIconColors = {
 };
 
 function SubcategoryTable({ className, coverageData }) {
+  const fieldFilter = useRecoilValue(filterState);
   const selectedSection = useRecoilValue(selectedSectionState);
   let profiles;
   if (selectedSection === overallSectionId) {
@@ -54,7 +55,7 @@ function SubcategoryTable({ className, coverageData }) {
     coverageData.forEach((section) => {
       profiles.push(
         ...section.data.map((profile) => {
-          const fields = getProfileFieldsCoveredCount(profile, selectedSection);
+          const fields = getProfileFieldsCoveredCount(profile, selectedSection, fieldFilter);
           return {
             name: profile.profile,
             section: section.section,
@@ -62,7 +63,7 @@ function SubcategoryTable({ className, coverageData }) {
             covered: fields.map((f) => f.covered).reduce((a, b) => a + b, 0),
             total: fields.map((f) => f.total).reduce((a, b) => a + b, 0),
             fields,
-            fieldSums: getProfileFieldsCoveredSum(profile, selectedSection),
+            fieldSums: getProfileFieldsCoveredSum(profile, selectedSection, fieldFilter),
           };
         }),
       );
@@ -71,7 +72,7 @@ function SubcategoryTable({ className, coverageData }) {
     profiles = coverageData
       .filter((x) => x.section === selectedSection)[0]
       ?.data?.map((profile) => {
-        const fields = getProfileFieldsCoveredCount(profile, selectedSection);
+        const fields = getProfileFieldsCoveredCount(profile, selectedSection, fieldFilter);
         return {
           name: profile.profile,
           section: selectedSection,
@@ -79,7 +80,7 @@ function SubcategoryTable({ className, coverageData }) {
           covered: fields.map((f) => f.covered).reduce((a, b) => a + b, 0),
           total: fields.map((f) => f.total).reduce((a, b) => a + b, 0),
           fields,
-          fieldSums: getProfileFieldsCoveredSum(profile, selectedSection),
+          fieldSums: getProfileFieldsCoveredSum(profile, selectedSection, fieldFilter),
         };
       });
   }

--- a/src/lib/coverageStats/coverageStats.js
+++ b/src/lib/coverageStats/coverageStats.js
@@ -13,8 +13,8 @@ import { getAllSectionsCoverage } from './statsUtils';
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getOverallStats(coverageData) {
-  return getAllSectionsCoverage(coverageData);
+function getOverallStats(coverageData, fieldFilter = null) {
+  return getAllSectionsCoverage(coverageData, fieldFilter);
 }
 
 /**
@@ -22,9 +22,9 @@ function getOverallStats(coverageData) {
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getPatientStats(coverageData) {
+function getPatientStats(coverageData, fieldFilter = null) {
   const patientData = coverageData.filter((sectionObject) => sectionObject.section === patientSectionId);
-  return getOverallStats(patientData);
+  return getOverallStats(patientData, fieldFilter);
 }
 
 /**
@@ -32,9 +32,9 @@ function getPatientStats(coverageData) {
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getOutcomeStats(coverageData) {
+function getOutcomeStats(coverageData, fieldFilter = null) {
   const outcomeData = coverageData.filter((sectionObject) => sectionObject.section === outcomeSectionId);
-  return getOverallStats(outcomeData);
+  return getOverallStats(outcomeData, fieldFilter);
 }
 
 /**
@@ -42,9 +42,9 @@ function getOutcomeStats(coverageData) {
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getDiseaseStats(coverageData) {
+function getDiseaseStats(coverageData, fieldFilter = null) {
   const diseaseStatusData = coverageData.filter((sectionObject) => sectionObject.section === diseaseSectionId);
-  return getOverallStats(diseaseStatusData);
+  return getOverallStats(diseaseStatusData, fieldFilter);
 }
 
 /**
@@ -52,9 +52,9 @@ function getDiseaseStats(coverageData) {
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getTreatmentStats(coverageData) {
+function getTreatmentStats(coverageData, fieldFilter = null) {
   const treatmentData = coverageData.filter((sectionObject) => sectionObject.section === treatmentSectionId);
-  return getOverallStats(treatmentData);
+  return getOverallStats(treatmentData, fieldFilter);
 }
 
 /**
@@ -62,9 +62,9 @@ function getTreatmentStats(coverageData) {
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getAssessmentStats(coverageData) {
+function getAssessmentStats(coverageData, fieldFilter = null) {
   const assessmentData = coverageData.filter((sectionObject) => sectionObject.section === assessmentSectionId);
-  return getOverallStats(assessmentData);
+  return getOverallStats(assessmentData, fieldFilter);
 }
 
 /**
@@ -72,9 +72,9 @@ function getAssessmentStats(coverageData) {
  * @param {CoverageData Object} coverageData conforming to the standard CoverageData format (explored in README)
  * @returns An object reporting percentage coverage and raw counts
  */
-function getGenomicsStats(coverageData) {
+function getGenomicsStats(coverageData, fieldFilter = null) {
   const genomicsData = coverageData.filter((sectionObject) => sectionObject.section === genomicsSectionId);
-  return getOverallStats(genomicsData);
+  return getOverallStats(genomicsData, fieldFilter);
 }
 
 export {

--- a/src/lib/coverageStats/statsUtils.js
+++ b/src/lib/coverageStats/statsUtils.js
@@ -1,31 +1,41 @@
 import fieldIds from '../coverageFieldIds';
 
+// NOTES
+// getProfileCoveredCount and getProfileTotalCount are pretty much the root functions here, everything else calls them
+// dont use recoil stuff here, these should be pure functions
+
+const getFilteredFields = (fieldFilter, profile) =>
+  Object.keys(fieldFilter[profile]).filter((field) => fieldFilter[profile][field]);
+
 // Number of covered fields nested in a profile object's several coverage objects
 // Here a field is considered covered if at least resource has a true covered value for it
 // thus the total can't exceed the number of fields in the profile
-function getProfileCoveredCount(profileObject) {
-  return fieldIds[profileObject.profile].filter((field) => profileObject.coverage.some((r) => r.data[field].covered))
-    .length;
+function getProfileCoveredCount(profileObject, fieldFilter = null) {
+  const fields = fieldFilter ? getFilteredFields(fieldFilter, profileObject.profile) : fieldIds[profileObject.profile];
+  return fields.filter((field) => profileObject.coverage.some((r) => r.data[field].covered)).length;
 }
 
 // Number of total fields covered across all resources
 // this counts each instance of a field being covered across all resources
 // thus the total can exceed the number of fields in the profile
-function getProfileCoveredSum(profileObject) {
-  return profileObject.coverage.reduce(
-    (accum2, coverageObject) =>
-      // Filter to only the elements in the coverageObject for whom the `covered` property is true
-      accum2 + Object.values(coverageObject.data).filter((coverageData) => coverageData.covered).length,
-    0,
-  );
+function getProfileCoveredSum(profileObject, fieldFilter = null) {
+  const fields = fieldFilter ? getFilteredFields(fieldFilter, profileObject.profile) : fieldIds[profileObject.profile];
+  return profileObject.coverage.reduce((accum2, coverageObject) => {
+    let sum = 0;
+    Object.entries(coverageObject.data).forEach(([key, value]) => {
+      if (fields.includes(key) && value.covered) sum += 1;
+    });
+    return accum2 + sum;
+  }, 0);
 }
 
 // Returns an array of objects representing if each field in a profile is covered
 // Here a field is considered covered if at least one resource has a true covered value for it
 // Thus total is always 1 and covered can be only 0 or 1
-function getProfileFieldsCoveredCount(profileObject, section) {
+function getProfileFieldsCoveredCount(profileObject, section, fieldFilter = null) {
   const fieldCounts = [];
-  fieldIds[profileObject.profile].forEach((field) => {
+  const fields = fieldFilter ? getFilteredFields(fieldFilter, profileObject.profile) : fieldIds[profileObject.profile];
+  fields.forEach((field) => {
     const coveredCount = profileObject.coverage.some((r) => r.data[field].covered) ? 1 : 0;
     fieldCounts.push({
       name: field,
@@ -42,8 +52,8 @@ function getProfileFieldsCoveredCount(profileObject, section) {
 // Returns an array of objects representing how many instances of each field in a profile are covered
 // This counts each instance of a field being covered across all resources
 // Thus total will be the number of resources present and covered can be between 0 and the number of resources
-function getProfileFieldsCoveredSum(profileObject, section) {
-  const fields = fieldIds[profileObject.profile];
+function getProfileFieldsCoveredSum(profileObject, section, fieldFilter = null) {
+  const fields = fieldFilter ? getFilteredFields(fieldFilter, profileObject.profile) : fieldIds[profileObject.profile];
   const fieldCounts = [];
   const totalCount = profileObject.coverage.length;
   fields.forEach((field) => {
@@ -66,11 +76,11 @@ function getProfileFieldsCoveredSum(profileObject, section) {
 // Returns an array of all fields covered counts (from getProfileFieldsCoveredCount) for each section
 // Here a field is considered covered if at least one resource has a true covered value for it
 // Thus total is always 1 and covered can be only 0 or 1
-function getAllFieldCoveredCounts(coverageData) {
+function getAllFieldCoveredCounts(coverageData, fieldFilter = null) {
   const allFieldsCoveredCount = [];
   coverageData.forEach((section) => {
     section.data.forEach((profile) => {
-      allFieldsCoveredCount.push(...getProfileFieldsCoveredCount(profile, section.section));
+      allFieldsCoveredCount.push(...getProfileFieldsCoveredCount(profile, section.section, fieldFilter));
     });
   });
   return allFieldsCoveredCount;
@@ -79,29 +89,36 @@ function getAllFieldCoveredCounts(coverageData) {
 // Returns an array of all fields covered sums (from getProfileFieldsCoveredSum) for each section
 // This counts each instance of a field being covered across all resources
 // Thus total will be the number of resources present and covered can be between 0 and the number of resources
-function getAllFieldCoveredSums(coverageData) {
+function getAllFieldCoveredSums(coverageData, fieldFilter = null) {
   const allFieldsCoveredSum = [];
   coverageData.forEach((section) => {
     section.data.forEach((profile) => {
-      allFieldsCoveredSum.push(...getProfileFieldsCoveredSum(profile, section.section));
+      allFieldsCoveredSum.push(...getProfileFieldsCoveredSum(profile, section.section, fieldFilter));
     });
   });
   return allFieldsCoveredSum;
 }
 
 // Number of total coverable-fields nested in a profile object's several coverage objects
-function getProfileTotalCount(profileObject) {
-  return fieldIds[profileObject.profile].length;
+function getProfileTotalCount(profileObject, fieldFilter = null) {
+  const fields = fieldFilter ? getFilteredFields(fieldFilter, profileObject.profile) : fieldIds[profileObject.profile];
+  return fields.length;
 }
 
 // Number of covered fields across an entire sections k-many profiles
-function getSectionCoveredCount(sectionObject) {
-  return sectionObject.data.reduce((accum, profileObject) => accum + getProfileCoveredCount(profileObject), 0);
+function getSectionCoveredCount(sectionObject, fieldFilter = null) {
+  return sectionObject.data.reduce(
+    (accum, profileObject) => accum + getProfileCoveredCount(profileObject, fieldFilter),
+    0,
+  );
 }
 
 // Number of coverable-fields across an entire sections k-many profiles
-function getSectionTotalCount(sectionObject) {
-  return sectionObject.data.reduce((accum, profileObject) => accum + getProfileTotalCount(profileObject), 0);
+function getSectionTotalCount(sectionObject, fieldFilter = null) {
+  return sectionObject.data.reduce(
+    (accum, profileObject) => accum + getProfileTotalCount(profileObject, fieldFilter),
+    0,
+  );
 }
 
 /**
@@ -111,11 +128,15 @@ function getSectionTotalCount(sectionObject) {
  * raw counts for total possible dataelements covered - `possible`,
  * and the actual number of dataelements covered - `covered`
  */
-function getAllSectionsCoverage(coverageData) {
-  const totalCovered = coverageData.reduce((accum, sectionObject) => accum + getSectionCoveredCount(sectionObject), 0);
-  // TODO: Since empty sections have no profiles with keys, totalPossible should be declarative informatino
-  // stored elsewhere in the app, not inferred information based on sections
-  const totalPossible = coverageData.reduce((accum, sectionObject) => accum + getSectionTotalCount(sectionObject), 0);
+function getAllSectionsCoverage(coverageData, fieldFilter = null) {
+  const totalCovered = coverageData.reduce(
+    (accum, sectionObject) => accum + getSectionCoveredCount(sectionObject, fieldFilter),
+    0,
+  );
+  const totalPossible = coverageData.reduce(
+    (accum, sectionObject) => accum + getSectionTotalCount(sectionObject, fieldFilter),
+    0,
+  );
   return {
     percentage: totalPossible === 0 ? totalPossible : totalCovered / totalPossible,
     covered: totalCovered,

--- a/src/recoil_state.js
+++ b/src/recoil_state.js
@@ -1,6 +1,7 @@
 import { atom, selector } from 'recoil';
 import defaultUploadedFiles from './data/DefaultUploadedFiles.json';
 import { overallSectionId } from './lib/coverageSectionIds';
+import fieldIds from './lib/coverageFieldIds';
 
 const uploadedFilesLookup = atom({
   key: 'uploadedFilesLookup',
@@ -31,4 +32,11 @@ const selectedFileState = selector({
   set: ({ set }, newValue) => set(selectedFile, newValue),
 });
 
-export { uploadedFilesLookup, uploadedFiles, selectedSectionState, selectedFileState };
+const initialFilter = {};
+Object.entries(fieldIds).forEach(([key, value]) => {
+  // convert each field id array to an object with an initial value of true for each field
+  initialFilter[key] = value.reduce((ac, a) => ({ ...ac, [a]: true }), {});
+});
+const filterState = atom({ key: 'filterState', default: initialFilter });
+
+export { uploadedFilesLookup, uploadedFiles, selectedSectionState, selectedFileState, filterState };


### PR DESCRIPTION
Adds a field filter to the recoil state to track which fields are enabled and disabled. Each stat and coverage checking function can now optionally take in the field filter and modify calculations appropriately. Added field filter to all components that require it. Currently there are issues with updating the line chart in the longitudinal section since those stats are calculated once on file upload and not updated live on the site, so that will need to be fixed in a future task.