### PR TITLE
Linechart now updates with field filters

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -1,26 +1,15 @@
 import { useState, useMemo, useCallback } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { Icon } from '@iconify/react';
 import { v4 as uuidv4 } from 'uuid';
-import { filterState, uploadedFilesLookup } from '../recoil_state';
+import { uploadedFilesLookup } from '../recoil_state';
 import formatBytes from '../lib/fileSize';
-import {
-  getAssessmentStats,
-  getDiseaseStats,
-  getGenomicsStats,
-  getOutcomeStats,
-  getOverallStats,
-  getPatientStats,
-  getTreatmentStats,
-} from '../lib/coverageStats/coverageStats';
 import FileNotification from './FileNotification';
 import RejectedFileNotification from './RejectedFileNotification';
 import Endpoint from './FHIRendpoint';
-import coverageChecker from '../lib/coverageChecker/coverageChecker';
 
 function FileUpload() {
-  const fieldFilter = useRecoilValue(filterState);
   const setFilesLookup = useSetRecoilState(uploadedFilesLookup);
   // What files are valid to upload
   function relevantFileFilter(file) {
@@ -76,17 +65,7 @@ function FileUpload() {
         return newProgress;
       });
       const body = JSON.parse(fileReader.result);
-      const coverageData = coverageChecker(body);
-      const stats = {
-        Overall: (getOverallStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-        Assessment: (getAssessmentStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-        Treatment: (getTreatmentStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-        Genomics: (getGenomicsStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-        Patient: (getPatientStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-        Disease: (getDiseaseStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-        Outcome: (getOutcomeStats(coverageData, fieldFilter).percentage * 100).toFixed(2),
-      };
-      const fileWithBody = { ...newFile, body, stats };
+      const fileWithBody = { ...newFile, body };
       resolve(fileWithBody);
     },
     [setProgress],

--- a/src/components/LongitudinalSection.js
+++ b/src/components/LongitudinalSection.js
@@ -21,6 +21,7 @@ import {
   getTreatmentStats,
   getOverallStats,
 } from '../lib/coverageStats/coverageStats';
+import coverageChecker from '../lib/coverageChecker/coverageChecker';
 import { filterState, selectedFileState, selectedSectionState } from '../recoil_state';
 
 const sectionTextColors = {
@@ -61,7 +62,9 @@ function Longitudinal({ className, coverageData, data }) {
     .map((file) => ({
       name: file.name,
       date: Date.parse(file.dateAdded),
-      coverage: file.stats[selectedSection],
+      coverage: (sectionPercentages[selectedSection](coverageChecker(file.body), fieldFilter).percentage * 100).toFixed(
+        2,
+      ),
     }))
     .sort((a, b) => a.date - b.date);
 

--- a/src/data/DefaultUploadedFiles.json
+++ b/src/data/DefaultUploadedFiles.json
@@ -1889,15 +1889,6 @@
           }
         }
       ]
-    },
-    "stats": {
-      "Overall": 21.59,
-      "Patient": 62.5,
-      "Outcome": 12.5,
-      "Disease": 23.08,
-      "Treatment": 13.04,
-      "Assessment": 55.56,
-      "Genomics": 7.41
     }
   },
   "1234": {
@@ -4382,15 +4373,6 @@
           }
         }
       ]
-    },
-    "stats": {
-      "Overall": 40.91,
-      "Patient": 62.5,
-      "Outcome": 50,
-      "Disease": 53.85,
-      "Treatment": 21.74,
-      "Assessment": 55.56,
-      "Genomics": 37.04
     }
   },
   "12345": {
@@ -17315,15 +17297,6 @@
           "resource": {}
         }
       ]
-    },
-    "stats": {
-      "Overall": 69.32,
-      "Patient": 87.5,
-      "Outcome": 87.5,
-      "Disease": 76.92,
-      "Treatment": 78.26,
-      "Assessment": 77.78,
-      "Genomics": 44.44
     }
   }
 }


### PR DESCRIPTION
Linechart data for each file uploaded was originally calculated just once upon upload, but now since the percentages can update as fields are filtered out, we need to recalculate linechart data on updates